### PR TITLE
Unmount components after testing

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -10,13 +10,13 @@
       "dependencies": {
         "@pinia/plugin-debounce": "^0.1.0",
         "@types/humanize-duration": "^3.27.1",
-        "@vueuse/core": "^8.9.1",
+        "@vueuse/core": "^8.9.2",
         "humanize-duration": "^3.27.2",
         "moment": "^2.29.4",
-        "pinia": "^2.0.15",
+        "pinia": "^2.0.16",
         "ts-debounce": "^4.0.0",
         "vue": "^3.2.37",
-        "vue-router": "4",
+        "vue-router": "^4.1.2",
         "vue3-promise-dialog": "^0.3.4"
       },
       "devDependencies": {
@@ -1083,13 +1083,13 @@
       }
     },
     "node_modules/@vueuse/core": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-8.9.1.tgz",
-      "integrity": "sha512-a7goYb/gJxjXRBw4Fr/jEACiN33ghwM1ohJVu+Zwsr3lNL4qCQ1nU+ogta98lNg5hXJxWj7mYEmQDjjyWOu5nA==",
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-8.9.2.tgz",
+      "integrity": "sha512-dE3/JgwqIHmmtmRBdZAnq87rZCSFbYVps2t3gWy9Jv/+Qp6sHSSKuPFtwguJVZ2OnaGnB/AMRmx4CuFRxFin3A==",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.14",
-        "@vueuse/metadata": "8.9.1",
-        "@vueuse/shared": "8.9.1",
+        "@vueuse/metadata": "8.9.2",
+        "@vueuse/shared": "8.9.2",
         "vue-demi": "*"
       },
       "funding": {
@@ -1109,9 +1109,9 @@
       }
     },
     "node_modules/@vueuse/core/node_modules/@vueuse/shared": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-8.9.1.tgz",
-      "integrity": "sha512-klZfn7ijI3juqVgpfQVrrlBh4uTFajwSCWm8Cdt45Kg26b1LZ9jn9n7J6GhmkFay5016GnjjivQoekQSMeJNUg==",
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-8.9.2.tgz",
+      "integrity": "sha512-s4Nk82oheL5z1GywyGnqjob0MzbAt88olMZa0vgt/p3gcMsT8Ff7+SqmNgEFC6AAs6xiuhOAZpnew9Zs3d90yQ==",
       "dependencies": {
         "vue-demi": "*"
       },
@@ -1132,9 +1132,9 @@
       }
     },
     "node_modules/@vueuse/core/node_modules/vue-demi": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.2.tgz",
-      "integrity": "sha512-41ukrclEbMddAyP7PvxMSYqnOSzPV6r7GNnyTSKSCNTaz19GehxmTiXyP9kwHSUv2+Dr6hHqiUiF7L1VAw2KdQ==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.4.tgz",
+      "integrity": "sha512-KP4lq9uSz0KZbaqCllRhnxMV3mYRsRWJfdsAhZyt5bV5O1RTpoeDptBRV9NOa/JgOpfaA9ane88VF7OjWNK/DA==",
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -1157,9 +1157,9 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-8.9.1.tgz",
-      "integrity": "sha512-6LADOlyl3oENHa9dsoY7LXjU1Mh14DnpM6ztETI3hpm5ZffOMIG5CB2Q6aEZfIvYr1lkJVmG2L82wFKk7VRfIA==",
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-8.9.2.tgz",
+      "integrity": "sha512-g2s2BeyeEtJElmMFfFPnM+BTvnt0omniyvz8U18/zXDpQIMGozlNQgHoFeratyMfgVBhH/u2VKzmchChtDsgPQ==",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -3793,9 +3793,9 @@
       }
     },
     "node_modules/pinia": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.15.tgz",
-      "integrity": "sha512-qkIvXdGWMbnc3UG3l8rn9SV4nE2H4I2R/exZcdn/0pDzjaKQmMUsBXlIurfKu62VJsjETkqss46NP/c88NnjYQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.16.tgz",
+      "integrity": "sha512-9/LMVO+/epny1NBfC77vnps4g3JRezxhhoF1xLUk8mZkUIxVnwfEAIRiAX8mYBTD/KCwZqnDMqXc8w3eU0FQGg==",
       "dependencies": {
         "@vue/devtools-api": "^6.1.4",
         "vue-demi": "*"
@@ -4731,11 +4731,11 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.16.tgz",
-      "integrity": "sha512-JcO7cb8QJLBWE+DfxGUL3xUDOae/8nhM1KVdnudadTAORbuxIC/xAydC5Zr/VLHUDQi1ppuTF5/rjBGzgzrJNA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.2.tgz",
+      "integrity": "sha512-5BP1qXFncVRwgV/XnqzsKApdMjQPqWIpoUBdL1ynz8HyLxIX/UDAx7Ql2BjmA5CXT/p61JfZvkpiFWFpaqcfag==",
       "dependencies": {
-        "@vue/devtools-api": "^6.0.0"
+        "@vue/devtools-api": "^6.1.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
@@ -5950,36 +5950,36 @@
       "requires": {}
     },
     "@vueuse/core": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-8.9.1.tgz",
-      "integrity": "sha512-a7goYb/gJxjXRBw4Fr/jEACiN33ghwM1ohJVu+Zwsr3lNL4qCQ1nU+ogta98lNg5hXJxWj7mYEmQDjjyWOu5nA==",
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-8.9.2.tgz",
+      "integrity": "sha512-dE3/JgwqIHmmtmRBdZAnq87rZCSFbYVps2t3gWy9Jv/+Qp6sHSSKuPFtwguJVZ2OnaGnB/AMRmx4CuFRxFin3A==",
       "requires": {
         "@types/web-bluetooth": "^0.0.14",
-        "@vueuse/metadata": "8.9.1",
-        "@vueuse/shared": "8.9.1",
+        "@vueuse/metadata": "8.9.2",
+        "@vueuse/shared": "8.9.2",
         "vue-demi": "*"
       },
       "dependencies": {
         "@vueuse/shared": {
-          "version": "8.9.1",
-          "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-8.9.1.tgz",
-          "integrity": "sha512-klZfn7ijI3juqVgpfQVrrlBh4uTFajwSCWm8Cdt45Kg26b1LZ9jn9n7J6GhmkFay5016GnjjivQoekQSMeJNUg==",
+          "version": "8.9.2",
+          "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-8.9.2.tgz",
+          "integrity": "sha512-s4Nk82oheL5z1GywyGnqjob0MzbAt88olMZa0vgt/p3gcMsT8Ff7+SqmNgEFC6AAs6xiuhOAZpnew9Zs3d90yQ==",
           "requires": {
             "vue-demi": "*"
           }
         },
         "vue-demi": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.2.tgz",
-          "integrity": "sha512-41ukrclEbMddAyP7PvxMSYqnOSzPV6r7GNnyTSKSCNTaz19GehxmTiXyP9kwHSUv2+Dr6hHqiUiF7L1VAw2KdQ==",
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.4.tgz",
+          "integrity": "sha512-KP4lq9uSz0KZbaqCllRhnxMV3mYRsRWJfdsAhZyt5bV5O1RTpoeDptBRV9NOa/JgOpfaA9ane88VF7OjWNK/DA==",
           "requires": {}
         }
       }
     },
     "@vueuse/metadata": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-8.9.1.tgz",
-      "integrity": "sha512-6LADOlyl3oENHa9dsoY7LXjU1Mh14DnpM6ztETI3hpm5ZffOMIG5CB2Q6aEZfIvYr1lkJVmG2L82wFKk7VRfIA=="
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-8.9.2.tgz",
+      "integrity": "sha512-g2s2BeyeEtJElmMFfFPnM+BTvnt0omniyvz8U18/zXDpQIMGozlNQgHoFeratyMfgVBhH/u2VKzmchChtDsgPQ=="
     },
     "abab": {
       "version": "2.0.6",
@@ -7857,9 +7857,9 @@
       "dev": true
     },
     "pinia": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.15.tgz",
-      "integrity": "sha512-qkIvXdGWMbnc3UG3l8rn9SV4nE2H4I2R/exZcdn/0pDzjaKQmMUsBXlIurfKu62VJsjETkqss46NP/c88NnjYQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.16.tgz",
+      "integrity": "sha512-9/LMVO+/epny1NBfC77vnps4g3JRezxhhoF1xLUk8mZkUIxVnwfEAIRiAX8mYBTD/KCwZqnDMqXc8w3eU0FQGg==",
       "requires": {
         "@vue/devtools-api": "^6.1.4",
         "vue-demi": "*"
@@ -8497,11 +8497,11 @@
       }
     },
     "vue-router": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.16.tgz",
-      "integrity": "sha512-JcO7cb8QJLBWE+DfxGUL3xUDOae/8nhM1KVdnudadTAORbuxIC/xAydC5Zr/VLHUDQi1ppuTF5/rjBGzgzrJNA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.2.tgz",
+      "integrity": "sha512-5BP1qXFncVRwgV/XnqzsKApdMjQPqWIpoUBdL1ynz8HyLxIX/UDAx7Ql2BjmA5CXT/p61JfZvkpiFWFpaqcfag==",
       "requires": {
-        "@vue/devtools-api": "^6.0.0"
+        "@vue/devtools-api": "^6.1.4"
       }
     },
     "vue-tsc": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -14,13 +14,13 @@
   "dependencies": {
     "@pinia/plugin-debounce": "^0.1.0",
     "@types/humanize-duration": "^3.27.1",
-    "@vueuse/core": "^8.9.1",
+    "@vueuse/core": "^8.9.2",
     "humanize-duration": "^3.27.2",
     "moment": "^2.29.4",
-    "pinia": "^2.0.15",
+    "pinia": "^2.0.16",
     "ts-debounce": "^4.0.0",
     "vue": "^3.2.37",
-    "vue-router": "4",
+    "vue-router": "^4.1.2",
     "vue3-promise-dialog": "^0.3.4"
   },
   "devDependencies": {

--- a/dashboard/test/components/PackageDetailsCard.test.ts
+++ b/dashboard/test/components/PackageDetailsCard.test.ts
@@ -3,12 +3,12 @@ import PackageDetailsCard from "../../src/components/PackageDetailsCard.vue";
 import { usePackageStore } from "../../src/stores/package";
 import { createTestingPinia } from "@pinia/testing";
 import { render } from "@testing-library/vue";
-import { flushPromises } from "@vue/test-utils";
 import { expect, describe, it, vi } from "vitest";
+import { nextTick } from "vue";
 
 describe("PackageDetailsCard.vue", () => {
   it("watches download requests from the store", async () => {
-    render(PackageDetailsCard, {
+    const { unmount } = render(PackageDetailsCard, {
       global: {
         plugins: [
           createTestingPinia({
@@ -31,13 +31,15 @@ describe("PackageDetailsCard.vue", () => {
     // Someone requests the download of the AIP via the package store.
     const packageStore = usePackageStore();
     packageStore.ui.download.request();
-    await flushPromises();
+    await nextTick();
 
     // Then we observe that the component download function is executed.
     expect(window.open).toBeCalledWith(
       "///api/storage/89229d18-5554-4e0d-8c4e-d0d88afd3bae/download",
       "_blank"
     );
+
+    unmount();
   });
 
   it("renders when the package is in pending status", async () => {

--- a/dashboard/test/components/PageLoadingAlert.test.ts
+++ b/dashboard/test/components/PageLoadingAlert.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 
 describe("PageLoadingAlert.vue", () => {
   it("should render", () => {
-    const { html } = render(PageLoadingAlert, {
+    const { html, unmount } = render(PageLoadingAlert, {
       props: {
         error: { response: { status: 404 } },
       },
@@ -26,5 +26,7 @@ describe("PageLoadingAlert.vue", () => {
       <!-- Other errors. -->
       <!--v-if-->"
     `);
+
+    unmount();
   });
 });


### PR DESCRIPTION
I've learned the hard way that `unmount` is necessary when testing components, otherwise you may be mounting the same component from multiple tests and start seeing some weird results in your assertions. This pull request also adds a test that was flaky because unmount was not being used.