### PR TITLE
Use cleanup fn in dashboard tests

### DIFF
--- a/dashboard/test/components/PackageDetailsCard.test.ts
+++ b/dashboard/test/components/PackageDetailsCard.test.ts
@@ -2,13 +2,15 @@ import { api } from "@/client";
 import PackageDetailsCard from "@/components/PackageDetailsCard.vue";
 import { usePackageStore } from "@/stores/package";
 import { createTestingPinia } from "@pinia/testing";
-import { render } from "@testing-library/vue";
-import { expect, describe, it, vi } from "vitest";
+import { render, cleanup } from "@testing-library/vue";
+import { expect, describe, it, vi, afterEach } from "vitest";
 import { nextTick } from "vue";
 
 describe("PackageDetailsCard.vue", () => {
+  afterEach(() => cleanup());
+
   it("watches download requests from the store", async () => {
-    const { unmount } = render(PackageDetailsCard, {
+    render(PackageDetailsCard, {
       global: {
         plugins: [
           createTestingPinia({
@@ -38,8 +40,6 @@ describe("PackageDetailsCard.vue", () => {
       "///api/storage/89229d18-5554-4e0d-8c4e-d0d88afd3bae/download",
       "_blank"
     );
-
-    unmount();
   });
 
   it("renders when the package is in pending status", async () => {

--- a/dashboard/test/components/PackageListLegend.test.ts
+++ b/dashboard/test/components/PackageListLegend.test.ts
@@ -1,21 +1,17 @@
 import PackageListLegend from "@/components/PackageListLegend.vue";
-import { render, fireEvent } from "@testing-library/vue";
-import { describe, it, expect } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/vue";
+import { describe, it, expect, afterEach } from "vitest";
 
 describe("PackageListLegend.vue", () => {
+  afterEach(() => cleanup());
+
   it("renders when the package is moving", async () => {
-    const {
-      getByText,
-      getByLabelText,
-      queryByText,
-      emitted,
-      unmount,
-      rerender,
-    } = render(PackageListLegend, {
-      props: {
-        modelValue: true,
-      },
-    });
+    const { getByText, getByLabelText, queryByText, emitted, rerender } =
+      render(PackageListLegend, {
+        props: {
+          modelValue: true,
+        },
+      });
 
     getByText("DONE");
     getByText("ERROR");
@@ -31,7 +27,5 @@ describe("PackageListLegend.vue", () => {
     // And setting the prop to false should hide the legend.
     await rerender({ modelValue: false });
     expect(queryByText("DONE")).toBeNull();
-
-    unmount();
   });
 });

--- a/dashboard/test/components/PackageLocationCard.test.ts
+++ b/dashboard/test/components/PackageLocationCard.test.ts
@@ -2,12 +2,14 @@ import { api } from "@/client";
 import PackageLocationCard from "@/components/PackageLocationCard.vue";
 import { usePackageStore } from "@/stores/package";
 import { createTestingPinia } from "@pinia/testing";
-import { render, fireEvent } from "@testing-library/vue";
-import { describe, it, vi, expect } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/vue";
+import { describe, it, vi, expect, afterEach } from "vitest";
 
 describe("PackageLocationCard.vue", () => {
+  afterEach(() => cleanup());
+
   it("renders when the package is stored", async () => {
-    const { html, unmount } = render(PackageLocationCard, {
+    const { html } = render(PackageLocationCard, {
       global: {
         plugins: [
           createTestingPinia({
@@ -36,12 +38,10 @@ describe("PackageLocationCard.vue", () => {
         </div>
       </div>"
     `);
-
-    unmount();
   });
 
   it("renders when the package location is moved", async () => {
-    const { getByText, unmount } = render(PackageLocationCard, {
+    const { getByText } = render(PackageLocationCard, {
       global: {
         plugins: [
           createTestingPinia({
@@ -85,12 +85,10 @@ describe("PackageLocationCard.vue", () => {
     await fireEvent.click(button);
 
     getByText("The package is being moved into a new location.");
-
-    unmount();
   });
 
   it("renders when the package location is not available", async () => {
-    const { html, unmount } = render(PackageLocationCard, {
+    const { html } = render(PackageLocationCard, {
       global: {
         plugins: [
           createTestingPinia({
@@ -118,12 +116,10 @@ describe("PackageLocationCard.vue", () => {
         </div>
       </div>"
     `);
-
-    unmount();
   });
 
   it("renders when the package is rejected", async () => {
-    const { html, unmount } = render(PackageLocationCard, {
+    const { html } = render(PackageLocationCard, {
       global: {
         plugins: [
           createTestingPinia({
@@ -152,12 +148,10 @@ describe("PackageLocationCard.vue", () => {
         </div>
       </div>"
     `);
-
-    unmount();
   });
 
   it("renders when the package is moving", async () => {
-    const { html, unmount } = render(PackageLocationCard, {
+    const { html } = render(PackageLocationCard, {
       global: {
         plugins: [
           createTestingPinia({
@@ -186,7 +180,5 @@ describe("PackageLocationCard.vue", () => {
         </div>
       </div>"
     `);
-
-    unmount();
   });
 });

--- a/dashboard/test/components/PageLoadingAlert.test.ts
+++ b/dashboard/test/components/PageLoadingAlert.test.ts
@@ -1,11 +1,13 @@
 import PageLoadingAlert from "@/components/PageLoadingAlert.vue";
-import { render } from "@testing-library/vue";
+import { render, cleanup } from "@testing-library/vue";
 import { RouterLinkStub } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, afterEach } from "vitest";
 
 describe("PageLoadingAlert.vue", () => {
+  afterEach(() => cleanup());
+
   it("should render", () => {
-    const { html, unmount } = render(PageLoadingAlert, {
+    const { html } = render(PageLoadingAlert, {
       props: {
         error: { response: { status: 404 } },
       },
@@ -26,7 +28,5 @@ describe("PageLoadingAlert.vue", () => {
       <!-- Other errors. -->
       <!--v-if-->"
     `);
-
-    unmount();
   });
 });

--- a/dashboard/test/components/PreservationActionCollapse.test.ts
+++ b/dashboard/test/components/PreservationActionCollapse.test.ts
@@ -1,13 +1,15 @@
 import { api } from "@/client";
 import PreservationActionCollapse from "@/components/PreservationActionCollapse.vue";
 import { createTestingPinia } from "@pinia/testing";
-import { render, fireEvent } from "@testing-library/vue";
-import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/vue";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 describe("PreservationActionCollapse.vue", () => {
+  afterEach(() => cleanup());
+
   it("renders, expands and collapses", async () => {
     const now = new Date();
-    const { getByText, getByRole, emitted, unmount, rerender } = render(
+    const { getByText, getByRole, emitted, rerender } = render(
       PreservationActionCollapse,
       {
         props: {
@@ -85,7 +87,5 @@ describe("PreservationActionCollapse.vue", () => {
 
     await rerender({ toggleAll: true });
     expect(emitted()["update:toggleAll"][2]).toStrictEqual([null]);
-
-    unmount();
   });
 });

--- a/dashboard/test/components/UUID.test.ts
+++ b/dashboard/test/components/UUID.test.ts
@@ -1,10 +1,12 @@
 import UUID from "@/components/UUID.vue";
-import { render } from "@testing-library/vue";
-import { describe, expect, it } from "vitest";
+import { render, cleanup } from "@testing-library/vue";
+import { afterEach, describe, expect, it } from "vitest";
 
 describe("UUID.vue", () => {
+  afterEach(() => cleanup());
+
   it("should render", () => {
-    const { getByText, unmount } = render(UUID, {
+    const { getByText } = render(UUID, {
       props: {
         id: "31ceb5d5-a9c1-488b-b4ee-40910e54109e",
       },
@@ -12,7 +14,5 @@ describe("UUID.vue", () => {
 
     const el = getByText("31ceb5d5-a9c1-488b-b4ee-40910e54109e");
     expect(el.className).toBe("font-monospace");
-
-    unmount();
   });
 });


### PR DESCRIPTION
Update tests to use `cleanup` instead of `unmount`:

    afterEach(() => cleanup())

[`cleanup`](https://github.com/testing-library/vue-testing-library/blob/4a663b9a265c4e2a51e0b550c8d1809169bd1daf/src/render.js#L58-L72) seems to take care of more details.