### PR TITLE
Add k8s cluster data flush

### DIFF
--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -18,8 +18,11 @@ jobs:
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.DO_DEV_KUBECONFIG }}
-      - name: Delete Kubernetes resources
-        run: kubectl delete all,pvc,pv --all -n sdps
+      - name: Flush existing data
+        run: |
+          kubectl create -f hack/kube/tools/mysql-recreate-databases-job.yaml
+          kubectl create -f hack/kube/tools/minio-recreate-buckets-job.yaml
+          kubectl create -f hack/kube/tools/opensearch-delete-index-job.yaml
       - name: Refresh and update Pulumi stack
         uses: pulumi/actions@v3.18.1
         with:
@@ -30,3 +33,8 @@ jobs:
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_TOKEN }}
           DOCKER_BUILDKIT: 1
+      - name: Restart resources
+        run: |
+          kubectl rollout restart deployment temporal -n sdps
+          kubectl rollout restart deployment enduro -n sdps
+          kubectl rollout restart statefulset enduro-a3m -n sdps

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ tilt up
 
 ### Clear the cluster
 
+> Check the Tilt UI helpers below to just flush the existing data.
+
 To remove the resources created by Tilt in the cluster, execute:
 
 ```
@@ -151,6 +153,12 @@ sure you update `/path/to/enduro` to the proper project folder in the host):
 
 - Host path: `/path/to/enduro/hack/sampledata/StructB-AM.zip`
 - Object name: `StructB-AM.zip`
+
+#### Flush
+
+Also in the Tilt UI header, click the trash button to flush the existing data.
+This will recreate the MySQL databases and the MinIO buckets, delete the
+Opensearch index and restart the required resources.
 
 ### Known issues
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -57,3 +57,20 @@ cmd_button(
     text_input("OBJECT_NAME", label="Object name"),
   ]
 )
+
+cmd_button(
+  "flush",
+  argv=[
+    "sh",
+    "-c",
+    "kubectl create -f hack/kube/tools/mysql-recreate-databases-job.yaml; \
+    kubectl create -f hack/kube/tools/minio-recreate-buckets-job.yaml; \
+    kubectl create -f hack/kube/tools/opensearch-delete-index-job.yaml; \
+    kubectl rollout restart deployment temporal -n sdps; \
+    kubectl rollout restart deployment enduro -n sdps; \
+    kubectl rollout restart statefulset enduro-a3m -n sdps;",
+  ],
+  location="nav",
+  icon_name="delete",
+  text="Flush",
+)

--- a/hack/kube/tools/minio-recreate-buckets-job.yaml
+++ b/hack/kube/tools/minio-recreate-buckets-job.yaml
@@ -1,24 +1,14 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: minio-setup-buckets
+  generateName: minio-recreate-buckets-
+  namespace: sdps
 spec:
-  backoffLimit: 100
   template:
     spec:
       restartPolicy: "OnFailure"
-      initContainers:
-        - name: check-minio
-          image: busybox
-          imagePullPolicy: IfNotPresent
-          command:
-            [
-              "sh",
-              "-c",
-              "until nslookup minio; do echo waiting for minio service; sleep 1; done;",
-            ]
       containers:
-        - name: setup-buckets
+        - name: recreate-buckets
           image: "minio/mc"
           imagePullPolicy: IfNotPresent
           env:
@@ -36,6 +26,7 @@ spec:
               "sh",
               "-c",
               "mc alias set enduro http://minio:9000 ${MINIO_USER} ${MINIO_PASSWORD};
+              mc rb --force --dangerous enduro;
               mc mb enduro/sips --ignore-existing;
               mc mb enduro/aips --ignore-existing;
               mc mb enduro/perma-aips-1 --ignore-existing;

--- a/hack/kube/tools/mysql-recreate-databases-job.yaml
+++ b/hack/kube/tools/mysql-recreate-databases-job.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: mysql-recreate-databases-
+  namespace: sdps
+spec:
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: recreate-databases
+          image: mysql:8.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: root-password
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: user
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: password
+          command: [
+              "sh",
+              "-c",
+              'mysql -h mysql -u root -p$MYSQL_ROOT_PASSWORD --execute "
+              DROP DATABASE IF EXISTS enduro;
+              CREATE DATABASE IF NOT EXISTS enduro;
+              GRANT ALL PRIVILEGES ON enduro.* TO ''$MYSQL_USER''@''%'';
+              DROP DATABASE IF EXISTS temporal;
+              CREATE DATABASE IF NOT EXISTS temporal;
+              GRANT ALL PRIVILEGES ON temporal.* TO ''$MYSQL_USER''@''%'';
+              DROP DATABASE IF EXISTS temporal_visibility;
+              CREATE DATABASE IF NOT EXISTS temporal_visibility;
+              GRANT ALL PRIVILEGES ON temporal_visibility.* TO ''$MYSQL_USER''@''%'';
+              "',
+            ]

--- a/hack/kube/tools/opensearch-delete-index-job.yaml
+++ b/hack/kube/tools/opensearch-delete-index-job.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: opensearch-delete-index-
+  namespace: sdps
+spec:
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+        - name: delete-index
+          image: alpine/curl
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "curl -X DELETE http://opensearch:9200/sdps"]

--- a/hack/pulumi/main.go
+++ b/hack/pulumi/main.go
@@ -35,6 +35,10 @@ taskqueue = "global"
 listen = "0.0.0.0:9000"
 debug = false
 
+[event]
+redisAddress = "redis://redis:6379"
+redisChannel = "enduro-events"
+
 [database]
 dsn = "{MYSQL_USER}:{MYSQL_PASSWORD}@tcp(mysql:3306)/enduro"
 


### PR DESCRIPTION
Add k8s jobs to recreate the MySQL databases and MinIO buckets and
delete the Opensearch index. Add a Tilt UI button to trigger them and
use them in the GHA workflow to update the Pulumi stack.