### PR TITLE
Fix test using faked timer

### DIFF
--- a/dashboard/test/components/UUID.test.ts
+++ b/dashboard/test/components/UUID.test.ts
@@ -1,11 +1,18 @@
 import UUID from "@/components/UUID.vue";
 import { cleanup, fireEvent, render } from "@testing-library/vue";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("UUID.vue", () => {
-  const uuid = "31ceb5d5-a9c1-488b-b4ee-40910e54109e";
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
 
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  const uuid = "31ceb5d5-a9c1-488b-b4ee-40910e54109e";
 
   it("should render", () => {
     const { getByText } = render(UUID, { props: { id: uuid } });
@@ -19,15 +26,15 @@ describe("UUID.vue", () => {
       clipboard: { writeText: (text: string) => (clipboardText = text) },
     });
 
-    const { getByRole } = render(UUID, { props: { id: uuid } });
+    const { getByRole, findByRole } = render(UUID, { props: { id: uuid } });
 
     await fireEvent.click(getByRole("button", { name: "Copy to clipboard" }));
 
     expect(clipboardText).toEqual(uuid);
     getByRole("button", { name: "Copied!" });
 
-    setTimeout(() => {
-      getByRole("button", { name: "Copy to clipboard" });
-    }, 500);
+    // Confirm that the button goes back into its original state.
+    vi.runOnlyPendingTimers();
+    await findByRole("button", { name: "Copy to clipboard" });
   });
 });


### PR DESCRIPTION
Fixes a false positive undetected because setTimeout was scheduled after the test was done running. It uses a faked timer that allows for running pending timers, i.e. forcing the clipboard composable to return into its original state immediately.