### PR TITLE
Load unplugin-icon types from env.d.ts

### DIFF
--- a/dashboard/src/env.d.ts
+++ b/dashboard/src/env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pages/client" />
 /// <reference types="vue/macros-global" />
+/// <reference types="unplugin-icons/types/vue" />
 
 declare module "*.vue" {
   import type { DefineComponent } from "vue";

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -15,8 +15,7 @@
     "skipLibCheck": true,
     "paths": {
       "@/*": ["src/*"]
-    },
-    "types": ["unplugin-icons/types/vue"]
+    }
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
This method seems to work best with VSCode.
