### PR TITLE
Fix router warnings in dashboard tests

### DIFF
--- a/dashboard/test/components/Breadcrumb.test.ts
+++ b/dashboard/test/components/Breadcrumb.test.ts
@@ -24,11 +24,13 @@ describe("Breadcrumb.vue", () => {
           }),
           createRouter({
             history: createWebHistory(),
-            routes: [{ name: "packages", path: "/packages", component: {} }],
+            routes: [
+              { name: "index", path: "", component: {} },
+              { name: "packages", path: "/packages", component: {} },
+            ],
           }),
         ],
       },
-      routes: [],
     });
 
     getByRole("navigation", { name: "Breadcrumb" });

--- a/dashboard/test/components/Header.test.ts
+++ b/dashboard/test/components/Header.test.ts
@@ -3,6 +3,12 @@ import { useLayoutStore } from "@/stores/layout";
 import { createTestingPinia } from "@pinia/testing";
 import { cleanup, fireEvent, render } from "@testing-library/vue";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRouter, createWebHistory } from "vue-router";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [{ name: "index", path: "", component: {} }],
+});
 
 describe("Header.vue", () => {
   afterEach(() => cleanup());
@@ -20,6 +26,7 @@ describe("Header.vue", () => {
             },
             stubActions: false,
           }),
+          router,
         ],
       },
     });
@@ -51,6 +58,7 @@ describe("Header.vue", () => {
               layout: { breadcrumb: [{ text: "Packages" }] },
             },
           }),
+          router,
         ],
       },
     });

--- a/dashboard/test/components/Sidebar.test.ts
+++ b/dashboard/test/components/Sidebar.test.ts
@@ -5,7 +5,18 @@ import { cleanup, fireEvent, render } from "@testing-library/vue";
 import { flushPromises } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
-import { createRouter, createWebHistory } from "vue-router";
+import { createRouter, createMemoryHistory } from "vue-router";
+
+const router = createRouter({
+  // Vue Router throws history.state warning when the second click is fired,
+  // createMemoryHistory does not have this problem.
+  history: createMemoryHistory(),
+  routes: [
+    { name: "index", path: "", component: {} },
+    { name: "packages", path: "/packages", component: {} },
+    { name: "locations", path: "/locations", component: {} },
+  ],
+});
 
 describe("Sidebar.vue", () => {
   afterEach(() => cleanup());
@@ -22,13 +33,7 @@ describe("Sidebar.vue", () => {
               },
             },
           }),
-          createRouter({
-            history: createWebHistory(),
-            routes: [
-              { name: "packages", path: "/packages", component: {} },
-              { name: "locations", path: "/locations", component: {} },
-            ],
-          }),
+          router,
         ],
       },
     });
@@ -41,7 +46,7 @@ describe("Sidebar.vue", () => {
     await flushPromises();
     expect(packagesLink.getAttribute("aria-current")).toEqual("page");
 
-    fireEvent.click(locationsLink);
+    await fireEvent.click(locationsLink);
     await flushPromises();
     expect(locationsLink.getAttribute("aria-current")).toEqual("page");
   });
@@ -58,6 +63,7 @@ describe("Sidebar.vue", () => {
               },
             },
           }),
+          router,
         ],
       },
     });


### PR DESCRIPTION
I noticed that some recent tests were throwing some warnings, e.g. missing router or missing index route.

```
stderr | test/components/Sidebar.test.ts > Sidebar.vue > collapses and expands
[Vue warn]: Failed to resolve component: router-link
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <Sidebar ref="VTU_COMPONENT" > 
  at <VTUROOT>
[Vue warn]: Failed to resolve component: router-link
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <Sidebar ref="VTU_COMPONENT" > 
  at <VTUROOT>
[Vue warn]: Failed to resolve component: router-link
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <Sidebar ref="VTU_COMPONENT" > 
  at <VTUROOT>

stderr | test/components/Sidebar.test.ts > Sidebar.vue > renders the navigation links
[Vue Router warn]: No match found for location with path ""
[Vue Router warn]: history.state seems to have been manually replaced without preserving the necessary values. Make sure to preserve existing history state if you are manually calling history.replaceState:

history.replaceState(history.state, '', url)

You can find more information at https://next.router.vuejs.org/guide/migration/#usage-of-history-state.

stderr | test/components/Header.test.ts > Header.vue > displays the breadcrumb navigation
stderr | test/components/Header.test.ts > Header.vue > collapses and expands the sidebar
[Vue warn]: Failed to resolve component: router-link
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <Header ref="VTU_COMPONENT" > 
  at <VTUROOT>
[Vue warn]: Failed to resolve component: router-link
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <Breadcrumb> 
  at <Header ref="VTU_COMPONENT" > 
  at <VTUROOT>

[Vue warn]: Failed to resolve component: router-link
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <Header ref="VTU_COMPONENT" > 
  at <VTUROOT>
[Vue warn]: Failed to resolve component: router-link
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <Breadcrumb> 
  at <Header ref="VTU_COMPONENT" > 
  at <VTUROOT>
[Vue warn]: Failed to resolve component: router-link
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <Header ref="VTU_COMPONENT" > 
  at <VTUROOT>
[Vue warn]: Failed to resolve component: router-link
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <Header ref="VTU_COMPONENT" > 
  at <VTUROOT>

stderr | test/components/Breadcrumb.test.ts > Breadcrumb.vue > renders
Providing 'store' or 'routes' options is no longer available.
You need to create a router/vuex instance and provide it through 'global.plugins'.
Check out the test examples on GitHub for further details.
[Vue Router warn]: No match found for location with path ""
```