### PR TITLE
Use unparam linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - gofumpt
     - importas
     - gci
+    - unparam
 
 issues:
   exclude-rules:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -97,6 +97,6 @@ func errorHandler(logger logr.Logger, msg string) func(context.Context, http.Res
 			reqID = "unknown"
 		}
 		_ = json.NewEncoder(w).Encode(&errorMessage{RequestID: reqID})
-		logger.Error(err, "Package service error.", "reqID", reqID)
+		logger.Error(err, "Package service error.", "reqID", reqID, "info", msg)
 	}
 }

--- a/internal/package_/package_.go
+++ b/internal/package_/package_.go
@@ -107,7 +107,7 @@ func (svc *packageImpl) UpdateWorkflowStatus(ctx context.Context, ID uint, name 
 		ID,
 	}
 
-	if _, err := svc.updateRow(ctx, query, args); err != nil {
+	if err := svc.updateRow(ctx, query, args); err != nil {
 		return err
 	}
 
@@ -126,7 +126,7 @@ func (svc *packageImpl) SetStatus(ctx context.Context, ID uint, status Status) e
 		ID,
 	}
 
-	if _, err := svc.updateRow(ctx, query, args); err != nil {
+	if err := svc.updateRow(ctx, query, args); err != nil {
 		return err
 	}
 
@@ -148,7 +148,7 @@ func (svc *packageImpl) SetStatusInProgress(ctx context.Context, ID uint, starte
 		args = append(args, ID)
 	}
 
-	if _, err := svc.updateRow(ctx, query, args); err != nil {
+	if err := svc.updateRow(ctx, query, args); err != nil {
 		return err
 	}
 
@@ -165,7 +165,7 @@ func (svc *packageImpl) SetStatusPending(ctx context.Context, ID uint) error {
 		ID,
 	}
 
-	if _, err := svc.updateRow(ctx, query, args); err != nil {
+	if err := svc.updateRow(ctx, query, args); err != nil {
 		return err
 	}
 
@@ -182,7 +182,7 @@ func (svc *packageImpl) SetLocationID(ctx context.Context, ID uint, locationID u
 		ID,
 	}
 
-	if _, err := svc.updateRow(ctx, query, args); err != nil {
+	if err := svc.updateRow(ctx, query, args); err != nil {
 		return err
 	}
 
@@ -192,18 +192,13 @@ func (svc *packageImpl) SetLocationID(ctx context.Context, ID uint, locationID u
 	return nil
 }
 
-func (svc *packageImpl) updateRow(ctx context.Context, query string, args []interface{}) (int64, error) {
-	res, err := svc.db.ExecContext(ctx, query, args...)
+func (svc *packageImpl) updateRow(ctx context.Context, query string, args []interface{}) error {
+	_, err := svc.db.ExecContext(ctx, query, args...)
 	if err != nil {
-		return 0, fmt.Errorf("error updating package: %v", err)
+		return fmt.Errorf("error updating package: %v", err)
 	}
 
-	n, err := res.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("error retrieving rows affected: %v", err)
-	}
-
-	return n, nil
+	return nil
 }
 
 func (svc *packageImpl) read(ctx context.Context, ID uint) (*Package, error) {

--- a/internal/storage/persistence/ent/client/client.go
+++ b/internal/storage/persistence/ent/client/client.go
@@ -165,7 +165,7 @@ func (c *Client) CreateLocation(ctx context.Context, location *goastorage.Locati
 		return nil, err
 	}
 
-	return locationAsGoa(ctx, l), nil
+	return locationAsGoa(l), nil
 }
 
 func (c *Client) ListLocations(ctx context.Context) (goastorage.StoredLocationCollection, error) {
@@ -173,7 +173,7 @@ func (c *Client) ListLocations(ctx context.Context) (goastorage.StoredLocationCo
 
 	res, err := c.c.Location.Query().All(ctx)
 	for _, item := range res {
-		locations = append(locations, locationAsGoa(ctx, item))
+		locations = append(locations, locationAsGoa(item))
 	}
 
 	return locations, err
@@ -193,10 +193,10 @@ func (c *Client) ReadLocation(ctx context.Context, locationID uuid.UUID) (*goast
 		}
 	}
 
-	return locationAsGoa(ctx, l), nil
+	return locationAsGoa(l), nil
 }
 
-func locationAsGoa(ctx context.Context, loc *db.Location) *goastorage.StoredLocation {
+func locationAsGoa(loc *db.Location) *goastorage.StoredLocation {
 	l := &goastorage.StoredLocation{
 		Name:        loc.Name,
 		Description: &loc.Description,

--- a/internal/watcher/minio_test.go
+++ b/internal/watcher/minio_test.go
@@ -49,6 +49,8 @@ func newWatcher(t *testing.T) (*miniredis.Miniredis, watcher.Watcher) {
 }
 
 func cleanup(t *testing.T, m *miniredis.Miniredis) {
+	t.Helper()
+
 	m.Close()
 }
 

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -472,11 +472,7 @@ func (w *ProcessingWorkflow) SessionHandler(sessCtx temporalsdk_workflow.Context
 		}
 	}
 
-	review, err := w.waitForReview(sessCtx)
-	if err != nil {
-		return err
-	}
-
+	review := w.waitForReview(sessCtx)
 	reviewCompletedAt := temporalsdk_workflow.Now(sessCtx).UTC()
 
 	// Set package to in progress status.
@@ -610,7 +606,7 @@ func (w *ProcessingWorkflow) SessionHandler(sessCtx temporalsdk_workflow.Context
 	return nil
 }
 
-func (w *ProcessingWorkflow) waitForReview(ctx temporalsdk_workflow.Context) (*package_.ReviewPerformedSignal, error) {
+func (w *ProcessingWorkflow) waitForReview(ctx temporalsdk_workflow.Context) *package_.ReviewPerformedSignal {
 	var review package_.ReviewPerformedSignal
 	signalChan := temporalsdk_workflow.GetSignalChannel(ctx, package_.ReviewPerformedSignalName)
 	selector := temporalsdk_workflow.NewSelector(ctx)
@@ -618,7 +614,7 @@ func (w *ProcessingWorkflow) waitForReview(ctx temporalsdk_workflow.Context) (*p
 		_ = channel.Receive(ctx, &review)
 	})
 	selector.Select(ctx)
-	return &review, nil
+	return &review
 }
 
 func (w *ProcessingWorkflow) transferA3m(sessCtx temporalsdk_workflow.Context, tinfo *TransferInfo) error {


### PR DESCRIPTION
This commit enables unparam, a linter available in golangci-lint that finds
unused paramaters, minimising false positives, e.g. satisfy interface methods or
function signatures, stubs, etc...
