### PR TITLE
Add gosec to golang-ci linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,12 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.19.x
-    - name: Install golangci-lint
+        cache: true
+    - name: Cache golangci-lint analysis results
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/golangci-lint
+        key: ${{ runner.os }}-golangci-lint
       run: |
         echo $(go env GOPATH)/bin >> $GITHUB_PATH
         echo $PATH

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,12 +20,15 @@ jobs:
       with:
         path: ~/.cache/golangci-lint
         key: ${{ runner.os }}-golangci-lint
+    - name: Define GOBIN
       run: |
-        echo $(go env GOPATH)/bin >> $GITHUB_PATH
-        echo $PATH
+        echo GOBIN=$(go env GOPATH)/bin >> $GITHUB_ENV
+    - name: Install bingo
+      run:
         make bingo
-        bingo get -l golangci-lint
+    - name: Install golangci-lint
+      run:
+        bingo get -v -l golangci-lint
     - name: Lint code
       run:
-        echo $(go env GOPATH)/bin >> $GITHUB_PATH
         make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - importas
     - gci
     - unparam
+    - gosec
 
 issues:
   exclude-rules:
@@ -37,3 +38,7 @@ linters-settings:
         alias: temporalsdk_$1
       - pkg: go.temporal.io/api/(\w+)
         alias: temporalapi_$1
+  gosec:
+    exclude-generated: false
+    severity: low
+    confidence: low

--- a/README.md
+++ b/README.md
@@ -55,14 +55,22 @@ If using Linux, Node.js binary distributions are available from [NodeSource].
 #### Go tools
 
 We use [bingo] to manage some Go tools and binaries needed to perform various
-development operations. First, set `GOPATH` in your environment:
+development operations.
+
+bingo builds pinned tools in your `$GOBIN` path. If `$GOBIN` is undefined, we
+try to set its value by expanding `$(go env GOPATH)/bin` since it is common for
+Go developers to have previously defined `$GOPATH`.
+
+Preferably, define `$GOBIN` in your environment and include the same directory
+in your `$PATH` so your system knows where to find the executables, e.g.:
 
 ```
-export GOPATH=$HOME/go
+export GOBIN=$HOME/go/bin
+export PATH=$HOME/go/bin:$PATH
 ```
 
-Make sure that environment variable is set each time you use bingo or one of
-the tools. For example, by adding that line to your `~/.profile` file.
+We recommend to [set the environment strings permanently] - follow the link to
+know more.
 
 Then, install and list them with:
 
@@ -70,7 +78,7 @@ Then, install and list them with:
 make tools
 ```
 
-This tools will be used through Makefile rules and the Tilt UI.
+These tools will be used through Makefile rules and the Tilt UI.
 
 ### Editor
 
@@ -246,3 +254,4 @@ is sometimes not setup properly. To solve it, from the Tilt UI, restart the
 [gcc]: https://gcc.gnu.org/
 [bingo]: https://github.com/bwplotka/bingo
 [visual studio code]: https://code.visualstudio.com/
+[set the environment strings permanently]: https://unix.stackexchange.com/a/117470


### PR DESCRIPTION
This commit adds gosec to the golang-ci linter. Running 'make lint' will
now use gosec to scan the go codebase for potential security issues.