### PR TITLE
Fix package workflow status when reviewing AIP

### DIFF
--- a/dashboard/src/pages/packages/[id]/index.vue
+++ b/dashboard/src/pages/packages/[id]/index.vue
@@ -14,7 +14,10 @@ const createAipWorkflow = $computed(
     packageStore.current_preservation_actions?.actions?.filter(
       (action) =>
         action.type ===
-        api.EnduroPackagePreservationActionResponseBodyTypeEnum.CreateAip
+          api.EnduroPackagePreservationActionResponseBodyTypeEnum.CreateAip ||
+        action.type ===
+          api.EnduroPackagePreservationActionResponseBodyTypeEnum
+            .CreateAndReviewAip
     )[0]
 );
 


### PR DESCRIPTION
This is a left over of https://github.com/artefactual-sdps/enduro/pull/255 which fixes the workflow status information in the package detail page when the `Create and Review AIP` workflow is enabled.