### PR TITLE
API clean-ups

### DIFF
--- a/internal/api/auth/ticket_test.go
+++ b/internal/api/auth/ticket_test.go
@@ -14,6 +14,23 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/api/auth/fake"
 )
 
+func TestTicketProviderNop(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	provider := auth.NewTicketProvider(ctx, nil, nil)
+
+	ticket, err := provider.Request(ctx)
+	assert.NilError(t, err)
+	assert.Equal(t, ticket, "")
+
+	err = provider.Check(ctx, ticket)
+	assert.NilError(t, err)
+
+	err = provider.Close()
+	assert.NilError(t, err)
+}
+
 func TestTicketProviderRequest(t *testing.T) {
 	t.Parallel()
 

--- a/main.go
+++ b/main.go
@@ -164,7 +164,7 @@ func main() {
 				store = auth.NewInMemStore()
 			}
 		}
-		ticketProvider = auth.NewTicketProvider(ctx, store, cfg.API.Auth.Ticket.Redis.Prefix, rand.Reader)
+		ticketProvider = auth.NewTicketProvider(ctx, store, rand.Reader)
 		defer ticketProvider.Close()
 	}
 


### PR DESCRIPTION
A couple of tiny improvements:

* Set up no-op ticket provider.
  Not really important, this is just me trying to figure out how could we provide a no-op mechanism when using a concrete type (*auth.TicketProvider). The ultimate goal is to encapsulate the auth enabled toggle functionaliy where it belongs while not recurring to an interface type again, as we earlier decided that the interface type would be the provider store and not the provider itself. I think that we can just keep iterating if we need to, but this feels "better".
* Make prefix an attribute of the Redis store.
  I realized that the way that the provider was building keys isn't always going to work with other stores, e.g. in-mem don't need to namespace at all, other stores may as well do non-string based namespacing or it may be based on credentials, etc. So I thought that I'd push the namespacing concern out to the Redis store.