### PR TITLE
Safelist all Content-Type headers

### DIFF
--- a/internal/api/design/design.go
+++ b/internal/api/design/design.go
@@ -33,6 +33,6 @@ var _ = API("enduro", func() {
 	})
 	cors.Origin("*", func() {
 		cors.Methods("GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS")
-		cors.Headers("Authorization")
+		cors.Headers("Authorization", "Content-Type")
 	})
 })

--- a/internal/api/gen/http/package_/server/server.go
+++ b/internal/api/gen/http/package_/server/server.go
@@ -644,7 +644,7 @@ func HandlePackageOrigin(h http.Handler) http.Handler {
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 				w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Authorization")
+				w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 			}
 			h.ServeHTTP(w, r)
 			return

--- a/internal/api/gen/http/storage/server/server.go
+++ b/internal/api/gen/http/storage/server/server.go
@@ -740,7 +740,7 @@ func HandleStorageOrigin(h http.Handler) http.Handler {
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 				w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Authorization")
+				w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 			}
 			h.ServeHTTP(w, r)
 			return

--- a/internal/api/gen/http/swagger/server/server.go
+++ b/internal/api/gen/http/swagger/server/server.go
@@ -121,7 +121,7 @@ func HandleSwaggerOrigin(h http.Handler) http.Handler {
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 				w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Authorization")
+				w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 			}
 			h.ServeHTTP(w, r)
 			return

--- a/internal/api/gen/http/upload/server/server.go
+++ b/internal/api/gen/http/upload/server/server.go
@@ -165,7 +165,7 @@ func HandleUploadOrigin(h http.Handler) http.Handler {
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 				w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Authorization")
+				w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 			}
 			h.ServeHTTP(w, r)
 			return


### PR DESCRIPTION
Content-Type is a CORS-safelisted request header but allowed values are only:
`application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`.

https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header
