### PR TITLE
Fix trigger mode config in Tiltfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /dist
+/.tilt.env


### PR DESCRIPTION
- Write custom dotenv that doesn't error if .tilt.env is missing.
- Add .tilt.env to .gitignore.
- Use trigger_mode in k8s_resource(s).