### PR TITLE
Fix ent client tests for `created_at` fields

### DIFF
--- a/internal/storage/persistence/ent/client/client_test.go
+++ b/internal/storage/persistence/ent/client/client_test.go
@@ -24,7 +24,7 @@ import (
 
 func fakeNow() time.Time {
 	const longForm = "Jan 2, 2006 at 3:04pm (MST)"
-	t, _ := time.Parse(longForm, "Feb 3, 2013 at 7:54pm (PST)")
+	t, _ := time.Parse(longForm, "Feb 3, 2013 at 7:54pm (UTC)")
 	return t
 }
 


### PR DESCRIPTION
Use UTC date/time for fake `created_at` field tests to match expected values.