### PR TITLE
Triggering the cleanup of the dead letter queue

### DIFF
--- a/internal/watcher/filesystem.go
+++ b/internal/watcher/filesystem.go
@@ -116,20 +116,20 @@ func (w *filesystemWatcher) loop() {
 	}
 }
 
-func (w *filesystemWatcher) Watch(ctx context.Context) (*BlobEvent, error) {
+func (w *filesystemWatcher) Watch(ctx context.Context) (*BlobEvent, Cleanup, error) {
 	fsevent, ok := <-w.ch
 	if !ok {
-		return nil, ErrWatchTimeout
+		return nil, noopCleanup, ErrWatchTimeout
 	}
 	info, err := os.Stat(fsevent.Name)
 	if err != nil {
-		return nil, fmt.Errorf("error in file stat check: %s", err)
+		return nil, noopCleanup, fmt.Errorf("error in file stat check: %s", err)
 	}
 	rel, err := filepath.Rel(w.path, fsevent.Name)
 	if err != nil {
-		return nil, fmt.Errorf("error generating relative path of fsvent.Name %s - %w", fsevent.Name, err)
+		return nil, noopCleanup, fmt.Errorf("error generating relative path of fsvent.Name %s - %w", fsevent.Name, err)
 	}
-	return NewBlobEvent(w, rel, info.IsDir()), nil
+	return NewBlobEvent(w, rel, info.IsDir()), noopCleanup, nil
 }
 
 func (w *filesystemWatcher) Path() string {

--- a/internal/watcher/minio_test.go
+++ b/internal/watcher/minio_test.go
@@ -63,7 +63,7 @@ func TestWatcherReturnsErrWhenNoMessages(t *testing.T) {
 	// TODO: slow test, should inject smaller timeout.
 
 	check := func(t poll.LogT) poll.Result {
-		_, err := w.Watch(context.Background())
+		_, _, err := w.Watch(context.Background())
 
 		if err == nil {
 			return poll.Error(errors.New("watched did not return an error"))
@@ -86,7 +86,7 @@ func TestWatcherReturnsErrOnInvalidMessages(t *testing.T) {
 	m.Lpush("minio-events", "{}")
 
 	check := func(t poll.LogT) poll.Result {
-		_, err := w.Watch(context.Background())
+		_, _, err := w.Watch(context.Background())
 
 		if err == nil {
 			return poll.Error(errors.New("watched did not return an error"))
@@ -163,7 +163,7 @@ func TestWatcherReturnsErrOnMessageInWrongBucket(t *testing.T) {
 ]`)
 
 	check := func(t poll.LogT) poll.Result {
-		_, err := w.Watch(context.Background())
+		_, _, err := w.Watch(context.Background())
 
 		if err == nil {
 			return poll.Error(errors.New("watched did not return an error"))
@@ -239,7 +239,7 @@ func TestWatcherReturnsOnValidMessage(t *testing.T) {
 ]`)
 
 	check := func(t poll.LogT) poll.Result {
-		event, err := w.Watch(context.Background())
+		event, _, err := w.Watch(context.Background())
 		if err != nil {
 			return poll.Error(fmt.Errorf("watcher return an error unexpectedly: %w", err))
 		}
@@ -277,7 +277,7 @@ func TestWatcherReturnsDecodedObjectKey(t *testing.T) {
 ]`)
 
 	check := func(t poll.LogT) poll.Result {
-		event, err := w.Watch(context.Background())
+		event, _, err := w.Watch(context.Background())
 		if err != nil {
 			return poll.Error(fmt.Errorf("watcher return an error unexpectedly: %w", err))
 		}
@@ -315,7 +315,7 @@ func TestWatcherReturnsErrOnInvalidObjectKey(t *testing.T) {
 ]`)
 
 	check := func(t poll.LogT) poll.Result {
-		_, err := w.Watch(context.Background())
+		_, _, err := w.Watch(context.Background())
 
 		if err == nil {
 			return poll.Error(errors.New("watched did not return an error"))

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -18,9 +18,18 @@ var (
 	ErrBucketMismatch = errors.New("bucket mismatch")
 )
 
+type Cleanup func(ctx context.Context) error
+
+func noopCleanup(ctx context.Context) error {
+	return nil
+}
+
 type Watcher interface {
 	// Watch waits until a blob is dispatched.
-	Watch(ctx context.Context) (*BlobEvent, error)
+	// After the event is successfully processed by the receiver, the returned
+	// Cleanup function must be executed to mark the event as processed.
+	// Implementors must not return a nil function.
+	Watch(ctx context.Context) (*BlobEvent, Cleanup, error)
 
 	// OpenBucket returns the bucket where the blobs can be found.
 	OpenBucket(ctx context.Context) (*blob.Bucket, error)

--- a/main.go
+++ b/main.go
@@ -250,7 +250,7 @@ func main() {
 						case <-done:
 							return nil
 						default:
-							event, err := cur.Watch(ctx)
+							event, clean, err := cur.Watch(ctx)
 							if err != nil {
 								if !errors.Is(err, watcher.ErrWatchTimeout) {
 									logger.Error(err, "Error monitoring watcher interface.", "watcher", cur)
@@ -271,6 +271,8 @@ func main() {
 								}
 								if err := package_.InitProcessingWorkflow(ctx, temporalClient, &req); err != nil {
 									logger.Error(err, "Error initializing processing workflow.")
+								} else {
+									_ = clean(ctx)
 								}
 							}()
 						}


### PR DESCRIPTION
This is a continuation of the work in the previous merge request #494.

In this merge request I am implementing the solution @sevein  suggested [here](https://github.com/artefactual-sdps/enduro/pull/494#discussion_r1221357065).

Instead of ACK, I named it cleanup since that seemed more like what I am doing and provides greater clarity. I also talked with @djjuhasz and a good next step would be implementing a better cleanup of the filesystem function.
Ideally I would have liked to implement this in the alternative way that aligns with what preprocessing is doing but I found that this was a lot simpler for me to grasp. 
