### PR TITLE
Configure lll linter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - gci
 #    - unparam  // https://github.com/golangci/golangci-lint/issues/3711
     - gosec
+    - lll
 
 issues:
   exclude-rules:
@@ -42,3 +43,6 @@ linters-settings:
     exclude-generated: false
     severity: low
     confidence: low
+  lll:
+    line-length: 160
+    tab-width: 4

--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,16 @@ test-race:  ## Run all tests with the race detector.
 ignored:  ## Print a list of packages ignored by tests.
 	$(foreach PACKAGE,$(IGNORED_PACKAGES),@echo $(PACKAGE)$(NEWLINE))
 
+format-line-length: $(GOLANGCI_LINT)  # Fix line-length formatting issues with gofumpt.
+	@golangci-lint cache clean
+	@$(MAKE) lint GOFUMPT_SPLIT_LONG_LINES=on
+	@golangci-lint cache clean
+
 lint: OUT_FORMAT ?= colored-line-number
 lint: LINT_FLAGS ?= --timeout=5m --fix
+lint: export GOFUMPT_SPLIT_LONG_LINES ?= off
 lint: $(GOLANGCI_LINT)  ## Lint the project Go files with golangci-lint.
-	golangci-lint run --out-format $(OUT_FORMAT) $(LINT_FLAGS)
+	@golangci-lint run --out-format $(OUT_FORMAT) $(LINT_FLAGS)
 
 gen-goa: $(GOA)  ## Generate Goa assets.
 	goa gen github.com/artefactual-sdps/enduro/internal/api/design -o internal/api

--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -101,7 +101,8 @@ func main() {
 	// Set up the package service.
 	var pkgsvc package_.Service
 	{
-		pkgsvc = package_.NewService(logger.WithName("package"), enduroDatabase, temporalClient, evsvc, &auth.NoopTokenVerifier{}, nil)
+		pkgsvc = package_.NewService(logger.WithName("package"), enduroDatabase,
+			temporalClient, evsvc, &auth.NoopTokenVerifier{}, nil)
 	}
 
 	// Set up the watcher service.
@@ -131,13 +132,22 @@ func main() {
 			os.Exit(1)
 		}
 
-		w.RegisterActivityWithOptions(activities.NewDownloadActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{Name: activities.DownloadActivityName})
-		w.RegisterActivityWithOptions(activities.NewBundleActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{Name: activities.BundleActivityName})
-		w.RegisterActivityWithOptions(a3m.NewCreateAIPActivity(logger, &cfg.A3m, pkgsvc).Execute, temporalsdk_activity.RegisterOptions{Name: a3m.CreateAIPActivityName})
-		w.RegisterActivityWithOptions(activities.NewCleanUpActivity().Execute, temporalsdk_activity.RegisterOptions{Name: activities.CleanUpActivityName})
+		w.RegisterActivityWithOptions(activities.NewDownloadActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{
+			Name: activities.DownloadActivityName,
+		})
+		w.RegisterActivityWithOptions(activities.NewBundleActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{
+			Name: activities.BundleActivityName,
+		})
+		w.RegisterActivityWithOptions(a3m.NewCreateAIPActivity(logger, &cfg.A3m, pkgsvc).Execute, temporalsdk_activity.RegisterOptions{
+			Name: a3m.CreateAIPActivityName,
+		})
+		w.RegisterActivityWithOptions(activities.NewCleanUpActivity().Execute, temporalsdk_activity.RegisterOptions{
+			Name: activities.CleanUpActivityName,
+		})
 
 		httpClient := &http.Client{Timeout: time.Second}
-		storageHttpClient := goahttpstorage.NewClient("http", cfg.Storage.EnduroAddress, httpClient, goahttp.RequestEncoder, goahttp.ResponseDecoder, false)
+		storageHttpClient := goahttpstorage.NewClient("http", cfg.Storage.EnduroAddress,
+			httpClient, goahttp.RequestEncoder, goahttp.ResponseDecoder, false)
 		storageClient := goastorage.NewClient(
 			storageHttpClient.Submit(),
 			storageHttpClient.Update(),
@@ -151,11 +161,21 @@ func main() {
 			storageHttpClient.ShowLocation(),
 			storageHttpClient.LocationPackages(),
 		)
-		w.RegisterActivityWithOptions(activities.NewUploadActivity(storageClient).Execute, temporalsdk_activity.RegisterOptions{Name: activities.UploadActivityName})
+		w.RegisterActivityWithOptions(activities.NewUploadActivity(storageClient).Execute, temporalsdk_activity.RegisterOptions{
+			Name: activities.UploadActivityName,
+		})
 
-		w.RegisterActivityWithOptions(activities.NewMoveToPermanentStorageActivity(storageClient).Execute, temporalsdk_activity.RegisterOptions{Name: activities.MoveToPermanentStorageActivityName})
-		w.RegisterActivityWithOptions(activities.NewPollMoveToPermanentStorageActivity(storageClient).Execute, temporalsdk_activity.RegisterOptions{Name: activities.PollMoveToPermanentStorageActivityName})
-		w.RegisterActivityWithOptions(activities.NewRejectPackageActivity(storageClient).Execute, temporalsdk_activity.RegisterOptions{Name: activities.RejectPackageActivityName})
+		w.RegisterActivityWithOptions(activities.NewMoveToPermanentStorageActivity(
+			storageClient).Execute, temporalsdk_activity.RegisterOptions{
+			Name: activities.MoveToPermanentStorageActivityName,
+		})
+		w.RegisterActivityWithOptions(activities.NewPollMoveToPermanentStorageActivity(
+			storageClient).Execute, temporalsdk_activity.RegisterOptions{
+			Name: activities.PollMoveToPermanentStorageActivityName,
+		})
+		w.RegisterActivityWithOptions(activities.NewRejectPackageActivity(storageClient).Execute, temporalsdk_activity.RegisterOptions{
+			Name: activities.RejectPackageActivityName,
+		})
 
 		g.Add(
 			func() error {

--- a/internal/a3m/a3m.go
+++ b/internal/a3m/a3m.go
@@ -114,7 +114,9 @@ func (a *CreateAIPActivity) Execute(ctx context.Context, opts *CreateAIPActivity
 				result.UUID = submitResp.Id
 
 				for {
-					readResp, err := c.TransferClient.Read(ctx, &a3m_transferservice.ReadRequest{Id: result.UUID})
+					readResp, err := c.TransferClient.Read(ctx, &a3m_transferservice.ReadRequest{
+						Id: result.UUID,
+					})
 					if err != nil {
 						return err
 					}
@@ -128,7 +130,8 @@ func (a *CreateAIPActivity) Execute(ctx context.Context, opts *CreateAIPActivity
 						return err
 					}
 
-					if readResp.Status == a3m_transferservice.PackageStatus_PACKAGE_STATUS_FAILED || readResp.Status == a3m_transferservice.PackageStatus_PACKAGE_STATUS_REJECTED {
+					if readResp.Status == a3m_transferservice.PackageStatus_PACKAGE_STATUS_FAILED ||
+						readResp.Status == a3m_transferservice.PackageStatus_PACKAGE_STATUS_REJECTED {
 						return errors.New("package failed or rejected")
 					}
 

--- a/internal/api/design/upload.go
+++ b/internal/api/design/upload.go
@@ -22,7 +22,8 @@ var _ = Service("upload", func() {
 		})
 
 		Error("invalid_media_type", ErrorResult, "Error returned when the Content-Type header does not define a multipart request.")
-		Error("invalid_multipart_request", ErrorResult, "Error returned when the request body is not a valid multipart content.")
+		Error("invalid_multipart_request", ErrorResult,
+			"Error returned when the request body is not a valid multipart content.")
 		Error("internal_error", ErrorResult, "Fault while processing upload.")
 
 		HTTP(func() {

--- a/internal/api/origin.go
+++ b/internal/api/origin.go
@@ -21,7 +21,8 @@ func sameOriginChecker(logger logr.Logger) func(r *http.Request) bool {
 		}
 		eq := equalASCIIFold(u.Host, r.Host)
 		if !eq {
-			logger.V(1).Info("WebSocket client rejected (origin and host not equal)", "origin-host", u.Host, "request-host", r.Host)
+			logger.V(1).Info("WebSocket client rejected (origin and host not equal)",
+				"origin-host", u.Host, "request-host", r.Host)
 		}
 		return eq
 	}

--- a/internal/bagit/bagit_test.go
+++ b/internal/bagit/bagit_test.go
@@ -10,8 +10,12 @@ import (
 
 func TestBagit(t *testing.T) {
 	assert.NilError(t, bagit.Complete("./tests/test-bagged-transfer"))
-	assert.ErrorContains(t, bagit.Complete("./tests/test-bagged-transfer-with-invalid-oxum"), "Payload-Oxum validation failed. Expected 1 files and 7 bytes but found 2 files and 7 bytes")
-	assert.ErrorContains(t, bagit.Complete("./tests/test-bagged-transfer-with-missing-manifest"), "Bag validation failed: tests/test-bagged-transfer-with-missing-manifest/manifest-sha256.txt does not exist")
-	assert.ErrorContains(t, bagit.Complete("./tests/test-bagged-transfer-with-unexpected-files"), "Bag validation failed: data/dos.txt exists on filesystem but is not in the manifest")
-	assert.ErrorContains(t, bagit.Complete("./tests/test-bagged-transfer-with-invalid-checksums"), "Bag validation failed: data/adios.txt sha256 validation failed")
+	assert.ErrorContains(t, bagit.Complete("./tests/test-bagged-transfer-with-invalid-oxum"),
+		"Payload-Oxum validation failed. Expected 1 files and 7 bytes but found 2 files and 7 bytes")
+	assert.ErrorContains(t, bagit.Complete("./tests/test-bagged-transfer-with-missing-manifest"),
+		"Bag validation failed: tests/test-bagged-transfer-with-missing-manifest/manifest-sha256.txt does not exist")
+	assert.ErrorContains(t, bagit.Complete("./tests/test-bagged-transfer-with-unexpected-files"),
+		"Bag validation failed: data/dos.txt exists on filesystem but is not in the manifest")
+	assert.ErrorContains(t, bagit.Complete("./tests/test-bagged-transfer-with-invalid-checksums"),
+		"Bag validation failed: data/adios.txt sha256 validation failed")
 }

--- a/internal/event/redis_test.go
+++ b/internal/event/redis_test.go
@@ -60,7 +60,17 @@ func TestEventServiceRedisPublish(t *testing.T) {
 
 	select {
 	case ret := <-input:
-		assert.DeepEqual(t, ret.Payload, `{"MonitorPingEvent":{"Message":"hello"},"PackageCreatedEvent":null,"PackageUpdatedEvent":null,"PackageStatusUpdatedEvent":null,"PackageLocationUpdatedEvent":null,"PreservationActionCreatedEvent":null,"PreservationActionUpdatedEvent":null,"PreservationTaskCreatedEvent":null,"PreservationTaskUpdatedEvent":null}`)
+		assert.DeepEqual(t, ret.Payload, "{"+
+			`"MonitorPingEvent":{"Message":"hello"},`+
+			`"PackageCreatedEvent":null,`+
+			`"PackageUpdatedEvent":null,`+
+			`"PackageStatusUpdatedEvent":null,`+
+			`"PackageLocationUpdatedEvent":null,`+
+			`"PreservationActionCreatedEvent":null,`+
+			`"PreservationActionUpdatedEvent":null,`+
+			`"PreservationTaskCreatedEvent":null,`+
+			`"PreservationTaskUpdatedEvent":null`+
+			"}")
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout!")
 	}

--- a/internal/package_/goa.go
+++ b/internal/package_/goa.go
@@ -116,7 +116,19 @@ func (w *goaWrapper) Monitor(ctx context.Context, payload *goapackage.MonitorPay
 
 // List all stored packages. It implements goapackage.Service.
 func (w *goaWrapper) List(ctx context.Context, payload *goapackage.ListPayload) (*goapackage.ListResult, error) {
-	query := "SELECT id, name, workflow_id, run_id, aip_id, location_id, status, CONVERT_TZ(created_at, @@session.time_zone, '+00:00') AS created_at, CONVERT_TZ(started_at, @@session.time_zone, '+00:00') AS started_at, CONVERT_TZ(completed_at, @@session.time_zone, '+00:00') AS completed_at FROM package"
+	query := `
+SELECT id,
+	name,
+	workflow_id,
+	run_id,
+	aip_id,
+	location_id,
+	status,
+	CONVERT_TZ(created_at, @@session.time_zone, '+00:00') AS created_at,
+	CONVERT_TZ(started_at, @@session.time_zone, '+00:00') AS started_at,
+	CONVERT_TZ(completed_at, @@session.time_zone, '+00:00') AS completed_at
+FROM PACKAGE
+`
 	args := []interface{}{}
 
 	// We extract one extra item so we can tell the next cursor.

--- a/internal/storage/activities/copy.go
+++ b/internal/storage/activities/copy.go
@@ -15,7 +15,9 @@ func NewCopyToPermanentLocationActivity(storagesvc storage.Service) *CopyToPerma
 	return &CopyToPermanentLocationActivity{storagesvc: storagesvc}
 }
 
-func (a *CopyToPermanentLocationActivity) Execute(ctx context.Context, params *storage.CopyToPermanentLocationActivityParams) error {
+func (a *CopyToPermanentLocationActivity) Execute(ctx context.Context,
+	params *storage.CopyToPermanentLocationActivityParams,
+) error {
 	p, err := a.storagesvc.ReadPackage(ctx, params.AIPID)
 	if err != nil {
 		return err

--- a/internal/storage/download.go
+++ b/internal/storage/download.go
@@ -51,7 +51,8 @@ func Download(svc Service, mux goahttp.Muxer, dec func(r *http.Request) goahttp.
 
 		rw.Header().Add("Content-Type", reader.ContentType())
 		rw.Header().Add("Content-Length", strconv.FormatInt(reader.Size(), 10))
-		rw.Header().Add("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+		rw.Header().Add("Content-Disposition",
+			fmt.Sprintf("attachment; filename=\"%s\"", filename))
 
 		// Copy reader contents into the response.
 		_, err = io.Copy(rw, reader)

--- a/internal/storage/persistence/ent/client/client.go
+++ b/internal/storage/persistence/ent/client/client.go
@@ -135,7 +135,9 @@ func pkgAsGoa(ctx context.Context, pkg *db.Pkg) *goastorage.Package {
 	return p
 }
 
-func (c *Client) CreateLocation(ctx context.Context, location *goastorage.Location, config *types.LocationConfig) (*goastorage.Location, error) {
+func (c *Client) CreateLocation(ctx context.Context, location *goastorage.Location,
+	config *types.LocationConfig,
+) (*goastorage.Location, error) {
 	q := c.c.Location.Create()
 
 	q.SetName(location.Name)

--- a/internal/storage/persistence/ent/client/client_test.go
+++ b/internal/storage/persistence/ent/client/client_test.go
@@ -135,7 +135,8 @@ func TestReadPackage(t *testing.T) {
 			SetStatus(types.StatusStored).
 			SaveX(context.Background())
 
-		pkg, err := c.ReadPackage(context.Background(), uuid.MustParse("488c64cc-d89b-4916-9131-c94152dfb12e"))
+		pkg, err := c.ReadPackage(context.Background(),
+			uuid.MustParse("488c64cc-d89b-4916-9131-c94152dfb12e"))
 		assert.NilError(t, err)
 		assert.DeepEqual(t, pkg, &goastorage.Package{
 			Name:       "Package",
@@ -152,7 +153,8 @@ func TestReadPackage(t *testing.T) {
 
 		_, c := setUpClient(t)
 
-		l, err := c.ReadPackage(context.Background(), uuid.MustParse("488c64cc-d89b-4916-9131-c94152dfb12e"))
+		l, err := c.ReadPackage(context.Background(),
+			uuid.MustParse("488c64cc-d89b-4916-9131-c94152dfb12e"))
 		assert.Assert(t, l == nil)
 		assert.ErrorContains(t, err, "package not found")
 	})
@@ -354,7 +356,8 @@ func TestReadLocation(t *testing.T) {
 			}).
 			SaveX(context.Background())
 
-		l, err := c.ReadLocation(context.Background(), uuid.MustParse("7a090f2c-7bd4-471c-8aa1-8c72125decd5"))
+		l, err := c.ReadLocation(context.Background(),
+			uuid.MustParse("7a090f2c-7bd4-471c-8aa1-8c72125decd5"))
 		assert.NilError(t, err)
 		assert.DeepEqual(t, l, &goastorage.Location{
 			Name:        "test_location",
@@ -380,7 +383,8 @@ func TestReadLocation(t *testing.T) {
 
 		_, c := setUpClient(t)
 
-		l, err := c.ReadLocation(context.Background(), uuid.MustParse("7a090f2c-7bd4-471c-8aa1-8c72125decd5"))
+		l, err := c.ReadLocation(context.Background(),
+			uuid.MustParse("7a090f2c-7bd4-471c-8aa1-8c72125decd5"))
 		assert.Assert(t, l == nil)
 		assert.ErrorContains(t, err, "location not found")
 	})

--- a/internal/storage/service.go
+++ b/internal/storage/service.go
@@ -218,7 +218,8 @@ func (s *serviceImpl) MoveStatus(ctx context.Context, payload *goastorage.MoveSt
 		return nil, err
 	}
 
-	resp, err := s.tc.DescribeWorkflowExecution(ctx, fmt.Sprintf("%s-%s", StorageMoveWorkflowName, p.AipID), "")
+	resp, err := s.tc.DescribeWorkflowExecution(ctx,
+		fmt.Sprintf("%s-%s", StorageMoveWorkflowName, p.AipID), "")
 	if err != nil {
 		return nil, goastorage.MakeFailedDependency(errors.New("cannot perform operation"))
 	}
@@ -363,7 +364,9 @@ func (s *serviceImpl) ShowLocation(ctx context.Context, payload *goastorage.Show
 	return s.ReadLocation(ctx, locationID)
 }
 
-func (s *serviceImpl) LocationPackages(ctx context.Context, payload *goastorage.LocationPackagesPayload) (goastorage.PackageCollection, error) {
+func (s *serviceImpl) LocationPackages(ctx context.Context,
+	payload *goastorage.LocationPackagesPayload,
+) (goastorage.PackageCollection, error) {
 	locationID, err := uuid.Parse(payload.UUID)
 	if err != nil {
 		return nil, goastorage.MakeNotValid(errors.New("cannot perform operation"))

--- a/internal/storage/service_test.go
+++ b/internal/storage/service_test.go
@@ -142,7 +142,9 @@ func fakeInternalLocationFactory(t *testing.T, b *blob.Bucket) storage.InternalL
 	}
 }
 
-func fakeInternalLocationFactoryWithContents(t *testing.T, b *blob.Bucket, objectKey, contents string) storage.InternalLocationFactory {
+func fakeInternalLocationFactoryWithContents(t *testing.T, b *blob.Bucket,
+	objectKey, contents string,
+) storage.InternalLocationFactory {
 	t.Helper()
 
 	if b == nil {
@@ -372,7 +374,9 @@ func TestServiceSubmit(t *testing.T) {
 		// Fake internal location, using fileblob because it can generate signed URLs.
 		furl, err := url.Parse("file:///tmp/dir")
 		assert.NilError(t, err)
-		b, err := fileblob.OpenBucket("/tmp", &fileblob.Options{URLSigner: fileblob.NewURLSignerHMAC(furl, []byte("1234"))})
+		b, err := fileblob.OpenBucket("/tmp", &fileblob.Options{
+			URLSigner: fileblob.NewURLSignerHMAC(furl, []byte("1234")),
+		})
 		assert.NilError(t, err)
 
 		AIPID := uuid.MustParse("5ab42bc3-acc2-420b-bbd0-76efdef94828")

--- a/internal/storage/workflow.go
+++ b/internal/storage/workflow.go
@@ -36,7 +36,9 @@ type CopyToPermanentLocationActivityParams struct {
 
 type UploadDoneSignal struct{}
 
-func InitStorageUploadWorkflow(ctx context.Context, tc temporalsdk_client.Client, req *StorageUploadWorkflowRequest) (temporalsdk_client.WorkflowRun, error) {
+func InitStorageUploadWorkflow(ctx context.Context, tc temporalsdk_client.Client,
+	req *StorageUploadWorkflowRequest,
+) (temporalsdk_client.WorkflowRun, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 
@@ -48,7 +50,9 @@ func InitStorageUploadWorkflow(ctx context.Context, tc temporalsdk_client.Client
 	return tc.ExecuteWorkflow(ctx, opts, StorageUploadWorkflowName, req)
 }
 
-func InitStorageMoveWorkflow(ctx context.Context, tc temporalsdk_client.Client, req *StorageMoveWorkflowRequest) (temporalsdk_client.WorkflowRun, error) {
+func InitStorageMoveWorkflow(ctx context.Context, tc temporalsdk_client.Client,
+	req *StorageMoveWorkflowRequest,
+) (temporalsdk_client.WorkflowRun, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 

--- a/internal/storage/workflows/move.go
+++ b/internal/storage/workflows/move.go
@@ -43,10 +43,11 @@ func (w *StorageMoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req stor
 				},
 			},
 		})
-		err := temporalsdk_workflow.ExecuteActivity(activityOpts, storage.CopyToPermanentLocationActivityName, &storage.CopyToPermanentLocationActivityParams{
-			AIPID:      req.AIPID,
-			LocationID: req.LocationID,
-		}).Get(activityOpts, nil)
+		err := temporalsdk_workflow.ExecuteActivity(activityOpts,
+			storage.CopyToPermanentLocationActivityName, &storage.CopyToPermanentLocationActivityParams{
+				AIPID:      req.AIPID,
+				LocationID: req.LocationID,
+			}).Get(activityOpts, nil)
 		if err != nil {
 			return err
 		}
@@ -64,9 +65,10 @@ func (w *StorageMoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req stor
 				MaximumAttempts:    3,
 			},
 		})
-		err := temporalsdk_workflow.ExecuteLocalActivity(activityOpts, storage.DeleteFromLocationLocalActivity, w.storagesvc, &storage.DeleteFromLocationLocalActivityParams{
-			AIPID: req.AIPID,
-		}).Get(activityOpts, nil)
+		err := temporalsdk_workflow.ExecuteLocalActivity(activityOpts,
+			storage.DeleteFromLocationLocalActivity, w.storagesvc, &storage.DeleteFromLocationLocalActivityParams{
+				AIPID: req.AIPID,
+			}).Get(activityOpts, nil)
 		if err != nil {
 			return err
 		}
@@ -83,10 +85,11 @@ func (w *StorageMoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req stor
 				MaximumAttempts:    3,
 			},
 		})
-		err := temporalsdk_workflow.ExecuteLocalActivity(activityOpts, storage.UpdatePackageLocationLocalActivity, w.storagesvc, &storage.UpdatePackageLocationLocalActivityParams{
-			AIPID:      req.AIPID,
-			LocationID: req.LocationID,
-		}).Get(activityOpts, nil)
+		err := temporalsdk_workflow.ExecuteLocalActivity(activityOpts,
+			storage.UpdatePackageLocationLocalActivity, w.storagesvc, &storage.UpdatePackageLocationLocalActivityParams{
+				AIPID:      req.AIPID,
+				LocationID: req.LocationID,
+			}).Get(activityOpts, nil)
 		if err != nil {
 			return err
 		}
@@ -118,5 +121,6 @@ func (w *StorageMoveWorkflow) updatePackageStatus(ctx temporalsdk_workflow.Conte
 		Status: st,
 	}
 
-	return temporalsdk_workflow.ExecuteLocalActivity(activityOpts, storage.UpdatePackageStatusLocalActivity, w.storagesvc, params).Get(activityOpts, nil)
+	return temporalsdk_workflow.ExecuteLocalActivity(activityOpts,
+		storage.UpdatePackageStatusLocalActivity, w.storagesvc, params).Get(activityOpts, nil)
 }

--- a/internal/storage/workflows/move_test.go
+++ b/internal/storage/workflows/move_test.go
@@ -32,7 +32,9 @@ func TestStorageMoveWorkflow(t *testing.T) {
 	storagesvc.EXPECT().UpdatePackageStatus(gomock.Any(), aipID, types.StatusStored)
 
 	// Worker activities
-	env.RegisterActivityWithOptions(activities.NewCopyToPermanentLocationActivity(storagesvc).Execute, temporalsdk_activity.RegisterOptions{Name: storage.CopyToPermanentLocationActivityName})
+	env.RegisterActivityWithOptions(activities.NewCopyToPermanentLocationActivity(storagesvc).Execute, temporalsdk_activity.RegisterOptions{
+		Name: storage.CopyToPermanentLocationActivityName,
+	})
 	env.OnActivity(storage.CopyToPermanentLocationActivityName, mock.Anything, mock.Anything).Return(nil)
 
 	env.ExecuteWorkflow(

--- a/internal/upload/service.go
+++ b/internal/upload/service.go
@@ -40,7 +40,9 @@ var _ Service = (*serviceImpl)(nil)
 
 var ErrInvalidToken error = goastorage.Unauthorized("invalid token")
 
-func NewService(logger logr.Logger, config Config, uploadMaxSize int, tokenVerifier auth.TokenVerifier) (s *serviceImpl, err error) {
+func NewService(logger logr.Logger, config Config, uploadMaxSize int,
+	tokenVerifier auth.TokenVerifier,
+) (s *serviceImpl, err error) {
 	s = &serviceImpl{
 		logger:        logger,
 		config:        config,
@@ -128,7 +130,8 @@ func (s *serviceImpl) Upload(ctx context.Context, payload *goaupload.UploadPaylo
 		return nil
 	}
 	if err != nil {
-		return goaupload.MakeInvalidMultipartRequest(errors.New("invalid multipart request"))
+		return goaupload.MakeInvalidMultipartRequest(
+			errors.New("invalid multipart request"))
 	}
 
 	w, err := s.bucket.NewWriter(ctx, part.FileName(), &blob.WriterOptions{})

--- a/internal/upload/service_test.go
+++ b/internal/upload/service_test.go
@@ -95,7 +95,9 @@ func TestServiceUpload(t *testing.T) {
 		ctx := context.Background()
 		r := io.NopCloser(strings.NewReader(multipartBody))
 
-		err := svc.Upload(ctx, &goaupload.UploadPayload{ContentType: "multipart/form-data; boundary=foobar"}, r)
+		err := svc.Upload(ctx, &goaupload.UploadPayload{
+			ContentType: "multipart/form-data; boundary=foobar",
+		}, r)
 		assert.NilError(t, err)
 
 		b := svc.Bucket()
@@ -132,7 +134,9 @@ func TestServiceUpload(t *testing.T) {
 		ctx := context.Background()
 		r := io.NopCloser(strings.NewReader(multipartBody))
 
-		err := svc.Upload(ctx, &goaupload.UploadPayload{ContentType: "multipart/form-data; boundary=foobar"}, r)
+		err := svc.Upload(ctx, &goaupload.UploadPayload{
+			ContentType: "multipart/form-data; boundary=foobar",
+		}, r)
 		assert.Equal(t, err.(*goa.ServiceError).Name, "invalid_multipart_request")
 		assert.ErrorContains(t, err, "invalid multipart request")
 	})

--- a/internal/workflow/activities/bundle.go
+++ b/internal/workflow/activities/bundle.go
@@ -145,7 +145,9 @@ func (a *BundleActivity) SingleFile(ctx context.Context, transferDir, key, tempF
 }
 
 // Bundle a transfer with the contents found in the archive.
-func (a *BundleActivity) Bundle(ctx context.Context, unar archiver.Unarchiver, transferDir, key, tempFile string, stripTopLevelDir bool) (string, string, error) {
+func (a *BundleActivity) Bundle(ctx context.Context, unar archiver.Unarchiver,
+	transferDir, key, tempFile string, stripTopLevelDir bool,
+) (string, string, error) {
 	// Create a new directory for our transfer with the name randomized.
 	const prefix = "enduro"
 	tempDir, err := os.MkdirTemp(transferDir, prefix)

--- a/internal/workflow/activities/download.go
+++ b/internal/workflow/activities/download.go
@@ -30,7 +30,8 @@ func tempFile(pattern string) (*os.File, error) {
 func (a *DownloadActivity) Execute(ctx context.Context, watcherName, key string) (string, error) {
 	file, err := tempFile("blob-*")
 	if err != nil {
-		return "", temporal.NonRetryableError(fmt.Errorf("error creating temporary file in processing directory: %v", err))
+		return "", temporal.NonRetryableError(fmt.Errorf(
+			"error creating temporary file in processing directory: %v", err))
 	}
 	defer file.Close() //#nosec G307 -- Errors returned by Close() here do not require specific handling.
 

--- a/internal/workflow/activities/upload_test.go
+++ b/internal/workflow/activities/upload_test.go
@@ -18,18 +18,23 @@ import (
 
 // StorageService implements goastorage.Service.
 type StorageService struct {
-	OAuth2AuthHandler       func(ctx context.Context, token string, scheme *security.OAuth2Scheme) (ctx2 context.Context, err error)
-	SubmitHandler           func(ctx context.Context, req *goastorage.SubmitPayload) (res *goastorage.SubmitResult, err error)
-	UpdateHandler           func(ctx context.Context, req *goastorage.UpdatePayload) (err error)
-	DownloadHandler         func(ctx context.Context, req *goastorage.DownloadPayload) (res []byte, err error)
-	LocationsHandler        func(ctx context.Context, req *goastorage.LocationsPayload) (res goastorage.LocationCollection, err error)
-	MoveHandler             func(ctx context.Context, req *goastorage.MovePayload) (err error)
-	MoveStatusHandler       func(ctx context.Context, req *goastorage.MoveStatusPayload) (res *goastorage.MoveStatusResult, err error)
-	RejectHandler           func(ctx context.Context, req *goastorage.RejectPayload) (err error)
-	ShowHandler             func(ctx context.Context, req *goastorage.ShowPayload) (res *goastorage.Package, err error)
-	AddLocationHandler      func(ctx context.Context, req *goastorage.AddLocationPayload) (res *goastorage.AddLocationResult, err error)
+	OAuth2AuthHandler func(ctx context.Context, token string, scheme *security.OAuth2Scheme) (ctx2 context.Context, err error)
+	SubmitHandler     func(ctx context.Context, req *goastorage.SubmitPayload) (
+		res *goastorage.SubmitResult, err error)
+	UpdateHandler    func(ctx context.Context, req *goastorage.UpdatePayload) (err error)
+	DownloadHandler  func(ctx context.Context, req *goastorage.DownloadPayload) (res []byte, err error)
+	LocationsHandler func(ctx context.Context, req *goastorage.LocationsPayload) (
+		res goastorage.LocationCollection, err error)
+	MoveHandler       func(ctx context.Context, req *goastorage.MovePayload) (err error)
+	MoveStatusHandler func(ctx context.Context, req *goastorage.MoveStatusPayload) (
+		res *goastorage.MoveStatusResult, err error)
+	RejectHandler      func(ctx context.Context, req *goastorage.RejectPayload) (err error)
+	ShowHandler        func(ctx context.Context, req *goastorage.ShowPayload) (res *goastorage.Package, err error)
+	AddLocationHandler func(ctx context.Context, req *goastorage.AddLocationPayload) (
+		res *goastorage.AddLocationResult, err error)
 	ShowLocationHandler     func(ctx context.Context, req *goastorage.ShowLocationPayload) (res *goastorage.Location, err error)
-	LocationPackagesHandler func(ctx context.Context, req *goastorage.LocationPackagesPayload) (res goastorage.PackageCollection, err error)
+	LocationPackagesHandler func(ctx context.Context, req *goastorage.LocationPackagesPayload) (
+		res goastorage.PackageCollection, err error)
 }
 
 func (s StorageService) OAuth2Auth(ctx context.Context, token string, scheme *security.OAuth2Scheme) (ctx2 context.Context, err error) {
@@ -76,7 +81,9 @@ func (s StorageService) ShowLocation(ctx context.Context, req *goastorage.ShowLo
 	return s.ShowLocationHandler(ctx, req)
 }
 
-func (s StorageService) LocationPackages(ctx context.Context, req *goastorage.LocationPackagesPayload) (res goastorage.PackageCollection, err error) {
+func (s StorageService) LocationPackages(ctx context.Context,
+	req *goastorage.LocationPackagesPayload,
+) (res goastorage.PackageCollection, err error) {
 	return s.LocationPackagesHandler(ctx, req)
 }
 
@@ -96,15 +103,21 @@ func TestUploadActivity(t *testing.T) {
 		defer minioTestServer.Close()
 
 		fakeStorageService := StorageService{}
-		fakeStorageService.OAuth2AuthHandler = func(ctx context.Context, token string, scheme *security.OAuth2Scheme) (ctx2 context.Context, err error) {
+		fakeStorageService.OAuth2AuthHandler = func(ctx context.Context, token string,
+			scheme *security.OAuth2Scheme,
+		) (ctx2 context.Context, err error) {
 			return ctx, nil
 		}
-		fakeStorageService.SubmitHandler = func(ctx context.Context, req *goastorage.SubmitPayload) (res *goastorage.SubmitResult, err error) {
+		fakeStorageService.SubmitHandler = func(ctx context.Context,
+			req *goastorage.SubmitPayload,
+		) (res *goastorage.SubmitResult, err error) {
 			return &goastorage.SubmitResult{
 				URL: minioTestServer.URL + "/aips/foobar.7z",
 			}, nil
 		}
-		fakeStorageService.UpdateHandler = func(ctx context.Context, req *goastorage.UpdatePayload) (err error) {
+		fakeStorageService.UpdateHandler = func(ctx context.Context,
+			req *goastorage.UpdatePayload,
+		) (err error) {
 			return nil
 		}
 
@@ -141,15 +154,21 @@ func TestUploadActivity(t *testing.T) {
 		defer minioTestServer.Close()
 
 		fakeStorageService := StorageService{}
-		fakeStorageService.OAuth2AuthHandler = func(ctx context.Context, token string, scheme *security.OAuth2Scheme) (ctx2 context.Context, err error) {
+		fakeStorageService.OAuth2AuthHandler = func(ctx context.Context, token string,
+			scheme *security.OAuth2Scheme,
+		) (ctx2 context.Context, err error) {
 			return ctx, nil
 		}
-		fakeStorageService.SubmitHandler = func(ctx context.Context, req *goastorage.SubmitPayload) (res *goastorage.SubmitResult, err error) {
+		fakeStorageService.SubmitHandler = func(ctx context.Context,
+			req *goastorage.SubmitPayload,
+		) (res *goastorage.SubmitResult, err error) {
 			return &goastorage.SubmitResult{
 				URL: minioTestServer.URL + "/aips/foobar.7z",
 			}, nil
 		}
-		fakeStorageService.UpdateHandler = func(ctx context.Context, req *goastorage.UpdatePayload) (err error) {
+		fakeStorageService.UpdateHandler = func(ctx context.Context,
+			req *goastorage.UpdatePayload,
+		) (err error) {
 			return errors.New("update failed")
 		}
 

--- a/internal/workflow/local_activities.go
+++ b/internal/workflow/local_activities.go
@@ -86,7 +86,9 @@ type saveLocationMovePreservationActionLocalActivityParams struct {
 	CompletedAt time.Time
 }
 
-func saveLocationMovePreservationActionLocalActivity(ctx context.Context, pkgsvc package_.Service, params *saveLocationMovePreservationActionLocalActivityParams) error {
+func saveLocationMovePreservationActionLocalActivity(ctx context.Context, pkgsvc package_.Service,
+	params *saveLocationMovePreservationActionLocalActivityParams,
+) error {
 	paID, err := createPreservationActionLocalActivity(ctx, pkgsvc, &createPreservationActionLocalActivityParams{
 		WorkflowID:  params.WorkflowID,
 		Type:        params.Type,
@@ -128,7 +130,9 @@ type createPreservationActionLocalActivityParams struct {
 	PackageID   uint
 }
 
-func createPreservationActionLocalActivity(ctx context.Context, pkgsvc package_.Service, params *createPreservationActionLocalActivityParams) (uint, error) {
+func createPreservationActionLocalActivity(ctx context.Context, pkgsvc package_.Service,
+	params *createPreservationActionLocalActivityParams,
+) (uint, error) {
 	pa := package_.PreservationAction{
 		WorkflowID: params.WorkflowID,
 		Type:       params.Type,
@@ -155,7 +159,9 @@ type completePreservationActionLocalActivityParams struct {
 	CompletedAt          time.Time
 }
 
-func completePreservationActionLocalActivity(ctx context.Context, pkgsvc package_.Service, params *completePreservationActionLocalActivityParams) error {
+func completePreservationActionLocalActivity(ctx context.Context, pkgsvc package_.Service,
+	params *completePreservationActionLocalActivityParams,
+) error {
 	return pkgsvc.CompletePreservationAction(ctx, params.PreservationActionID, params.Status, params.CompletedAt)
 }
 
@@ -169,7 +175,9 @@ type createPreservationTaskLocalActivityParams struct {
 	PreservationActionID uint
 }
 
-func createPreservationTaskLocalActivity(ctx context.Context, pkgsvc package_.Service, params *createPreservationTaskLocalActivityParams) (uint, error) {
+func createPreservationTaskLocalActivity(ctx context.Context, pkgsvc package_.Service,
+	params *createPreservationTaskLocalActivityParams,
+) (uint, error) {
 	pt := package_.PreservationTask{
 		TaskID:               params.TaskID,
 		Name:                 params.Name,
@@ -194,6 +202,8 @@ type completePreservationTaskLocalActivityParams struct {
 	Note        *string
 }
 
-func completePreservationTaskLocalActivity(ctx context.Context, pkgsvc package_.Service, params *completePreservationTaskLocalActivityParams) error {
+func completePreservationTaskLocalActivity(ctx context.Context, pkgsvc package_.Service,
+	params *completePreservationTaskLocalActivityParams,
+) error {
 	return pkgsvc.CompletePreservationTask(ctx, params.ID, params.Status, params.CompletedAt, params.Note)
 }

--- a/internal/workflow/move.go
+++ b/internal/workflow/move.go
@@ -30,7 +30,8 @@ func (w *MoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req *package_.M
 	// Set package to in progress status.
 	{
 		ctx := withLocalActivityOpts(ctx)
-		err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setStatusLocalActivity, w.pkgsvc, req.ID, package_.StatusInProgress).Get(ctx, nil)
+		err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setStatusLocalActivity,
+			w.pkgsvc, req.ID, package_.StatusInProgress).Get(ctx, nil)
 		if err != nil {
 			return err
 		}
@@ -39,10 +40,11 @@ func (w *MoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req *package_.M
 	// Move package to permanent storage
 	{
 		activityOpts := withActivityOptsForRequest(ctx)
-		err := temporalsdk_workflow.ExecuteActivity(activityOpts, activities.MoveToPermanentStorageActivityName, &activities.MoveToPermanentStorageActivityParams{
-			AIPID:      req.AIPID,
-			LocationID: req.LocationID,
-		}).Get(activityOpts, nil)
+		err := temporalsdk_workflow.ExecuteActivity(activityOpts,
+			activities.MoveToPermanentStorageActivityName, &activities.MoveToPermanentStorageActivityParams{
+				AIPID:      req.AIPID,
+				LocationID: req.LocationID,
+			}).Get(activityOpts, nil)
 		if err != nil {
 			status = package_.ActionStatusError
 		}
@@ -52,9 +54,10 @@ func (w *MoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req *package_.M
 	{
 		if status != package_.ActionStatusError {
 			activityOpts := withActivityOptsForLongLivedRequest(ctx)
-			err := temporalsdk_workflow.ExecuteActivity(activityOpts, activities.PollMoveToPermanentStorageActivityName, &activities.PollMoveToPermanentStorageActivityParams{
-				AIPID: req.AIPID,
-			}).Get(activityOpts, nil)
+			err := temporalsdk_workflow.ExecuteActivity(activityOpts,
+				activities.PollMoveToPermanentStorageActivityName, &activities.PollMoveToPermanentStorageActivityParams{
+					AIPID: req.AIPID,
+				}).Get(activityOpts, nil)
 			if err != nil {
 				status = package_.ActionStatusError
 			}
@@ -66,7 +69,8 @@ func (w *MoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req *package_.M
 	// Set package to done status.
 	{
 		ctx := withLocalActivityOpts(ctx)
-		err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setStatusLocalActivity, w.pkgsvc, req.ID, package_.StatusDone).Get(ctx, nil)
+		err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setStatusLocalActivity,
+			w.pkgsvc, req.ID, package_.StatusDone).Get(ctx, nil)
 		if err != nil {
 			return err
 		}
@@ -76,7 +80,8 @@ func (w *MoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req *package_.M
 	{
 		if status != package_.ActionStatusError {
 			ctx := withLocalActivityOpts(ctx)
-			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setLocationIDLocalActivity, w.pkgsvc, req.ID, req.LocationID).Get(ctx, nil)
+			err := temporalsdk_workflow.ExecuteLocalActivity(ctx,
+				setLocationIDLocalActivity, w.pkgsvc, req.ID, req.LocationID).Get(ctx, nil)
 			if err != nil {
 				return err
 			}
@@ -87,15 +92,16 @@ func (w *MoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req *package_.M
 	{
 		ctx := withLocalActivityOpts(ctx)
 		completedAt := temporalsdk_workflow.Now(ctx).UTC()
-		err := temporalsdk_workflow.ExecuteLocalActivity(ctx, saveLocationMovePreservationActionLocalActivity, w.pkgsvc, &saveLocationMovePreservationActionLocalActivityParams{
-			PackageID:   req.ID,
-			LocationID:  req.LocationID,
-			WorkflowID:  temporalsdk_workflow.GetInfo(ctx).WorkflowExecution.ID,
-			Type:        package_.ActionTypeMovePackage,
-			Status:      status,
-			StartedAt:   startedAt,
-			CompletedAt: completedAt,
-		}).Get(ctx, nil)
+		err := temporalsdk_workflow.ExecuteLocalActivity(ctx,
+			saveLocationMovePreservationActionLocalActivity, w.pkgsvc, &saveLocationMovePreservationActionLocalActivityParams{
+				PackageID:   req.ID,
+				LocationID:  req.LocationID,
+				WorkflowID:  temporalsdk_workflow.GetInfo(ctx).WorkflowExecution.ID,
+				Type:        package_.ActionTypeMovePackage,
+				Status:      status,
+				StartedAt:   startedAt,
+				CompletedAt: completedAt,
+			}).Get(ctx, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -39,13 +39,27 @@ func (s *ProcessingWorkflowTestSuite) SetupTest() {
 	pkgsvc := packagefake.NewMockService(ctrl)
 	wsvc := watcherfake.NewMockService(ctrl)
 
-	s.env.RegisterActivityWithOptions(activities.NewDownloadActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{Name: activities.DownloadActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewBundleActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{Name: activities.BundleActivityName})
-	s.env.RegisterActivityWithOptions(a3m.NewCreateAIPActivity(logger, &a3m.Config{}, pkgsvc).Execute, temporalsdk_activity.RegisterOptions{Name: a3m.CreateAIPActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewUploadActivity(nil).Execute, temporalsdk_activity.RegisterOptions{Name: activities.UploadActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewMoveToPermanentStorageActivity(nil).Execute, temporalsdk_activity.RegisterOptions{Name: activities.MoveToPermanentStorageActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewPollMoveToPermanentStorageActivity(nil).Execute, temporalsdk_activity.RegisterOptions{Name: activities.PollMoveToPermanentStorageActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewRejectPackageActivity(nil).Execute, temporalsdk_activity.RegisterOptions{Name: activities.RejectPackageActivityName})
+	s.env.RegisterActivityWithOptions(activities.NewDownloadActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{
+		Name: activities.DownloadActivityName,
+	})
+	s.env.RegisterActivityWithOptions(activities.NewBundleActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{
+		Name: activities.BundleActivityName,
+	})
+	s.env.RegisterActivityWithOptions(a3m.NewCreateAIPActivity(logger, &a3m.Config{}, pkgsvc).Execute, temporalsdk_activity.RegisterOptions{
+		Name: a3m.CreateAIPActivityName,
+	})
+	s.env.RegisterActivityWithOptions(activities.NewUploadActivity(nil).Execute, temporalsdk_activity.RegisterOptions{
+		Name: activities.UploadActivityName,
+	})
+	s.env.RegisterActivityWithOptions(activities.NewMoveToPermanentStorageActivity(nil).Execute, temporalsdk_activity.RegisterOptions{
+		Name: activities.MoveToPermanentStorageActivityName,
+	})
+	s.env.RegisterActivityWithOptions(activities.NewPollMoveToPermanentStorageActivity(nil).Execute, temporalsdk_activity.RegisterOptions{
+		Name: activities.PollMoveToPermanentStorageActivityName,
+	})
+	s.env.RegisterActivityWithOptions(activities.NewRejectPackageActivity(nil).Execute, temporalsdk_activity.RegisterOptions{
+		Name: activities.RejectPackageActivityName,
+	})
 
 	s.workflow = NewProcessingWorkflow(logger, pkgsvc, wsvc)
 }
@@ -77,16 +91,20 @@ func (s *ProcessingWorkflowTestSuite) TestPackageConfirmation() {
 
 	// Activity mocks/assertions sequence
 	s.env.OnActivity(createPackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(pkgID, nil)
-	s.env.OnActivity(setStatusInProgressLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	s.env.OnActivity(setStatusInProgressLocalActivity, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything).Return(nil)
 	s.env.OnActivity(createPreservationActionLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(uint(0), nil)
 	s.env.OnActivity(activities.DownloadActivityName, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-	s.env.OnActivity(activities.BundleActivityName, mock.Anything, mock.Anything).Return(&activities.BundleActivityResult{FullPath: "/tmp/aip", FullPathBeforeStrip: "/tmp/aip"}, nil)
+	s.env.OnActivity(activities.BundleActivityName, mock.Anything, mock.Anything).Return(&activities.BundleActivityResult{
+		FullPath: "/tmp/aip", FullPathBeforeStrip: "/tmp/aip",
+	}, nil)
 	s.env.OnActivity(a3m.CreateAIPActivityName, mock.Anything, mock.Anything).Return(nil, nil)
 	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	s.env.OnActivity(createPreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(uint(0), nil)
 	s.env.OnActivity(activities.UploadActivityName, mock.Anything, mock.Anything).Return(nil)
 	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything).Return(nil)
 	s.env.OnActivity(completePreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	s.env.OnActivity(activities.MoveToPermanentStorageActivityName, mock.Anything, mock.Anything).Return(nil)
 	s.env.OnActivity(activities.PollMoveToPermanentStorageActivityName, mock.Anything, mock.Anything).Return(nil)
@@ -128,21 +146,35 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 		pkgsvc,
 		&createPackageLocalActivityParams{Key: key, Status: package_.StatusQueued},
 	).Return(pkgID, nil).Once()
-	s.env.OnActivity(setStatusInProgressLocalActivity, ctx, pkgsvc, pkgID, mock.AnythingOfType("time.Time")).Return(nil).Once()
-	s.env.OnActivity(createPreservationActionLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.createPreservationActionLocalActivityParams")).Return(uint(0), nil).Once()
+	s.env.OnActivity(setStatusInProgressLocalActivity, ctx, pkgsvc, pkgID,
+		mock.AnythingOfType("time.Time")).Return(nil).Once()
+	s.env.OnActivity(createPreservationActionLocalActivity, ctx, pkgsvc,
+		mock.AnythingOfType("*workflow.createPreservationActionLocalActivityParams")).Return(uint(0), nil).Once()
 	s.env.OnActivity(activities.DownloadActivityName, sessionCtx, watcherName, key).Return("", nil).Once()
-	s.env.OnActivity(activities.BundleActivityName, sessionCtx, mock.AnythingOfType("*activities.BundleActivityParams")).Return(&activities.BundleActivityResult{FullPath: "/tmp/aip", FullPathBeforeStrip: "/tmp/aip"}, nil).Once()
-	s.env.OnActivity(a3m.CreateAIPActivityName, sessionCtx, mock.AnythingOfType("*a3m.CreateAIPActivityParams")).Return(nil, nil).Once()
-	s.env.OnActivity(updatePackageLocalActivity, ctx, logger, pkgsvc, mock.AnythingOfType("*workflow.updatePackageLocalActivityParams")).Return(nil).Times(2)
-	s.env.OnActivity(createPreservationTaskLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.createPreservationTaskLocalActivityParams")).Return(uint(0), nil).Once()
-	s.env.OnActivity(activities.UploadActivityName, sessionCtx, mock.AnythingOfType("*activities.UploadActivityParams")).Return(nil).Once()
+	s.env.OnActivity(activities.BundleActivityName, sessionCtx,
+		mock.AnythingOfType("*activities.BundleActivityParams")).Return(&activities.BundleActivityResult{
+		FullPath: "/tmp/aip", FullPathBeforeStrip: "/tmp/aip",
+	}, nil).Once()
+	s.env.OnActivity(a3m.CreateAIPActivityName, sessionCtx,
+		mock.AnythingOfType("*a3m.CreateAIPActivityParams")).Return(nil, nil).Once()
+	s.env.OnActivity(updatePackageLocalActivity, ctx, logger, pkgsvc,
+		mock.AnythingOfType("*workflow.updatePackageLocalActivityParams")).Return(nil).Times(2)
+	s.env.OnActivity(createPreservationTaskLocalActivity, ctx, pkgsvc,
+		mock.AnythingOfType("*workflow.createPreservationTaskLocalActivityParams")).Return(uint(0), nil).Once()
+	s.env.OnActivity(activities.UploadActivityName, sessionCtx,
+		mock.AnythingOfType("*activities.UploadActivityParams")).Return(nil).Once()
 	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Never()
-	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Never()
-	s.env.OnActivity(completePreservationTaskLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.completePreservationTaskLocalActivityParams")).Return(nil).Once()
-	s.env.OnActivity(activities.MoveToPermanentStorageActivityName, sessionCtx, mock.AnythingOfType("*activities.MoveToPermanentStorageActivityParams")).Return(nil).Once()
-	s.env.OnActivity(activities.PollMoveToPermanentStorageActivityName, sessionCtx, mock.AnythingOfType("*activities.PollMoveToPermanentStorageActivityParams")).Return(nil).Once()
+	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything).Return(nil).Never()
+	s.env.OnActivity(completePreservationTaskLocalActivity, ctx, pkgsvc,
+		mock.AnythingOfType("*workflow.completePreservationTaskLocalActivityParams")).Return(nil).Once()
+	s.env.OnActivity(activities.MoveToPermanentStorageActivityName, sessionCtx,
+		mock.AnythingOfType("*activities.MoveToPermanentStorageActivityParams")).Return(nil).Once()
+	s.env.OnActivity(activities.PollMoveToPermanentStorageActivityName, sessionCtx,
+		mock.AnythingOfType("*activities.PollMoveToPermanentStorageActivityParams")).Return(nil).Once()
 	s.env.OnActivity(setLocationIDLocalActivity, ctx, pkgsvc, pkgID, locationID).Return(nil).Once()
-	s.env.OnActivity(completePreservationActionLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.completePreservationActionLocalActivityParams")).Return(nil).Once()
+	s.env.OnActivity(completePreservationActionLocalActivity, ctx, pkgsvc,
+		mock.AnythingOfType("*workflow.completePreservationActionLocalActivityParams")).Return(nil).Once()
 	// TODO: CleanUpActivityName
 	// TODO: DeleteOriginalActivityName
 
@@ -178,18 +210,23 @@ func (s *ProcessingWorkflowTestSuite) TestPackageRejection() {
 
 	// Activity mocks/assertions sequence
 	s.env.OnActivity(createPackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(pkgID, nil)
-	s.env.OnActivity(setStatusInProgressLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	s.env.OnActivity(setStatusInProgressLocalActivity, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything).Return(nil)
 	s.env.OnActivity(createPreservationActionLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(uint(0), nil)
 	s.env.OnActivity(activities.DownloadActivityName, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-	s.env.OnActivity(activities.BundleActivityName, mock.Anything, mock.Anything).Return(&activities.BundleActivityResult{FullPath: "/tmp/aip", FullPathBeforeStrip: "/tmp/aip"}, nil)
+	s.env.OnActivity(activities.BundleActivityName, mock.Anything, mock.Anything).Return(&activities.BundleActivityResult{
+		FullPath: "/tmp/aip", FullPathBeforeStrip: "/tmp/aip",
+	}, nil)
 	s.env.OnActivity(a3m.CreateAIPActivityName, mock.Anything, mock.Anything).Return(nil, nil)
 	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	s.env.OnActivity(completePreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	s.env.OnActivity(activities.UploadActivityName, mock.Anything, mock.Anything).Return(nil)
 	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything).Return(nil)
 	s.env.OnActivity(createPreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(uint(0), nil)
-	s.env.OnActivity(activities.RejectPackageActivityName, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	s.env.OnActivity(activities.RejectPackageActivityName, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything).Return(nil)
 	// TODO: CleanUpActivityName
 	// TODO: DeleteOriginalActivityName
 	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/internal/workflow/timer_test.go
+++ b/internal/workflow/timer_test.go
@@ -66,5 +66,6 @@ func TestTimer(t *testing.T) {
 
 	// Workflow should end with an error: deadline exceeded.
 	assert.Equal(t, env.IsWorkflowCompleted(), true)
-	assert.ErrorContains(t, env.GetWorkflowError(), fmt.Sprintf("deadline exceeded: %s", deadline))
+	assert.ErrorContains(t, env.GetWorkflowError(),
+		fmt.Sprintf("deadline exceeded: %s", deadline))
 }


### PR DESCRIPTION
This is an attempt to enforce a line-length rule using the [lll linter](https://golangci-lint.run/usage/linters/#lll) configured in the [.golangci.yml file](https://github.com/artefactual-sdps/enduro/blob/dev/line-length-formatting/.golangci.yml). This should raise line-length issues whether you're using `make lint` or golangci-lint is your lint tool in VSCode.

I've also added a `make format-line-length` helper based on gofumpt's experimental ability to split long lines, since lll doesn't support auto-fix. Something I've noticed is that the split is improvable in some cases, please review the changes. It does not split long strings but lll would complain anyways so I had to update a bunch of them manually.

Here's one of the examples where I think we could do better and may prefer to do it manually:

```go
		w.RegisterActivityWithOptions(activities.NewMoveToPermanentStorageActivity(
			storageClient).Execute, temporalsdk_activity.RegisterOptions{
			Name: activities.MoveToPermanentStorageActivityName,
		})
```

For more, see https://gist.github.com/sevein/f4949622f4ba14a6d3b2fc1632202339.