### PR TITLE
Set http server write timeout

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -62,7 +62,7 @@ func HTTPServer(
 	storageEndpoints := storage.NewEndpoints(storagesvc)
 	storageErrorHandler := errorHandler(logger, "Storage error.")
 	storageServer := storagesvr.New(storageEndpoints, mux, dec, enc, storageErrorHandler, nil)
-	storageServer.Download = intstorage.Download(storagesvc, mux, dec)
+	storageServer.Download = writeTimeout(intstorage.Download(storagesvc, mux, dec), 0)
 	storagesvr.Mount(mux, storageServer)
 
 	// Upload service.
@@ -86,12 +86,10 @@ func HTTPServer(
 	}
 
 	return &http.Server{
-		Addr:        config.Listen,
-		Handler:     handler,
-		ReadTimeout: time.Second * 5,
-		// WriteTimeout is set to 0 because we have streaming endpoints.
-		// https://github.com/golang/go/issues/16100#issuecomment-285573480
-		WriteTimeout: 0,
+		Addr:         config.Listen,
+		Handler:      handler,
+		ReadTimeout:  time.Second * 5,
+		WriteTimeout: time.Second * 5,
 		IdleTimeout:  time.Second * 120,
 	}
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 )
@@ -42,4 +43,18 @@ func versionHeaderMiddleware(version string) func(http.Handler) http.Handler {
 			h.ServeHTTP(w, r)
 		})
 	}
+}
+
+// writeTimeout sets the write deadline for writing the response. A zero value
+// means no timeout.
+func writeTimeout(h http.Handler, timeout time.Duration) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rc := http.NewResponseController(w)
+		var deadline time.Time
+		if timeout != 0 {
+			deadline = time.Now().Add(timeout)
+		}
+		_ = rc.SetWriteDeadline(deadline)
+		h.ServeHTTP(w, r)
+	})
 }

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/funcr"
 	"gotest.tools/v3/assert"
@@ -42,4 +44,33 @@ func TestVersionHeaderMiddleware(t *testing.T) {
 
 	assert.Equal(t, resp.Header.Get("X-Enduro-Version"), "v1.2.3")
 	assert.Equal(t, continued, true)
+}
+
+func TestWriteTimeout(t *testing.T) {
+	t.Parallel()
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(time.Microsecond * 100)
+		w.Write([]byte("Hi there!"))
+	})
+
+	t.Run("Sets a write timeout", func(t *testing.T) {
+		ts := httptest.NewServer(writeTimeout(h, time.Microsecond))
+		defer ts.Close()
+
+		_, err := ts.Client().Get(ts.URL)
+		assert.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("Sets an unlimited write timeout", func(t *testing.T) {
+		ts := httptest.NewServer(writeTimeout(h, 0))
+		defer ts.Close()
+
+		resp, err := ts.Client().Get(ts.URL)
+		assert.NilError(t, err)
+
+		blob, err := io.ReadAll(resp.Body)
+		assert.NilError(t, err)
+		assert.Equal(t, string(blob), "Hi there!")
+	})
 }


### PR DESCRIPTION
Fixes issue #592

- Set an http server write timeout to 5 seconds for most responses
- Add an unlimited write timeout for storage server downloads