### PR TITLE
Fix Temporal UI SSO login with Dex

### DIFF
--- a/hack/kube/base/temporal-ui.yaml
+++ b/hack/kube/base/temporal-ui.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: temporal-ui
-          image: temporalio/ui:2.16.1
+          image: temporalio/ui:2.16.2
           env:
             - name: TEMPORAL_ADDRESS
               value: temporal.enduro-sdps:7233
@@ -48,6 +48,8 @@ spec:
                 secretKeyRef:
                   name: temporal-ui-secret
                   key: auth-client-secret
+            - name: TEMPORAL_AUTH_SCOPES
+              value: openid,profile,email
           ports:
             - containerPort: 8080
           resources: {}

--- a/hack/kube/base/temporal.yaml
+++ b/hack/kube/base/temporal.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: temporal
-          image: temporalio/auto-setup:1.20.3
+          image: temporalio/auto-setup:1.20.4
           env:
             - name: DB
               value: mysql

--- a/hack/kube/overlays/dev/dex-secret.yaml
+++ b/hack/kube/overlays/dev/dex-secret.yaml
@@ -18,7 +18,7 @@ stringData:
           mode: "false"
     web:
       http: 0.0.0.0:5556
-      allowedOrigins: ["http://localhost:3000"]
+      allowedOrigins: ["http://localhost:3000", "http://localhost:7440"]
     expiry:
       idTokens: 1h
     oauth2:


### PR DESCRIPTION
- Explicitly add OIDC scopes (openid,profile,email) to Temporal UI OIDC request
- Add temporal URI to Dex's list of allowed origins
- Bump Temporal UI base image from 2.16.1 -> 2.16.2
- Bump temporalio auto-setup base image from 1.20.3 -> 1.20.4