### PR TITLE
Add RBAC rules and basic service account

### DIFF
--- a/hack/kube/base/enduro.yaml
+++ b/hack/kube/base/enduro.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: enduro
     spec:
+      serviceAccountName: enduro-serviceaccount
       initContainers:
         - name: check-temporal
           image: busybox
@@ -21,7 +22,8 @@ spec:
             [
               "sh",
               "-c",
-              "until echo STATUS | nc -w 2 temporal.enduro-sdps 7233; do echo waiting for temporal to start; sleep 1; done;",
+              "until echo STATUS | nc -w 2 temporal.enduro-sdps 7233; do echo
+              waiting for temporal to start; sleep 1; done;",
             ]
       containers:
         - name: enduro

--- a/hack/kube/base/kustomization.yaml
+++ b/hack/kube/base/kustomization.yaml
@@ -13,5 +13,8 @@ resources:
   - mysql.yaml
   - namespace.yaml
   - redis.yaml
+  - role.yaml
+  - role-binding.yaml
+  - serviceaccount.yaml
   - temporal-ui.yaml
   - temporal.yaml

--- a/hack/kube/base/role-binding.yaml
+++ b/hack/kube/base/role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-access-role-binding
+  namespace: enduro-sdps
+subjects:
+  - kind: ServiceAccount
+    name: enduro-serviceaccount
+roleRef:
+  kind: Role
+  name: pod-access-role
+  apiGroup: rbac.authorization.k8s.io

--- a/hack/kube/base/role.yaml
+++ b/hack/kube/base/role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: enduro-sdps
+  name: pod-access-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]

--- a/hack/kube/base/serviceaccount.yaml
+++ b/hack/kube/base/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: enduro-serviceaccount


### PR DESCRIPTION
Adds a named service account and restricts access to retrieving pod info only.