### PR TITLE
Add RBAC rules and basic service account

### DIFF
--- a/hack/kube/base/dex.yaml
+++ b/hack/kube/base/dex.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: dex
     spec:
+      serviceAccountName: sdps
       containers:
         - name: dex
           image: ghcr.io/dexidp/dex:v2.30.0

--- a/hack/kube/base/enduro-a3m.yaml
+++ b/hack/kube/base/enduro-a3m.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: enduro-a3m
     spec:
+      serviceAccountName: sdps
       securityContext:
         fsGroup: 1000
       initContainers:

--- a/hack/kube/base/enduro-dashboard.yaml
+++ b/hack/kube/base/enduro-dashboard.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: enduro-dashboard
     spec:
+      serviceAccountName: sdps
       containers:
         - name: enduro-dashboard
           image: ghcr.io/artefactual-sdps/enduro-dashboard:main

--- a/hack/kube/base/enduro-internal.yaml
+++ b/hack/kube/base/enduro-internal.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: enduro-internal
     spec:
+      serviceAccountName: sdps
       initContainers:
         - name: check-temporal
           image: busybox

--- a/hack/kube/base/enduro.yaml
+++ b/hack/kube/base/enduro.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: enduro
     spec:
+      serviceAccountName: sdps
       initContainers:
         - name: check-temporal
           image: busybox

--- a/hack/kube/base/kustomization.yaml
+++ b/hack/kube/base/kustomization.yaml
@@ -13,5 +13,8 @@ resources:
   - mysql.yaml
   - namespace.yaml
   - redis.yaml
+  - role.yaml
+  - role-binding.yaml
+  - service-account.yaml
   - temporal-ui.yaml
   - temporal.yaml

--- a/hack/kube/base/minio-setup-buckets-job.yaml
+++ b/hack/kube/base/minio-setup-buckets-job.yaml
@@ -6,6 +6,7 @@ spec:
   backoffLimit: 100
   template:
     spec:
+      serviceAccountName: sdps
       restartPolicy: OnFailure
       containers:
         - name: setup-buckets

--- a/hack/kube/base/minio.yaml
+++ b/hack/kube/base/minio.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: minio
     spec:
+      serviceAccountName: sdps
       initContainers:
         - name: check-redis
           image: busybox

--- a/hack/kube/base/mysql-create-locations-job.yaml
+++ b/hack/kube/base/mysql-create-locations-job.yaml
@@ -6,6 +6,7 @@ spec:
   backoffLimit: 100
   template:
     spec:
+      serviceAccountName: sdps
       restartPolicy: OnFailure
       containers:
         - name: create-locations

--- a/hack/kube/base/mysql.yaml
+++ b/hack/kube/base/mysql.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: mysql
     spec:
+      serviceAccountName: sdps
       containers:
         - name: mysql
           image: mysql:8.0

--- a/hack/kube/base/redis.yaml
+++ b/hack/kube/base/redis.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: redis
     spec:
+      serviceAccountName: sdps
       containers:
         - name: redis
           image: redis:7

--- a/hack/kube/base/role-binding.yaml
+++ b/hack/kube/base/role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: secure-sdps
+  namespace: enduro-sdps
+subjects:
+  - kind: ServiceAccount
+    name: sdps
+roleRef:
+  kind: Role
+  name: secure
+  apiGroup: rbac.authorization.k8s.io

--- a/hack/kube/base/role.yaml
+++ b/hack/kube/base/role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: enduro-sdps
+  name: secure
+rules:
+  - apiGroups: [""]
+    resources: [""]
+    verbs: [""]

--- a/hack/kube/base/service-account.yaml
+++ b/hack/kube/base/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sdps
+automountServiceAccountToken: false

--- a/hack/kube/base/temporal-ui.yaml
+++ b/hack/kube/base/temporal-ui.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: temporal-ui
     spec:
+      serviceAccountName: sdps
       containers:
         - name: temporal-ui
           image: temporalio/ui:2.16.2

--- a/hack/kube/base/temporal.yaml
+++ b/hack/kube/base/temporal.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: temporal
     spec:
+      serviceAccountName: sdps
       containers:
         - name: temporal
           image: temporalio/auto-setup:1.20.4


### PR DESCRIPTION
Adds a named service account and restricts access to retrieving pod info only.