### PR TITLE
Add `make gosec` target to run a security scan

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -25,4 +25,11 @@ jobs:
     - name: Install Gosec Security Scanner
       run: go install github.com/securego/gosec/v2/cmd/gosec@latest
     - name: Run Gosec Security Scanner
-      run: gosec -exclude-dir=dashboard -exclude-dir=hack/ -exclude-dir=internal/api/gen -exclude-dir=internal/persistence/ent/db -exclude-dir=internal/persistence/ent/db ./...
+      run: >
+        gosec
+        -exclude-dir=dashboard
+        -exclude-dir=hack/
+        -exclude-dir=internal/api/gen
+        -exclude-dir=internal/persistence/ent/db
+        -exclude-dir=internal/storage/persistence/ent/db
+        ./...

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,17 @@ gen-ent: $(ENT)
 		--feature sql/versioned-migration \
 		--target=./internal/storage/persistence/ent/db
 
+gosec: # @HELP Run gosec security scanner
+gosec:
+	go install github.com/securego/gosec/v2/cmd/gosec@latest
+	gosec \
+		-exclude-dir=dashboard \
+		-exclude-dir=hack \
+		-exclude-dir=internal/api/gen \
+		-exclude-dir=internal/persistence/ent/db \
+		-exclude-dir=internal/storage/persistence/ent/db \
+		./...
+
 tilt-trigger-internal: # @HELP Restart enduro-internal and wait until ready.
 tilt-trigger-internal:
 	@tilt trigger enduro-internal


### PR DESCRIPTION
- Add gosec target to Makefile
- Fix duplicate -exclude-dir in gosec Github action