### PR TITLE
Make preservation system configurable

### DIFF
--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -127,7 +127,7 @@ func main() {
 			MaxConcurrentSessionExecutionSize:  1000,
 			MaxConcurrentActivityExecutionSize: 1,
 		}
-		w := temporalsdk_worker.New(temporalClient, cfg.A3m.TaskQueue, workerOpts)
+		w := temporalsdk_worker.New(temporalClient, temporal.A3mWorkerTaskQueue, workerOpts)
 		if err != nil {
 			logger.Error(err, "Error creating Temporal worker.")
 			os.Exit(1)

--- a/enduro.toml
+++ b/enduro.toml
@@ -3,7 +3,6 @@
 debug = true
 debugListen = "127.0.0.1:9001"
 verbosity = 2
-useArchivematica = false
 
 [temporal]
 namespace = "default"
@@ -63,6 +62,10 @@ key = "minio"
 secret = "minio123"
 region = "us-west-1"
 bucket = "aips"
+
+# Change the taskqueue setting to your prefered preservation system, by default it is a3m.
+[preservation]
+taskqueue = "a3m"
 
 [a3m]
 address = "127.0.0.1:7000"

--- a/internal/a3m/config.go
+++ b/internal/a3m/config.go
@@ -3,10 +3,9 @@ package a3m
 import transferservice "buf.build/gen/go/artefactual/a3m/protocolbuffers/go/a3m/api/transferservice/v1beta1"
 
 type Config struct {
-	Name      string
-	ShareDir  string
-	TaskQueue string
-	Address   string
+	Name     string
+	ShareDir string
+	Address  string
 	Processing
 }
 

--- a/internal/am/poll_transfer.go
+++ b/internal/am/poll_transfer.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/artefactual-sdps/enduro/internal/temporal"
 	"github.com/go-logr/logr"
 	"go.artefactual.dev/amclient"
 	temporalsdk_activity "go.temporal.io/sdk/activity"
+
+	"github.com/artefactual-sdps/enduro/internal/temporal"
 )
 
 const PollTransferActivityName = "poll-transfer-activity"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/api"
 	"github.com/artefactual-sdps/enduro/internal/db"
 	"github.com/artefactual-sdps/enduro/internal/event"
+	"github.com/artefactual-sdps/enduro/internal/pres"
 	"github.com/artefactual-sdps/enduro/internal/storage"
 	"github.com/artefactual-sdps/enduro/internal/temporal"
 	"github.com/artefactual-sdps/enduro/internal/upload"
@@ -23,19 +24,19 @@ type ConfigurationValidator interface {
 }
 
 type Configuration struct {
-	Verbosity        int
-	Debug            bool
-	DebugListen      string
-	UseArchivematica bool
-	API              api.Config
-	Event            event.Config
-	Database         db.Config
-	Temporal         temporal.Config
-	Watcher          watcher.Config
-	Storage          storage.Config
-	Upload           upload.Config
-	A3m              a3m.Config
-	Am               am.Config
+	Verbosity    int
+	Debug        bool
+	DebugListen  string
+	API          api.Config
+	Event        event.Config
+	Database     db.Config
+	Temporal     temporal.Config
+	Watcher      watcher.Config
+	Storage      storage.Config
+	Upload       upload.Config
+	A3m          a3m.Config
+	Am           am.Config
+	Preservation pres.Config
 }
 
 func (c Configuration) Validate() error {
@@ -63,7 +64,7 @@ func Read(config *Configuration, configFile string) (found bool, configFileUsed 
 	v.AddConfigPath("/etc")
 	v.SetConfigName("enduro")
 	v.SetDefault("api.processing", a3m.ProcessingDefault)
-	v.SetDefault("a3m.taskqueue", temporal.A3mWorkerTaskQueue)
+	v.SetDefault("preservation.taskqueue", temporal.A3mWorkerTaskQueue)
 	v.SetDefault("temporal.taskqueue", temporal.GlobalTaskQueue)
 	v.SetDefault("debugListen", "127.0.0.1:9001")
 	v.SetDefault("api.listen", "127.0.0.1:9000")

--- a/internal/pres/config.go
+++ b/internal/pres/config.go
@@ -1,0 +1,10 @@
+package pres
+
+type Config struct {
+	// TaskQueue sets the Temporal task queue to use for the processing workflow
+	// (e.g. ` temporal.A3mWorkerTaskQueue`, ` temporal.AMWorkerTaskQueue`).
+	// The task queue determines which processing worker will run the processing
+	// workflow - a3m or Archivematica, and is used to branch the processing
+	// workflow logic.
+	TaskQueue string
+}

--- a/main.go
+++ b/main.go
@@ -271,7 +271,7 @@ func main() {
 									AutoApproveAIP:             autoApproveAIP,
 									DefaultPermanentLocationID: &defaultPermanentLocationID,
 									TaskQueue:                  cfg.Temporal.TaskQueue,
-									A3mTaskQueue:               cfg.A3m.TaskQueue,
+									A3mTaskQueue:               cfg.Preservation.TaskQueue,
 								}
 								if err := package_.InitProcessingWorkflow(ctx, temporalClient, &req); err != nil {
 									logger.Error(err, "Error initializing processing workflow.")
@@ -299,7 +299,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		w.RegisterWorkflowWithOptions(workflow.NewProcessingWorkflow(logger, pkgsvc, wsvc, cfg.UseArchivematica).Execute, temporalsdk_workflow.RegisterOptions{Name: package_.ProcessingWorkflowName})
+		w.RegisterWorkflowWithOptions(workflow.NewProcessingWorkflow(logger, pkgsvc, wsvc, cfg.Preservation.TaskQueue).Execute, temporalsdk_workflow.RegisterOptions{Name: package_.ProcessingWorkflowName})
 		w.RegisterActivityWithOptions(activities.NewDeleteOriginalActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalActivityName})
 		w.RegisterActivityWithOptions(activities.NewDisposeOriginalActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{Name: activities.DisposeOriginalActivityName})
 


### PR DESCRIPTION
This is change exists to allow for the taskqueue to determine whether or not to use archivematica or not. This could be done in a different way than the current option which is to set the preservation system variable to the a3m taskqueue. I think that simply using the taskqueue variable was a little awkward since it was tide to the a3m configuration struct. I think perhaps changing the a3m struct to a more general purpose preservation system struct or creating a new preservation struct may be more useful.  