### PR TITLE
Add more access details to devel page

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,9 +1,10 @@
 {
   "default": true,
   "MD010": {
-    "code_blocks": false
+    "code_blocks": false,
   },
   "MD013": {
-    "code_blocks": false
+    "code_blocks": false,
+    "tables": false,
   },
 }

--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -94,11 +94,13 @@ documentation to know more about it.
 
 ## Access
 
-There are four services available from the host:
+There are three services available from the host:
 
-- Enduro dashboard: <http://localhost:8080>
-- Minio console: <http://localhost:7460> (username: minio, password: minio123)
-- Temporal UI: <http://localhost:7440>
+| Service         | URL                         | Username            | Password   |
+|-----------------|-----------------------------|---------------------|------------|
+| Dashboard       | <http://localhost:8080>     | `admin@example.com` | `admin`    |
+| MinIO console   | <http://localhost:7460>     | `minio`             | `minio123` |
+| Temporal UI     | <http://localhost:7440>     | `admin@example.com` | `admin`    |
 
 ## Live updates
 


### PR DESCRIPTION
Édith told me she couldn't find the credentials to access the Dashboard at some point. It made me realize that we were not sharing the details clearly in the documentation. 

We could probably clarify further and mention the OIDC integration, Dex and the LDAP directory (hack/kube/overlays/dev/ldap.yaml), but this is a good start.

Preview:
![image](https://github.com/artefactual-sdps/enduro/assets/606459/b1d3d5e3-df23-4a2c-9710-bc85756bb4ba)
