### PR TITLE
Set default value for storage taskqueue

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,14 +25,15 @@ type Configuration struct {
 	Verbosity   int
 	Debug       bool
 	DebugListen string
-	API         api.Config
-	Event       event.Config
-	Database    db.Config
-	Temporal    temporal.Config
-	Watcher     watcher.Config
-	Storage     storage.Config
-	Upload      upload.Config
-	A3m         a3m.Config
+
+	A3m      a3m.Config
+	API      api.Config
+	Database db.Config
+	Event    event.Config
+	Storage  storage.Config
+	Temporal temporal.Config
+	Upload   upload.Config
+	Watcher  watcher.Config
 }
 
 func (c Configuration) Validate() error {
@@ -59,8 +60,9 @@ func Read(config *Configuration, configFile string) (found bool, configFileUsed 
 	v.AddConfigPath("$HOME/.config/")
 	v.AddConfigPath("/etc")
 	v.SetConfigName("enduro")
-	v.SetDefault("api.processing", a3m.ProcessingDefault)
+	v.SetDefault("a3m.processing", a3m.ProcessingDefault)
 	v.SetDefault("a3m.taskqueue", temporal.A3mWorkerTaskQueue)
+	v.SetDefault("storage.taskqueue", temporal.GlobalTaskQueue)
 	v.SetDefault("temporal.taskqueue", temporal.GlobalTaskQueue)
 	v.SetDefault("debugListen", "127.0.0.1:9001")
 	v.SetDefault("api.listen", "127.0.0.1:9000")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,7 +6,9 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"
 
+	"github.com/artefactual-sdps/enduro/internal/a3m"
 	"github.com/artefactual-sdps/enduro/internal/config"
+	"github.com/artefactual-sdps/enduro/internal/temporal"
 )
 
 const testConfig = `# Config
@@ -18,20 +20,44 @@ address = "host:port"
 `
 
 func TestConfig(t *testing.T) {
-	tmpDir := fs.NewDir(
-		t, "",
-		fs.WithFile(
-			"enduro-config.toml",
-			testConfig,
-		),
-	)
-	configFile := tmpDir.Join("enduro-config.toml")
+	t.Run("Loads toml configs", func(t *testing.T) {
+		tmpDir := fs.NewDir(
+			t, "",
+			fs.WithFile(
+				"enduro-config.toml",
+				testConfig,
+			),
+		)
+		configFile := tmpDir.Join("enduro-config.toml")
 
-	var c config.Configuration
-	found, configFileUsed, err := config.Read(&c, configFile)
+		var c config.Configuration
+		found, configFileUsed, err := config.Read(&c, configFile)
 
-	assert.NilError(t, err)
-	assert.Equal(t, found, true)
-	assert.Equal(t, configFileUsed, configFile)
-	assert.Equal(t, c.Temporal.Address, "host:port")
+		assert.NilError(t, err)
+		assert.Equal(t, found, true)
+		assert.Equal(t, configFileUsed, configFile)
+		assert.Equal(t, c.Temporal.Address, "host:port")
+	})
+
+	t.Run("Sets default configs", func(t *testing.T) {
+		var c config.Configuration
+		found, configFileUsed, err := config.Read(&c, "")
+
+		assert.NilError(t, err)
+		assert.Equal(t, found, false)
+		assert.Equal(t, configFileUsed, "")
+
+		// Zero value defaults.
+		assert.Equal(t, c.Verbosity, 0)
+		assert.Equal(t, c.Debug, false)
+		assert.Equal(t, c.Database.DSN, "")
+
+		// Valued defaults.
+		assert.Equal(t, c.DebugListen, "127.0.0.1:9001")
+		assert.Equal(t, c.A3m.Processing, a3m.ProcessingDefault)
+		assert.Equal(t, c.A3m.TaskQueue, temporal.A3mWorkerTaskQueue)
+		assert.Equal(t, c.API.Listen, "127.0.0.1:9000")
+		assert.Equal(t, c.Storage.TaskQueue, temporal.GlobalTaskQueue)
+		assert.Equal(t, c.Temporal.TaskQueue, temporal.GlobalTaskQueue)
+	})
 }

--- a/internal/storage/service.go
+++ b/internal/storage/service.go
@@ -122,6 +122,7 @@ func (s *serviceImpl) Submit(ctx context.Context, payload *goastorage.SubmitPayl
 		TaskQueue: s.config.TaskQueue,
 	})
 	if err != nil {
+		s.logger.Error(err, "storage service: InitStorageUploadWorkflow")
 		return nil, goastorage.MakeNotAvailable(errors.New("cannot perform operation"))
 	}
 


### PR DESCRIPTION
Fixes issue #759.

- Also fix SetDefault key for setting a3m.processing defaults
- Add config test to confirm default values are set
- Reorder embedded configs alphabetically
- Log detailed error when storage.InitStorageUploadWorkflow fails