### PR TITLE
Add a rand parameter to the storage service

### DIFF
--- a/internal/storage/service_test.go
+++ b/internal/storage/service_test.go
@@ -91,6 +91,7 @@ func setUpService(t *testing.T, attrs *setUpAttrs) storage.Service {
 		*params.persistence,
 		*params.temporalClient,
 		params.tokenVerifier,
+		staticRand{},
 	)
 	assert.NilError(t, err)
 
@@ -128,6 +129,7 @@ func TestNewService(t *testing.T) {
 			nil,
 			nil,
 			&auth.OIDCTokenVerifier{},
+			nil,
 		)
 
 		assert.ErrorContains(t, err, "invalid configuration")
@@ -1434,9 +1436,6 @@ func TestServiceAddLocation(t *testing.T) {
 	})
 
 	t.Run("Returns not_valid if cannot persist location", func(t *testing.T) {
-		t.Cleanup(func() { uuid.SetRand(nil) })
-
-		uuid.SetRand(staticRand{})
 		locationID := uuid.MustParse("00010203-0405-4607-8809-0a0b0c0d0e0f")
 		attrs := &setUpAttrs{}
 		svc := setUpService(t, attrs)
@@ -1480,9 +1479,6 @@ func TestServiceAddLocation(t *testing.T) {
 	})
 
 	t.Run("Returns result with location UUID", func(t *testing.T) {
-		t.Cleanup(func() { uuid.SetRand(nil) })
-
-		uuid.SetRand(staticRand{})
 		locationID := uuid.MustParse("00010203-0405-4607-8809-0a0b0c0d0e0f")
 		attrs := &setUpAttrs{}
 		svc := setUpService(t, attrs)
@@ -1525,9 +1521,6 @@ func TestServiceAddLocation(t *testing.T) {
 	})
 
 	t.Run("Returns location with URL config", func(t *testing.T) {
-		t.Cleanup(func() { uuid.SetRand(nil) })
-
-		uuid.SetRand(staticRand{})
 		locationID := uuid.MustParse("00010203-0405-4607-8809-0a0b0c0d0e0f")
 		attrs := &setUpAttrs{}
 		svc := setUpService(t, attrs)

--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func main() {
 	// Set up the storage service.
 	var storagesvc storage.Service
 	{
-		storagesvc, err = storage.NewService(logger.WithName("storage"), cfg.Storage, storagePersistence, temporalClient, tokenVerifier)
+		storagesvc, err = storage.NewService(logger.WithName("storage"), cfg.Storage, storagePersistence, temporalClient, tokenVerifier, rand.Reader)
 		if err != nil {
 			logger.Error(err, "Error setting up storage service.")
 			os.Exit(1)


### PR DESCRIPTION
This modification enables the use of a custom random number generator in our
tests. It eliminates the need to alter global state in the
`github.com/google/uuid` package, which is unsafe during parallel testing.

We continue to utilize `crypto/rand`, but now it must be explicitly passed to
the service. We maintain the assumption that the operation will succeed, and
will trigger a panic otherwise, to mirror the behavior of `uuid.New`. We have
implemented middleware to manage panics, thus mitigating concerns in the
unlikely event of such failures.

Fixes https://github.com/artefactual-sdps/enduro/issues/760.
