### PR TITLE
Fix shfmt job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,5 +27,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Read Go version
+        id: go_version
+        run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
+      - name: Install Go (${{ steps.go_version.outputs.go_version }})
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ steps.go_version.outputs.go_version }}
       - name: Run shfmt
         run: make shfmt


### PR DESCRIPTION
We need to install the version of Go in .go-version since the one provided by the CI runner is too old.