### PR TITLE
Add start transfer activity to AM workflow

### DIFF
--- a/enduro.toml
+++ b/enduro.toml
@@ -88,6 +88,12 @@ PerformPolicyChecksOnPreservationDerivatives = true
 AipCompressionLevel                          = 1
 AipCompressionAlgorithm                      = 6
 
+[am]
+address = ""
+user = "" # Secret: set with env var ENDURO_AM_USER.
+apiKey = "" # Secret: set with env var ENDURO_AM_APIKEY.
+processingConfig = "automated"
+
 [am.sftp]
 host = "" # The Archivematica Storage Service hostname.
 user = ""

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.17.0
 	github.com/stretchr/testify v1.8.4
+	go.artefactual.dev/amclient v0.2.0
 	go.artefactual.dev/tools v0.8.0
 	go.temporal.io/api v1.24.0
 	go.temporal.io/sdk v1.25.1
@@ -98,6 +99,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/wire v0.5.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
+	github.com/gorilla/schema v1.2.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1118,6 +1118,8 @@ github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=
+github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
@@ -1352,6 +1354,8 @@ github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
+go.artefactual.dev/amclient v0.2.0 h1:fO1lUsxaG23EGtbgPBfye5+ytnqg3H7BxAoAaQr0Mqc=
+go.artefactual.dev/amclient v0.2.0/go.mod h1:jAJ98cSJ7QDSgMq/YUkmGpAJ4ssSzbIUN7XpynCa6uA=
 go.artefactual.dev/tools v0.8.0 h1:PYmurlVFIA5hA2p/lX4wq+sHkIhezN8kCpiBDT0NaFA=
 go.artefactual.dev/tools v0.8.0/go.mod h1:tBZMFxz4jkQK5MW+uDROYaAkTGQSG0lJgCVhqDbQ1Dg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/hack/kube/overlays/dev-am/enduro-am.yaml
+++ b/hack/kube/overlays/dev-am/enduro-am.yaml
@@ -61,6 +61,21 @@ spec:
               value: $(MINIO_PASSWORD)
             - name: ENDURO_PRESERVATION_TASKQUEUE
               value: "am"
+            - name: ENDURO_AM_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: enduro-am-secret
+                  key: address
+            - name: ENDURO_AM_USER
+              valueFrom:
+                secretKeyRef:
+                  name: enduro-am-secret
+                  key: user
+            - name: ENDURO_AM_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: enduro-am-secret
+                  key: api_key
             - name: ENDURO_AM_SFTP_HOST
               valueFrom:
                 secretKeyRef:

--- a/internal/am/config.go
+++ b/internal/am/config.go
@@ -3,6 +3,18 @@ package am
 import "github.com/artefactual-sdps/enduro/internal/sftp"
 
 type Config struct {
+	// Archivematica server address.
+	Address string
+
+	// Archivematica API user.
+	User string
+
+	// Archivematica API key.
+	APIKey string
+
+	// Archivematica processing configuration to use (default: "automated").
+	ProcessingConfig string
+
 	// SFTP configuration for uploading transfers to Archivematica.
 	SFTP sftp.Config
 }

--- a/internal/am/errors.go
+++ b/internal/am/errors.go
@@ -1,0 +1,29 @@
+package am
+
+import (
+	"errors"
+	"net/http"
+
+	"go.artefactual.dev/amclient"
+
+	"github.com/artefactual-sdps/enduro/internal/temporal"
+)
+
+// ConvertAMClientError converts an Archivematica API response to a
+// non-retryable temporal ApplicationError if the response is guaranteed not to
+// change in subsequent requests.
+func convertAMClientError(resp *amclient.Response, err error) error {
+	if resp != nil {
+		switch resp.Response.StatusCode {
+		case http.StatusUnauthorized:
+			return temporal.NonRetryableError(errors.New("invalid Archivematica credentials"))
+		case http.StatusForbidden:
+			return temporal.NonRetryableError(errors.New("insufficient Archivematica permissions"))
+		case http.StatusNotFound:
+			return temporal.NonRetryableError(errors.New("Archivematica transfer not found"))
+		}
+	}
+
+	// Retry any client requests that don't return one of the above responses.
+	return err
+}

--- a/internal/am/start_transfer.go
+++ b/internal/am/start_transfer.go
@@ -1,0 +1,59 @@
+package am
+
+import (
+	context "context"
+
+	"github.com/go-logr/logr"
+	"go.artefactual.dev/amclient"
+)
+
+const StartTransferActivityName = "start-transfer-activity"
+
+type StartTransferActivity struct {
+	logger logr.Logger
+	cfg    *Config
+	amps   amclient.PackageService
+}
+
+type StartTransferActivityParams struct {
+	Name string
+	Path string
+}
+
+type StartTransferActivityResult struct {
+	UUID string
+}
+
+func NewStartTransferActivity(logger logr.Logger, cfg *Config, amps amclient.PackageService) *StartTransferActivity {
+	return &StartTransferActivity{
+		logger: logger,
+		cfg:    cfg,
+		amps:   amps,
+	}
+}
+
+// Execute sends a request to the Archivematica API to start a new
+// "auto-approved" transfer. If the request is successful a transfer UUID is
+// returned.  An error response will return a retryable or non-retryable
+// temporal.ApplicationError, depending on the nature of the error.
+func (a *StartTransferActivity) Execute(ctx context.Context, opts *StartTransferActivityParams) (*StartTransferActivityResult, error) {
+	a.logger.Info("Executing StartTransferActivity", "Name", opts.Name, "Path", opts.Path)
+
+	processingConfig := a.cfg.ProcessingConfig
+	if processingConfig == "" {
+		processingConfig = "automated" // Default value.
+	}
+
+	payload, resp, err := a.amps.Create(ctx, &amclient.PackageCreateRequest{
+		Name:             opts.Name,
+		Type:             "zipfile",
+		Path:             opts.Path,
+		ProcessingConfig: processingConfig,
+		AutoApprove:      true,
+	})
+	if err != nil {
+		return nil, convertAMClientError(resp, err)
+	}
+
+	return &StartTransferActivityResult{UUID: payload.ID}, nil
+}

--- a/internal/am/start_transfer_test.go
+++ b/internal/am/start_transfer_test.go
@@ -1,0 +1,126 @@
+package am_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"go.artefactual.dev/amclient"
+	"go.artefactual.dev/amclient/amclienttest"
+	"go.artefactual.dev/tools/mockutil"
+	"go.artefactual.dev/tools/temporal"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/am"
+)
+
+func TestStartTransferActivity(t *testing.T) {
+	transferID := uuid.New().String()
+	opts := am.StartTransferActivityParams{
+		Name: "Testing",
+		Path: "/tmp",
+	}
+
+	amcrDefault := func(m *amclienttest.MockPackageServiceMockRecorder, st http.Response) {
+		m.Create(
+			mockutil.Context(),
+			&amclient.PackageCreateRequest{
+				Name:             opts.Name,
+				Type:             "zipfile",
+				Path:             opts.Path,
+				ProcessingConfig: "automated",
+				AutoApprove:      true,
+			},
+		).Return(
+			&amclient.PackageCreateResponse{ID: transferID},
+			&amclient.Response{Response: &st},
+			&amclient.ErrorResponse{Response: &st},
+		)
+	}
+
+	type test struct {
+		name   string
+		want   am.StartTransferActivityResult
+		amcr   func(*amclienttest.MockPackageServiceMockRecorder, http.Response)
+		st     http.Response
+		errMsg string
+	}
+	for _, tt := range []test{
+		{
+			name: "Returns transfer ID",
+			amcr: func(mpsmr *amclienttest.MockPackageServiceMockRecorder, r http.Response) {
+				mpsmr.Create(
+					mockutil.Context(),
+					&amclient.PackageCreateRequest{
+						Name:             opts.Name,
+						Type:             "zipfile",
+						Path:             opts.Path,
+						ProcessingConfig: "automated",
+						AutoApprove:      true,
+					},
+				).Return(
+					&amclient.PackageCreateResponse{ID: transferID},
+					&amclient.Response{Response: &r},
+					nil,
+				)
+			},
+			want: am.StartTransferActivityResult{UUID: transferID},
+		},
+		{
+			name:   "Returns an invalid credentials error",
+			amcr:   amcrDefault,
+			st:     http.Response{StatusCode: http.StatusUnauthorized},
+			errMsg: "invalid Archivematica credentials",
+		},
+		{
+			name:   "Returns an insufficient permissions error",
+			amcr:   amcrDefault,
+			st:     http.Response{StatusCode: http.StatusForbidden},
+			errMsg: "insufficient Archivematica permissions",
+		},
+		{
+			name:   "Returns a not found error",
+			amcr:   amcrDefault,
+			st:     http.Response{StatusCode: http.StatusNotFound},
+			errMsg: "Archivematica transfer not found",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			ctrl := gomock.NewController(t)
+			amps := amclienttest.NewMockPackageService(ctrl)
+
+			if tt.amcr != nil {
+				tt.amcr(amps.EXPECT(), tt.st)
+			}
+
+			env.RegisterActivityWithOptions(
+				am.NewStartTransferActivity(logr.Discard(), &am.Config{}, amps).Execute,
+				temporalsdk_activity.RegisterOptions{
+					Name: am.StartTransferActivityName,
+				},
+			)
+
+			future, err := env.ExecuteActivity(am.StartTransferActivityName, opts)
+			if tt.errMsg != "" {
+				assert.ErrorContains(t, err, tt.errMsg)
+				assert.Assert(t, temporal.NonRetryableError(err))
+
+				return
+			}
+
+			var r am.StartTransferActivityResult
+			err = future.Get(&r)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, r, am.StartTransferActivityResult{UUID: transferID})
+		})
+	}
+}

--- a/internal/am/upload_transfer.go
+++ b/internal/am/upload_transfer.go
@@ -32,19 +32,17 @@ func NewUploadTransferActivity(logger logr.Logger, client sftp.Client) *UploadTr
 }
 
 func (a *UploadTransferActivity) Execute(ctx context.Context, params *UploadTransferActivityParams) (*UploadTransferActivityResult, error) {
-	a.logger.V(1).Info("Execute UploadTransferActivity",
-		"SourcePath", params.SourcePath,
-	)
+	a.logger.V(1).Info("Execute UploadTransferActivity", "SourcePath", params.SourcePath)
 
 	src, err := os.Open(params.SourcePath)
 	if err != nil {
-		return nil, fmt.Errorf("upload transfer: %v", err)
+		return nil, fmt.Errorf("%s: %v", UploadTransferActivityName, err)
 	}
 	defer src.Close()
 
 	bytes, path, err := a.client.Upload(ctx, src, filepath.Base(params.SourcePath))
 	if err != nil {
-		return nil, fmt.Errorf("upload transfer: %v", err)
+		return nil, fmt.Errorf("%s: %v", UploadTransferActivityName, err)
 	}
 
 	return &UploadTransferActivityResult{

--- a/internal/am/upload_transfer_test.go
+++ b/internal/am/upload_transfer_test.go
@@ -55,7 +55,7 @@ func TestUploadTransferActivity(t *testing.T) {
 			params: am.UploadTransferActivityParams{
 				SourcePath: td.Join("missing"),
 			},
-			errMsg: fmt.Sprintf("upload transfer: open %s: no such file or directory", td.Join("missing")),
+			errMsg: fmt.Sprintf("UploadTransferActivity: open %s: no such file or directory", td.Join("missing")),
 		},
 		{
 			name: "Errors when upload fails",
@@ -74,7 +74,7 @@ func TestUploadTransferActivity(t *testing.T) {
 					errors.New("SSH: failed to connect: dial tcp 127.0.0.1:2200: connect: connection refused"),
 				)
 			},
-			errMsg: "upload transfer: SSH: failed to connect: dial tcp 127.0.0.1:2200: connect: connection refused",
+			errMsg: "UploadTransferActivity: SSH: failed to connect: dial tcp 127.0.0.1:2200: connect: connection refused",
 		},
 	} {
 		tt := tt

--- a/internal/package_/workflow.go
+++ b/internal/package_/workflow.go
@@ -60,8 +60,8 @@ type ProcessingWorkflowRequest struct {
 	DefaultPermanentLocationID *uuid.UUID
 
 	// Task queues used for starting new workflows.
-	TaskQueue    string
-	A3mTaskQueue string
+	GlobalTaskQueue       string
+	PreservationTaskQueue string
 }
 
 func InitProcessingWorkflow(ctx context.Context, tc temporalsdk_client.Client, req *ProcessingWorkflowRequest) error {
@@ -74,7 +74,7 @@ func InitProcessingWorkflow(ctx context.Context, tc temporalsdk_client.Client, r
 
 	opts := temporalsdk_client.StartWorkflowOptions{
 		ID:                    req.WorkflowID,
-		TaskQueue:             req.TaskQueue,
+		TaskQueue:             req.GlobalTaskQueue,
 		WorkflowIDReusePolicy: temporalsdk_api_enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 	}
 	_, err := tc.ExecuteWorkflow(ctx, opts, ProcessingWorkflowName, req)

--- a/main.go
+++ b/main.go
@@ -272,8 +272,8 @@ func main() {
 									IsDir:                      event.IsDir,
 									AutoApproveAIP:             autoApproveAIP,
 									DefaultPermanentLocationID: &defaultPermanentLocationID,
-									TaskQueue:                  cfg.Temporal.TaskQueue,
-									A3mTaskQueue:               cfg.Preservation.TaskQueue,
+									GlobalTaskQueue:            cfg.Temporal.TaskQueue,
+									PreservationTaskQueue:      cfg.Preservation.TaskQueue,
 								}
 								if err := package_.InitProcessingWorkflow(ctx, temporalClient, &req); err != nil {
 									logger.Error(err, "Error initializing processing workflow.")


### PR DESCRIPTION
Add a start transfer activity to send an "/api/v2beta/package" POST request to the Archivematica REST API to start creating a SIP from a transfer.

Add filepaths to AM workflow in `processing_test.go` to catch path mistakes when moving transfer files around.