### PR TITLE
Fix creation and upload of zip file

### DIFF
--- a/internal/am/upload_transfer.go
+++ b/internal/am/upload_transfer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/go-logr/logr"
 
@@ -14,7 +15,6 @@ const UploadTransferActivityName = "UploadTransferActivity"
 
 type UploadTransferActivityParams struct {
 	SourcePath string
-	Filename   string
 }
 
 type UploadTransferActivityResult struct {
@@ -34,7 +34,6 @@ func NewUploadTransferActivity(logger logr.Logger, client sftp.Client) *UploadTr
 func (a *UploadTransferActivity) Execute(ctx context.Context, params *UploadTransferActivityParams) (*UploadTransferActivityResult, error) {
 	a.logger.V(1).Info("Execute UploadTransferActivity",
 		"SourcePath", params.SourcePath,
-		"Filename", params.Filename,
 	)
 
 	src, err := os.Open(params.SourcePath)
@@ -43,7 +42,7 @@ func (a *UploadTransferActivity) Execute(ctx context.Context, params *UploadTran
 	}
 	defer src.Close()
 
-	bytes, path, err := a.client.Upload(ctx, src, params.Filename)
+	bytes, path, err := a.client.Upload(ctx, src, filepath.Base(params.SourcePath))
 	if err != nil {
 		return nil, fmt.Errorf("upload transfer: %v", err)
 	}

--- a/internal/am/upload_transfer_test.go
+++ b/internal/am/upload_transfer_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestUploadTransferActivity(t *testing.T) {
-	filename := "fake_bag"
+	filename := "transfer.zip"
 	td := tfs.NewDir(t, "enduro-upload-transfer-test",
 		tfs.WithFile(filename, "Testing 1-2-3!"),
 	)
@@ -36,7 +36,6 @@ func TestUploadTransferActivity(t *testing.T) {
 			name: "Uploads transfer",
 			params: am.UploadTransferActivityParams{
 				SourcePath: td.Join(filename),
-				Filename:   filename,
 			},
 			recorder: func(m *sftp_fake.MockClientMockRecorder) {
 				var t *os.File
@@ -55,7 +54,6 @@ func TestUploadTransferActivity(t *testing.T) {
 			name: "Errors when local file can't be read",
 			params: am.UploadTransferActivityParams{
 				SourcePath: td.Join("missing"),
-				Filename:   filename,
 			},
 			errMsg: fmt.Sprintf("upload transfer: open %s: no such file or directory", td.Join("missing")),
 		},
@@ -63,7 +61,6 @@ func TestUploadTransferActivity(t *testing.T) {
 			name: "Errors when upload fails",
 			params: am.UploadTransferActivityParams{
 				SourcePath: td.Join(filename),
-				Filename:   filename,
 			},
 			recorder: func(m *sftp_fake.MockClientMockRecorder) {
 				var t *os.File

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -671,10 +671,7 @@ func (w *ProcessingWorkflow) transferAM(sessCtx temporalsdk_workflow.Context, ti
 	err = temporalsdk_workflow.ExecuteActivity(
 		activityOpts,
 		am.UploadTransferActivityName,
-		&am.UploadTransferActivityParams{
-			SourcePath: zipResult.Path,
-			Filename:   tinfo.req.Key,
-		},
+		&am.UploadTransferActivityParams{SourcePath: zipResult.Path},
 	).Get(activityOpts, &uploadResult)
 	if err != nil {
 		return err


### PR DESCRIPTION
- Don't include parent dirs when creating a zip file from a dir
- Use the zip file name as the remote file name in the upload transfer activity
- Fix a bug in the zip activity that set the destination file name to
  an empty string when `DestPath` was set