### PR TITLE
Add an activity to poll AM transfer status

### DIFF
--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -139,6 +139,10 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: am.StartTransferActivityName},
 		)
 		w.RegisterActivityWithOptions(
+			am.NewPollTransferActivity(logger, &cfg.AM, amc.Transfer).Execute,
+			temporalsdk_activity.RegisterOptions{Name: am.PollTransferActivityName},
+		)
+		w.RegisterActivityWithOptions(
 			activities.NewCleanUpActivity().Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.CleanUpActivityName},
 		)

--- a/enduro.toml
+++ b/enduro.toml
@@ -94,6 +94,15 @@ user = "" # Secret: set with env var ENDURO_AM_USER.
 apiKey = "" # Secret: set with env var ENDURO_AM_APIKEY.
 processingConfig = "automated"
 
+# pollInterval is the time to wait between AM polling requests in a string
+# format compatible with https://pkg.go.dev/time#ParseDuration (Default: 10s).
+pollInterval = "10s"
+
+# transferDeadline is the maximum time to wait for a transfer to complete in a
+# format compatible with https://pkg.go.dev/time#ParseDuration. Set to "0" for
+# no time limit.
+transferDeadline = "1h"
+
 [am.sftp]
 host = "" # The Archivematica Storage Service hostname.
 user = ""

--- a/internal/am/config.go
+++ b/internal/am/config.go
@@ -1,6 +1,10 @@
 package am
 
-import "github.com/artefactual-sdps/enduro/internal/sftp"
+import (
+	"time"
+
+	"github.com/artefactual-sdps/enduro/internal/sftp"
+)
 
 type Config struct {
 	// Archivematica server address.
@@ -17,4 +21,11 @@ type Config struct {
 
 	// SFTP configuration for uploading transfers to Archivematica.
 	SFTP sftp.Config
+
+	// PollInterval is the time to wait between poll requests to the AM API.
+	PollInterval time.Duration
+
+	// TransferDeadline is the maximum time to wait for a transfer to complete.
+	// Set to zero for no deadline.
+	TransferDeadline time.Duration
 }

--- a/internal/am/poll_transfer.go
+++ b/internal/am/poll_transfer.go
@@ -1,0 +1,144 @@
+package am
+
+import (
+	context "context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.artefactual.dev/amclient"
+	temporal_tools "go.artefactual.dev/tools/temporal"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+)
+
+const PollTransferActivityName = "poll-transfer-activity"
+
+var errWorkOngoing = errors.New("work ongoing")
+
+type PollTransferActivityParams struct {
+	TransferID string
+}
+
+type PollTransferActivity struct {
+	logger logr.Logger
+	cfg    *Config
+	amts   amclient.TransferService
+}
+
+type PollTransferActivityResult struct {
+	SIPID string
+	Path  string
+}
+
+func NewPollTransferActivity(logger logr.Logger, cfg *Config, amts amclient.TransferService) *PollTransferActivity {
+	return &PollTransferActivity{logger: logger, cfg: cfg, amts: amts}
+}
+
+// Execute polls Archivematica for the status of a transfer and returns when
+// the transfer is complete or returns an error status. Execute sends an
+// activity heartbeat after each poll.
+//
+// A transfer status of "REJECTED", "FAILED", "USER_INPUT", or "BACKLOG" returns
+// a temporal.NonRetryableApplicationError to indicate that processing can not
+// continue.
+func (a *PollTransferActivity) Execute(ctx context.Context, params *PollTransferActivityParams) (*PollTransferActivityResult, error) {
+	a.logger.V(1).Info("Executing PollTransferActivity", "TransferID", params.TransferID)
+
+	ticker := time.NewTicker(a.cfg.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			reqCtx, cancel := context.WithTimeout(ctx, a.cfg.PollInterval/2)
+			r, err := a.poll(reqCtx, params.TransferID, cancel)
+			if err == errWorkOngoing {
+				// Send a heartbeat then continue polling after the poll interval.
+				temporalsdk_activity.RecordHeartbeat(ctx, fmt.Sprintf("Last HTTP response: %v", errWorkOngoing))
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+
+			return r, nil
+		}
+	}
+}
+
+// poll polls the Archivematica transfer status endpoint, returning a non-nil
+// result if transfer processing is complete. An errWorkOngoing error indicates
+// work is ongoing and polling should continue. All other errors should
+// terminate polling.
+func (a *PollTransferActivity) poll(ctx context.Context, transferID string, cancel context.CancelFunc) (*PollTransferActivityResult, error) {
+	// Cancel the context timer when we return so it doesn't wait for the
+	// timeout deadline to expire.
+	defer cancel()
+
+	resp, httpResp, err := a.amts.Status(ctx, transferID)
+	if ferr := transferFailedError(httpResp, err); ferr != nil {
+		a.logger.V(2).Info("Poll transfer error",
+			"StatusCode", httpResp.StatusCode,
+			"Status", httpResp.Status,
+		)
+		return nil, ferr
+	}
+
+	complete, err := isComplete(resp)
+	if err != nil {
+		return nil, err
+	}
+	if complete {
+		return &PollTransferActivityResult{SIPID: resp.SIPID, Path: resp.Path}, nil
+	}
+
+	return nil, errWorkOngoing
+}
+
+// transferFailedError checks an amclient error to determine if the transfer has
+// failed, or if it is still processing (which returns a 400 status code). If an
+// error is returned the activity should return the error, which may or may not
+// be a non-retryable error.
+func transferFailedError(r *amclient.Response, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// AM can return a "400 Bad request" HTTP status code while processing, in
+	// which case we should continue polling.
+	if r != nil && r.Response.StatusCode == http.StatusBadRequest {
+		return nil
+	}
+
+	return convertAMClientError(r, err)
+}
+
+// isComplete checks the AM transfer status response to determine if
+// processing has completed successfully. A non-nil error indicates then AM has
+// ended processing with a failure or requires user input, and Enduro processing
+// should stop. If error is nil then a true result indicates the transfer has
+// completed successfully, and a false result means the transfer is still
+// processing.
+func isComplete(resp *amclient.TransferStatusResponse) (bool, error) {
+	if resp == nil {
+		return false, nil
+	}
+
+	switch resp.Status {
+	case "COMPLETE":
+		if resp.SIPID == "BACKLOG" {
+			return false, temporal_tools.NewNonRetryableError(errors.New("Archivematica SIP sent to backlog"))
+		}
+		return true, nil
+	case "PROCESSING", "":
+		return false, nil
+	case "REJECTED", "FAILED", "USER_INPUT":
+		return false, temporal_tools.NewNonRetryableError(fmt.Errorf("Invalid Archivematica transfer status: %s", resp.Status))
+	default:
+		return false, temporal_tools.NewNonRetryableError(fmt.Errorf("Unknown Archivematica transfer status: %s", resp.Status))
+	}
+}

--- a/internal/am/poll_transfer_test.go
+++ b/internal/am/poll_transfer_test.go
@@ -1,0 +1,190 @@
+package am_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"go.artefactual.dev/amclient"
+	"go.artefactual.dev/amclient/amclienttest"
+	"go.artefactual.dev/tools/mockutil"
+	temporal_tools "go.artefactual.dev/tools/temporal"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/am"
+)
+
+func TestPollTransferActivity(t *testing.T) {
+	transferID := uuid.New().String()
+	sipID := uuid.New().String()
+	path := "/var/archivematica/fake/sip"
+	httpError := func(m *amclienttest.MockTransferServiceMockRecorder, statusCode int) {
+		m.Status(
+			mockutil.Context(),
+			transferID,
+		).Return(
+			nil,
+			&amclient.Response{Response: &http.Response{StatusCode: statusCode}},
+			&amclient.ErrorResponse{Response: &http.Response{StatusCode: statusCode}},
+		)
+	}
+
+	type test struct {
+		name         string
+		statusCode   int
+		mockr        func(*amclienttest.MockTransferServiceMockRecorder, int)
+		want         am.PollTransferActivityResult
+		wantErr      string
+		retryableErr bool
+	}
+	for _, tt := range []test{
+		{
+			name: "Polls twice then returns successfully",
+			mockr: func(m *amclienttest.MockTransferServiceMockRecorder, statusCode int) {
+				// AM sometimes returns a "400 Bad Request" error when a
+				// transfer is processing.
+				m.Status(
+					mockutil.Context(),
+					transferID,
+				).Return(
+					nil,
+					&amclient.Response{
+						Response: &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad request"},
+					},
+					&amclient.ErrorResponse{
+						Response: &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad request"},
+					},
+				)
+
+				// AM sometimes returns a "200 OK" response when a transfer is
+				// processing.
+				m.Status(
+					mockutil.Context(),
+					transferID,
+				).Return(
+					&amclient.TransferStatusResponse{Status: "PROCESSING"},
+					&amclient.Response{
+						Response: &http.Response{StatusCode: http.StatusOK, Status: "200 OK"},
+					},
+					nil,
+				)
+				m.Status(
+					mockutil.Context(),
+					transferID,
+				).Return(
+					&amclient.TransferStatusResponse{Status: "COMPLETE", SIPID: sipID, Path: path},
+					nil,
+					nil,
+				)
+			},
+			want:         am.PollTransferActivityResult{SIPID: sipID, Path: path},
+			retryableErr: true,
+		},
+		{
+			name: "Non-retryable error because SIP is in BACKLOG",
+			mockr: func(m *amclienttest.MockTransferServiceMockRecorder, statusCode int) {
+				m.Status(
+					mockutil.Context(),
+					transferID,
+				).Return(
+					&amclient.TransferStatusResponse{Status: "COMPLETE", SIPID: "BACKLOG", Path: path},
+					&amclient.Response{},
+					nil,
+				)
+			},
+			wantErr: "Archivematica SIP sent to backlog",
+		},
+		{
+			name: "Non-retryable error from unknown transfer status",
+			mockr: func(m *amclienttest.MockTransferServiceMockRecorder, statusCode int) {
+				m.Status(
+					mockutil.Context(),
+					transferID,
+				).Return(
+					&amclient.TransferStatusResponse{Status: "UNKNOWN"},
+					nil,
+					nil,
+				)
+			},
+			wantErr: "Unknown Archivematica transfer status: UNKNOWN",
+		},
+		{
+			name: "Non-retryable error because transfer failed",
+			mockr: func(m *amclienttest.MockTransferServiceMockRecorder, statusCode int) {
+				m.Status(
+					mockutil.Context(),
+					transferID,
+				).Return(
+					&amclient.TransferStatusResponse{Status: "FAILED"},
+					nil,
+					nil,
+				)
+			},
+			wantErr: "Archivematica transfer status: FAILED",
+		},
+		{
+			name:       "Non-retryable error from http invalid credentials",
+			mockr:      httpError,
+			statusCode: http.StatusUnauthorized,
+			wantErr:    "invalid Archivematica credentials",
+		},
+		{
+			name:       "Non-retryable error from http insufficient permissions",
+			mockr:      httpError,
+			statusCode: http.StatusForbidden,
+			wantErr:    "insufficient Archivematica permissions",
+		},
+		{
+			name:       "Non-retryable error from http not found response",
+			mockr:      httpError,
+			statusCode: http.StatusNotFound,
+			wantErr:    "Archivematica resource not found",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			ctrl := gomock.NewController(t)
+			amts := amclienttest.NewMockTransferService(ctrl)
+
+			if tt.mockr != nil {
+				tt.mockr(amts.EXPECT(), tt.statusCode)
+			}
+
+			env.RegisterActivityWithOptions(
+				am.NewPollTransferActivity(
+					logr.Discard(),
+					&am.Config{PollInterval: time.Millisecond * 10},
+					amts,
+				).Execute,
+				temporalsdk_activity.RegisterOptions{
+					Name: am.PollTransferActivityName,
+				},
+			)
+
+			enc, err := env.ExecuteActivity(
+				am.PollTransferActivityName,
+				am.PollTransferActivityParams{TransferID: transferID},
+			)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.Assert(t, temporal_tools.NonRetryableError(err))
+
+				return
+			}
+			assert.NilError(t, err)
+
+			var r am.PollTransferActivityResult
+			enc.Get(&r)
+			assert.DeepEqual(t, r, tt.want)
+		})
+	}
+}

--- a/internal/am/start_transfer.go
+++ b/internal/am/start_transfer.go
@@ -21,7 +21,7 @@ type StartTransferActivityParams struct {
 }
 
 type StartTransferActivityResult struct {
-	UUID string
+	TransferID string
 }
 
 func NewStartTransferActivity(logger logr.Logger, cfg *Config, amps amclient.PackageService) *StartTransferActivity {
@@ -37,7 +37,7 @@ func NewStartTransferActivity(logger logr.Logger, cfg *Config, amps amclient.Pac
 // returned.  An error response will return a retryable or non-retryable
 // temporal.ApplicationError, depending on the nature of the error.
 func (a *StartTransferActivity) Execute(ctx context.Context, opts *StartTransferActivityParams) (*StartTransferActivityResult, error) {
-	a.logger.Info("Executing StartTransferActivity", "Name", opts.Name, "Path", opts.Path)
+	a.logger.V(1).Info("Executing StartTransferActivity", "Name", opts.Name, "Path", opts.Path)
 
 	processingConfig := a.cfg.ProcessingConfig
 	if processingConfig == "" {
@@ -55,5 +55,5 @@ func (a *StartTransferActivity) Execute(ctx context.Context, opts *StartTransfer
 		return nil, convertAMClientError(resp, err)
 	}
 
-	return &StartTransferActivityResult{UUID: payload.ID}, nil
+	return &StartTransferActivityResult{TransferID: payload.ID}, nil
 }

--- a/internal/am/start_transfer_test.go
+++ b/internal/am/start_transfer_test.go
@@ -68,7 +68,7 @@ func TestStartTransferActivity(t *testing.T) {
 					nil,
 				)
 			},
-			want: am.StartTransferActivityResult{UUID: transferID},
+			want: am.StartTransferActivityResult{TransferID: transferID},
 		},
 		{
 			name:   "Returns an invalid credentials error",
@@ -86,7 +86,7 @@ func TestStartTransferActivity(t *testing.T) {
 			name:   "Returns a not found error",
 			amcr:   amcrDefault,
 			st:     http.Response{StatusCode: http.StatusNotFound},
-			errMsg: "Archivematica transfer not found",
+			errMsg: "Archivematica resource not found",
 		},
 	} {
 		tt := tt
@@ -120,7 +120,7 @@ func TestStartTransferActivity(t *testing.T) {
 			var r am.StartTransferActivityResult
 			err = future.Get(&r)
 			assert.NilError(t, err)
-			assert.DeepEqual(t, r, am.StartTransferActivityResult{UUID: transferID})
+			assert.DeepEqual(t, r, am.StartTransferActivityResult{TransferID: transferID})
 		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/viper"
 
@@ -70,6 +71,7 @@ func Read(config *Configuration, configFile string) (found bool, configFileUsed 
 	v.SetDefault("temporal.taskqueue", temporal.GlobalTaskQueue)
 	v.SetDefault("debugListen", "127.0.0.1:9001")
 	v.SetDefault("api.listen", "127.0.0.1:9000")
+	v.SetDefault("am.pollInterval", 10*time.Second)
 	v.SetEnvPrefix("enduro")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"
@@ -59,5 +60,6 @@ func TestConfig(t *testing.T) {
 		assert.Equal(t, c.Preservation.TaskQueue, temporal.A3mWorkerTaskQueue)
 		assert.Equal(t, c.Storage.TaskQueue, temporal.GlobalTaskQueue)
 		assert.Equal(t, c.Temporal.TaskQueue, temporal.GlobalTaskQueue)
+		assert.Equal(t, c.AM.PollInterval, 10*time.Second)
 	})
 }

--- a/internal/package_/workflow.go
+++ b/internal/package_/workflow.go
@@ -62,6 +62,13 @@ type ProcessingWorkflowRequest struct {
 	// Task queues used for starting new workflows.
 	GlobalTaskQueue       string
 	PreservationTaskQueue string
+
+	// PollInterval is the time to wait between poll requests to the AM API.
+	PollInterval time.Duration
+
+	// TransferDeadline is the maximum time to wait for a transfer to complete.
+	// Set to zero for no deadline.
+	TransferDeadline time.Duration
 }
 
 func InitProcessingWorkflow(ctx context.Context, tc temporalsdk_client.Client, req *ProcessingWorkflowRequest) error {

--- a/internal/temporal/temporal.go
+++ b/internal/temporal/temporal.go
@@ -1,11 +1,5 @@
 package temporal
 
-import (
-	"fmt"
-
-	temporalsdk_temporal "go.temporal.io/sdk/temporal"
-)
-
 const (
 	// There are task queues used by our workflow and activity workers. It may
 	// be convenient to make these configurable in the future .
@@ -13,9 +7,3 @@ const (
 	A3mWorkerTaskQueue = "a3m"
 	AmWorkerTaskQueue  = "am"
 )
-
-func NonRetryableError(err error) error {
-	return temporalsdk_temporal.NewNonRetryableApplicationError(
-		fmt.Sprintf("non retryable error: %v", err.Error()), "", nil, nil,
-	)
-}

--- a/internal/workflow/activities/bundle.go
+++ b/internal/workflow/activities/bundle.go
@@ -12,10 +12,10 @@ import (
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/mholt/archiver/v3"
 	"github.com/otiai10/copy"
+	temporal_tools "go.artefactual.dev/tools/temporal"
 
 	"github.com/artefactual-sdps/enduro/internal/bagit"
 	"github.com/artefactual-sdps/enduro/internal/bundler"
-	"github.com/artefactual-sdps/enduro/internal/temporal"
 	"github.com/artefactual-sdps/enduro/internal/watcher"
 )
 
@@ -57,7 +57,7 @@ func (a *BundleActivity) Execute(ctx context.Context, params *BundleActivityPara
 
 	defer func() {
 		if err != nil {
-			err = temporal.NonRetryableError(err)
+			err = temporal_tools.NewNonRetryableError(err)
 		}
 	}()
 
@@ -79,12 +79,12 @@ func (a *BundleActivity) Execute(ctx context.Context, params *BundleActivityPara
 		}
 	}
 	if err != nil {
-		return nil, temporal.NonRetryableError(err)
+		return nil, temporal_tools.NewNonRetryableError(err)
 	}
 
 	err = unbag(res.FullPath)
 	if err != nil {
-		return nil, temporal.NonRetryableError(err)
+		return nil, temporal_tools.NewNonRetryableError(err)
 	}
 
 	res.RelPath, err = filepath.Rel(params.TransferDir, res.FullPath)

--- a/internal/workflow/activities/download.go
+++ b/internal/workflow/activities/download.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/artefactual-sdps/enduro/internal/temporal"
+	temporal_tools "go.artefactual.dev/tools/temporal"
+
 	"github.com/artefactual-sdps/enduro/internal/watcher"
 )
 
@@ -30,12 +31,12 @@ func tempFile(pattern string) (*os.File, error) {
 func (a *DownloadActivity) Execute(ctx context.Context, watcherName, key string) (string, error) {
 	file, err := tempFile("blob-*")
 	if err != nil {
-		return "", temporal.NonRetryableError(fmt.Errorf("error creating temporary file in processing directory: %v", err))
+		return "", temporal_tools.NewNonRetryableError(fmt.Errorf("error creating temporary file in processing directory: %v", err))
 	}
 	defer file.Close() //#nosec G307 -- Errors returned by Close() here do not require specific handling.
 
 	if err := a.wsvc.Download(ctx, file, watcherName, key); err != nil {
-		return "", temporal.NonRetryableError(fmt.Errorf("error downloading blob: %v", err))
+		return "", temporal_tools.NewNonRetryableError(fmt.Errorf("error downloading blob: %v", err))
 	}
 
 	return file.Name(), nil

--- a/main.go
+++ b/main.go
@@ -274,6 +274,8 @@ func main() {
 									DefaultPermanentLocationID: &defaultPermanentLocationID,
 									GlobalTaskQueue:            cfg.Temporal.TaskQueue,
 									PreservationTaskQueue:      cfg.Preservation.TaskQueue,
+									PollInterval:               cfg.AM.PollInterval,
+									TransferDeadline:           cfg.AM.TransferDeadline,
 								}
 								if err := package_.InitProcessingWorkflow(ctx, temporalClient, &req); err != nil {
 									logger.Error(err, "Error initializing processing workflow.")


### PR DESCRIPTION
- Add a PollTransferActivity to poll AM until transfer processing is complete or fails
- Add a PollInterval config option to control frequency of polls
- Send a heartbeat after each poll, and set a maximum time between heartbeats
- Add a TransferDeadline config option that limits the total duration of the PollTransferActivity in case Archivematica processing stalls
- Improve error handling for AM HTTP errors based on the legacy Enduro error handling
- Use go.artefactual.dev/tools/temporal for creating and checking non-retryable temporal errors