### PR TITLE
Implement delete activity

### DIFF
--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -117,6 +117,7 @@ func main() {
 		}
 
 		httpClient := cleanhttp.DefaultPooledClient()
+		sftpClient := sftp.NewGoClient(logger, cfg.AM.SFTP)
 		amc := amclient.NewClient(httpClient, cfg.AM.Address, cfg.AM.User, cfg.AM.APIKey)
 
 		w.RegisterActivityWithOptions(
@@ -131,8 +132,12 @@ func main() {
 			activities.NewZipActivity(logger).Execute, temporalsdk_activity.RegisterOptions{Name: activities.ZipActivityName},
 		)
 		w.RegisterActivityWithOptions(
-			am.NewUploadTransferActivity(logger, sftp.NewGoClient(logger, cfg.AM.SFTP)).Execute,
+			am.NewUploadTransferActivity(logger, sftpClient).Execute,
 			temporalsdk_activity.RegisterOptions{Name: am.UploadTransferActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			am.NewDeleteTransferActivity(logger, sftpClient).Execute,
+			temporalsdk_activity.RegisterOptions{Name: am.DeleteTransferActivityName},
 		)
 		w.RegisterActivityWithOptions(
 			am.NewStartTransferActivity(logger, &cfg.AM, amc.Package).Execute,

--- a/internal/am/delete_transfer.go
+++ b/internal/am/delete_transfer.go
@@ -1,0 +1,38 @@
+package am
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	"github.com/artefactual-sdps/enduro/internal/sftp"
+)
+
+const DeleteTransferActivityName = "DeleteTransferActivity"
+
+type DeleteTransferActivityParams struct {
+	Destination string
+}
+
+type DeleteTransferActivity struct {
+	client sftp.Client
+	logger logr.Logger
+}
+
+func NewDeleteTransferActivity(logger logr.Logger, client sftp.Client) *DeleteTransferActivity {
+	return &DeleteTransferActivity{client: client, logger: logger}
+}
+
+func (a *DeleteTransferActivity) Execute(ctx context.Context, params *DeleteTransferActivityParams) error {
+	a.logger.V(1).Info("Execute DeleteTransferActivity",
+		"destination", params.Destination,
+	)
+
+	err := a.client.Delete(ctx, params.Destination)
+	if err != nil {
+		return fmt.Errorf("delete transfer: path: %q: %v", params.Destination, err)
+	}
+
+	return nil
+}

--- a/internal/am/delete_transfer_test.go
+++ b/internal/am/delete_transfer_test.go
@@ -1,0 +1,107 @@
+package am_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"go.artefactual.dev/tools/mockutil"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+	tfs "gotest.tools/v3/fs"
+
+	"github.com/artefactual-sdps/enduro/internal/am"
+	sftp_fake "github.com/artefactual-sdps/enduro/internal/sftp/fake"
+)
+
+func TestDeleteTransferActivity(t *testing.T) {
+	t.Parallel()
+
+	filename := "fake_bag"
+	activityErr := "activity error (type: DeleteTransferActivity, scheduledEventID: 0, startedEventID: 0, identity: ): "
+	td := tfs.NewDir(t, "enduro-delete-transfer-test",
+		tfs.WithFile(filename, "Testing 1-2-3!"),
+	)
+
+	type test struct {
+		name     string
+		params   am.DeleteTransferActivityParams
+		recorder func(*sftp_fake.MockClientMockRecorder, am.DeleteTransferActivityParams)
+		errMsg   string
+	}
+	for _, tt := range []test{
+		{
+			name: "Deletes transfer",
+			params: am.DeleteTransferActivityParams{
+				Destination: td.Path(),
+			},
+			recorder: func(m *sftp_fake.MockClientMockRecorder, params am.DeleteTransferActivityParams) {
+				m.Delete(
+					mockutil.Context(),
+					params.Destination,
+				).Return(nil)
+			},
+		},
+		{
+			name: "Errors when file does not exist",
+			params: am.DeleteTransferActivityParams{
+				Destination: td.Join("missing"),
+			},
+			recorder: func(m *sftp_fake.MockClientMockRecorder, params am.DeleteTransferActivityParams) {
+				m.Delete(
+					mockutil.Context(),
+					params.Destination,
+				).Return(
+					errors.New("SFTP: unable to remove file \"test.txt\": file does not exist"),
+				)
+			},
+			errMsg: fmt.Sprintf("delete transfer: path: %q: %v", td.Join("missing"), errors.New("SFTP: unable to remove file \"test.txt\": file does not exist")),
+		},
+		{
+			name: "Errors when Delete fails",
+			params: am.DeleteTransferActivityParams{
+				Destination: td.Join(filename),
+			},
+			recorder: func(m *sftp_fake.MockClientMockRecorder, params am.DeleteTransferActivityParams) {
+				m.Delete(
+					mockutil.Context(),
+					params.Destination,
+				).Return(
+					errors.New("SSH: failed to connect: dial tcp 127.0.0.1:2200: connect: connection refused"),
+				)
+			},
+			errMsg: fmt.Sprintf("delete transfer: path: %q: %v", td.Join(filename), errors.New("SSH: failed to connect: dial tcp 127.0.0.1:2200: connect: connection refused")),
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			msvc := sftp_fake.NewMockClient(gomock.NewController(t))
+
+			if tt.recorder != nil {
+				tt.recorder(msvc.EXPECT(), tt.params)
+			}
+
+			env.RegisterActivityWithOptions(
+				am.NewDeleteTransferActivity(logr.Discard(), msvc).Execute,
+				temporalsdk_activity.RegisterOptions{
+					Name: am.DeleteTransferActivityName,
+				},
+			)
+
+			_, err := env.ExecuteActivity(am.DeleteTransferActivityName, tt.params)
+			if tt.errMsg != "" {
+				assert.Error(t, err, activityErr+tt.errMsg)
+				return
+			}
+
+			assert.NilError(t, err)
+		})
+	}
+}

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -718,7 +718,7 @@ func (w *ProcessingWorkflow) transferAM(sessCtx temporalsdk_workflow.Context, ti
 		return err
 	}
 
-	// Set SIP ID.
+	// Set SP ID.
 	tinfo.SIPID = pollTransferResult.SIPID
 
 	// Poll ingest status.
@@ -734,6 +734,15 @@ func (w *ProcessingWorkflow) transferAM(sessCtx temporalsdk_workflow.Context, ti
 
 	// Set AIP "stored at" time.
 	tinfo.StoredAt = temporalsdk_workflow.Now(sessCtx).UTC()
+
+	// Delete transfer.
+	activityOpts = withActivityOptsForRequest(sessCtx)
+	err = temporalsdk_workflow.ExecuteActivity(activityOpts, am.DeleteTransferActivityName, am.DeleteTransferActivityParams{
+		Destination: uploadResult.RemotePath,
+	}).Get(activityOpts, nil)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -73,6 +73,12 @@ func (s *ProcessingWorkflowTestSuite) SetupWorkflowTest(taskQueue string) {
 		temporalsdk_activity.RegisterOptions{Name: am.UploadTransferActivityName},
 	)
 	s.env.RegisterActivityWithOptions(
+		am.NewDeleteTransferActivity(logger, sftpc).Execute,
+		temporalsdk_activity.RegisterOptions{
+			Name: am.DeleteTransferActivityName,
+		},
+	)
+	s.env.RegisterActivityWithOptions(
 		am.NewStartTransferActivity(logger, &am.Config{}, amclienttest.NewMockPackageService(ctrl)).Execute,
 		temporalsdk_activity.RegisterOptions{Name: am.StartTransferActivityName},
 	)
@@ -249,6 +255,9 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 	s.env.OnActivity(am.PollIngestActivityName,
 		sessionCtx, &am.PollIngestActivityParams{SIPID: sipID.String()},
 	).Return(&am.PollIngestActivityResult{Status: "COMPLETE"}, nil).Once()
+	s.env.OnActivity(am.DeleteTransferActivityName,
+		sessionCtx, &am.DeleteTransferActivityParams{Destination: "transfer.zip"},
+	).Return(nil).Once()
 
 	// Post-preservation activities.
 	s.env.OnActivity(updatePackageLocalActivity, ctx, logger, pkgsvc, mock.AnythingOfType("*workflow.updatePackageLocalActivityParams")).Return(nil).Once()


### PR DESCRIPTION
I have approached the deletion of transfers in a number of different ways, first by implementing a separate activity like in this approach. I also tried to add the capability of deleting transfers to the cleanup activity. The reason we did not go with this approach is that it was ultimately too complex for the benefits. The final approach was to not use an activity at all and just implement delete in the workflow directly, this also did not work as an approach because the workflow uses the 'internal.Context' interface and not the context.Context. It also meant spreading dependencies. The Am worker and the global worker needed to use the sftpclient. This can be a problem because worker clients can be different and there is no guarantee that they are the same.  

- Implement delete activity
- Add delete to am worker registration
Closes #785 