### PR TITLE
Allow running a local version of a3m

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -3,8 +3,15 @@ secret_settings(disable_scrub=True)
 load("ext://uibutton", "cmd_button", "text_input")
 load('ext://dotenv', 'dotenv')
 
-# Set preservation system (default: 'a3m')
+# Load tilt env file if it exists
+dotenv_path = ".tilt.env"
+if os.path.exists(dotenv_path):
+  dotenv(fn=dotenv_path)
+
+# Get preservation system (default: 'a3m')
 PRES_SYS = os.environ.get('ENDURO_PRES_SYSTEM', 'a3m')
+if PRES_SYS not in ("a3m", "am"):
+  fail("Invalid ENDURO_PRES_SYSTEM: {pres_sys}.".format(pres_sys=PRES_SYS))
 
 # Docker images
 custom_build(
@@ -45,11 +52,6 @@ docker_build(
     ),
   ]
 )
-
-# Load tilt env file if it exists
-dotenv_path = ".tilt.env"
-if os.path.exists(dotenv_path):
-  dotenv(fn=dotenv_path)
 
 # Get kube overlay path
 KUBE_OVERLAY = 'hack/kube/overlays/dev-a3m'

--- a/Tiltfile
+++ b/Tiltfile
@@ -13,6 +13,9 @@ PRES_SYS = os.environ.get('ENDURO_PRES_SYSTEM', 'a3m')
 if PRES_SYS not in ("a3m", "am"):
   fail("Invalid ENDURO_PRES_SYSTEM: {pres_sys}.".format(pres_sys=PRES_SYS))
 
+true = ("true", "1", "yes", "t", "y")
+LOCAL_A3M = os.environ.get("LOCAL_A3M", "").lower() in true
+
 # Docker images
 custom_build(
   ref="enduro:dev",
@@ -32,6 +35,8 @@ else:
     command=["hack/build_docker.sh", "enduro-a3m-worker"],
     deps=["."],
   )
+  if LOCAL_A3M:
+    docker_build("ghcr.io/artefactual-labs/a3m", context="../a3m")
 
 docker_build(
   "enduro-dashboard:dev",
@@ -63,7 +68,7 @@ k8s_yaml(kustomize(KUBE_OVERLAY))
 
 # Configure trigger mode
 trigger_mode = TRIGGER_MODE_MANUAL
-if os.environ.get('TRIGGER_MODE_AUTO', ''):
+if os.environ.get('TRIGGER_MODE_AUTO', '').lower() in true:
   trigger_mode = TRIGGER_MODE_AUTO
 
 # Enduro resources

--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -20,9 +20,9 @@ even against remote clusters, check Tilt's [Choosing a Local Dev Cluster] and
 [Install] documentation for more information to install these requirements.
 
 Additionally, follow the [Manage Docker as a non-root user] post-install guide
-so that you don’t have to run Tilt with `sudo`. *Note that managing Docker as a
+so that you don’t have to run Tilt with `sudo`. _Note that managing Docker as a
 non-root user is **different** from running the docker daemon as a non-root user
-(rootless).*
+(rootless)._
 
 ### Dex host
 
@@ -96,11 +96,11 @@ documentation to know more about it.
 
 There are three services available from the host:
 
-| Service         | URL                         | Username            | Password   |
-|-----------------|-----------------------------|---------------------|------------|
-| Dashboard       | <http://localhost:8080>     | `admin@example.com` | `admin`    |
-| MinIO console   | <http://localhost:7460>     | `minio`             | `minio123` |
-| Temporal UI     | <http://localhost:7440>     | `admin@example.com` | `admin`    |
+| Service       | URL                     | Username            | Password   |
+| ------------- | ----------------------- | ------------------- | ---------- |
+| Dashboard     | <http://localhost:8080> | `admin@example.com` | `admin`    |
+| MinIO console | <http://localhost:7460> | `minio`             | `minio123` |
+| Temporal UI   | <http://localhost:7440> | `admin@example.com` | `admin`    |
 
 ## Live updates
 
@@ -154,6 +154,25 @@ cluster container from the host. With k3d, run:
 ```bash
 k3d cluster delete sdps-local
 ```
+
+## Tilt environment configuration
+
+A few configuration options can be changed by having a `.tilt.env` file
+located in the root of the project. Example:
+
+```text
+TRIGGER_MODE_AUTO=true
+ENDURO_PRES_SYSTEM=a3m
+```
+
+### TRIGGER_MODE_AUTO
+
+Enables live updates on code changes for the enduro services.
+
+### ENDURO_PRES_SYSTEM
+
+Determines the preservation system between Archivematica (`am`) and a3m
+(`a3m`). Defaults to a3m.
 
 ## Tilt UI helpers
 

--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -163,6 +163,7 @@ located in the root of the project. Example:
 ```text
 TRIGGER_MODE_AUTO=true
 ENDURO_PRES_SYSTEM=a3m
+LOCAL_A3M=true
 ```
 
 ### TRIGGER_MODE_AUTO
@@ -173,6 +174,11 @@ Enables live updates on code changes for the enduro services.
 
 Determines the preservation system between Archivematica (`am`) and a3m
 (`a3m`). Defaults to a3m.
+
+### LOCAL_A3M
+
+Build and use a local version of a3m. Requires to have the `a3m` repository
+cloned as a sibling of this repository folder.
 
 ## Tilt UI helpers
 


### PR DESCRIPTION
Also, allows setting preservation system in .tilt.env:

- Load `.tilt.env` before getting `ENDURO_PRES_SYSTEM` env. var.
- Fail if `ENDURO_PRES_SYSTEM` is not one of the allowed values.
- Document Tilt environment configuration.