### PR TITLE
Specify node version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+  node: 20.10.0
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0


### PR DESCRIPTION
I'm not able to run the markdownlint pre-commit hook without this change. It seems like pre-commit is trying to install a really old `node` version using my local `npm` version.

```
$ pre-commit run --all-files
[INFO] Installing environment for https://github.com/igorshubovych/markdownlint-cli.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/home/radda/.cache/pre-commit/repol2go7x5_/node_env-system/bin/node', '/usr/local/bin/npm', 'install', '--include=dev', '--include=prod', '--ignore-prepublish', '--no-progress', '--no-save')
return code: 1
stdout: (none)
stderr:
    ERROR: npm v10.2.3 is known not to run on Node.js v12.22.9.  This version of npm supports the following node versions: `^18.17.0 || >=20.5.0`. You can find the latest version at https://nodejs.org/.
    
    ERROR:
    /usr/local/lib/node_modules/npm/lib/utils/exit-handler.js:19
      const hasLoadedNpm = npm?.config.loaded
                               ^
    
    SyntaxError: Unexpected token '.'
        at wrapSafe (internal/modules/cjs/loader.js:915:16)
        at Module._compile (internal/modules/cjs/loader.js:963:27)
        at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
        at Module.load (internal/modules/cjs/loader.js:863:32)
        at Function.Module._load (internal/modules/cjs/loader.js:708:14)
        at Module.require (internal/modules/cjs/loader.js:887:19)
        at require (internal/modules/cjs/helpers.js:74:18)
        at module.exports (/usr/local/lib/node_modules/npm/lib/cli-entry.js:15:23)
        at module.exports (/usr/local/lib/node_modules/npm/lib/es6/validate-engines.js:39:10)
        at module.exports (/usr/local/lib/node_modules/npm/lib/cli.js:4:31)
```

Is this happening to somebody else? Do you know other solutions? I don't like having to maintain this version here but I could not find another way to fix this issue.

Refs:

https://github.com/jupyterlab/jupyterlab/issues/12675
https://stackoverflow.com/questions/71939099/bitbucket-pipeline-error-installing-pre-commit-ts-lint