### PR TITLE
Save AM job data in poll transfer activity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/jmoiron/sqlx v1.3.5
+	github.com/jonboulle/clockwork v0.4.0
 	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/nyudlts/go-bagit v0.2.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -1155,6 +1155,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/internal/am/errors.go
+++ b/internal/am/errors.go
@@ -10,13 +10,13 @@ import (
 )
 
 var (
-	// errWorkOngoing indicates work is ongoing and polling should continue.
-	errWorkOngoing = errors.New("work ongoing")
+	// ErrWorkOngoing indicates work is ongoing and polling should continue.
+	ErrWorkOngoing = errors.New("work ongoing")
 
-	// errBadRequest respresents an AM "400 Bad request" response, which can
+	// ErrBadRequest respresents an AM "400 Bad request" response, which can
 	// occur while a transfer or ingest is still processing and may require
 	// special handling.
-	errBadRequest = errors.New("Archivematica response: 400 Bad request")
+	ErrBadRequest = errors.New("Archivematica response: 400 Bad request")
 )
 
 // ConvertAMClientError converts an Archivematica API response to a
@@ -30,7 +30,7 @@ func convertAMClientError(resp *amclient.Response, err error) error {
 	switch {
 	case resp.Response.StatusCode == http.StatusBadRequest:
 		// Allow retries for "400 Bad request" errors.
-		return errBadRequest
+		return ErrBadRequest
 	case resp.Response.StatusCode == http.StatusUnauthorized:
 		return temporal_tools.NewNonRetryableError(errors.New("invalid Archivematica credentials"))
 	case resp.Response.StatusCode == http.StatusForbidden:

--- a/internal/am/job_tracker.go
+++ b/internal/am/job_tracker.go
@@ -1,0 +1,123 @@
+package am
+
+import (
+	context "context"
+	"database/sql"
+
+	"github.com/jonboulle/clockwork"
+	"go.artefactual.dev/amclient"
+
+	"github.com/artefactual-sdps/enduro/internal/package_"
+)
+
+var jobStatusToPreservationTaskStatus = map[amclient.JobStatus]package_.PreservationTaskStatus{
+	amclient.JobStatusUnknown:    package_.TaskStatusUnspecified,
+	amclient.JobStatusComplete:   package_.TaskStatusDone,
+	amclient.JobStatusProcessing: package_.TaskStatusInProgress,
+	amclient.JobStatusFailed:     package_.TaskStatusError,
+}
+
+type JobTracker struct {
+	// clock is a service that provides clock time.
+	clock  clockwork.Clock
+	jobSvc amclient.JobsService
+	pkgSvc package_.Service
+
+	// presActionID is the PreservationAction ID that will be the parent ID for
+	// all saved preservation tasks.
+	presActionID uint
+
+	// savedIDs caches the ID of jobs that have already been saved so we don't
+	// create duplicates.
+	savedIDs map[string]struct{}
+}
+
+func NewJobTracker(clock clockwork.Clock, jobSvc amclient.JobsService, pkgSvc package_.Service, presActionID uint) *JobTracker {
+	return &JobTracker{
+		clock:  clock,
+		jobSvc: jobSvc,
+		pkgSvc: pkgSvc,
+
+		presActionID: presActionID,
+		savedIDs:     make(map[string]struct{}),
+	}
+}
+
+// SavePreservationTasks queries the Archivematica jobs list endpoint to get a
+// list of completed jobs related to the transfer or ingest identified by
+// unitID, then saves any new jobs as preservation tasks.
+func (jt *JobTracker) SavePreservationTasks(ctx context.Context, unitID string) (int, error) {
+	jobs, err := jt.list(ctx, unitID)
+	if err != nil {
+		return 0, err
+	}
+
+	count, err := jt.savePreservationTasks(ctx, jobs)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// list requests a job list for unitID from the Archivematica jobs endpoint.
+func (jt *JobTracker) list(ctx context.Context, unitID string) ([]amclient.Job, error) {
+	jobs, httpResp, err := jt.jobSvc.List(ctx, unitID, &amclient.JobsListRequest{})
+	if err != nil {
+		return nil, convertAMClientError(httpResp, err)
+	}
+
+	return jobs, nil
+}
+
+// savePreservationTasks persists Archivematica jobs data as preservation tasks.
+func (jt *JobTracker) savePreservationTasks(ctx context.Context, jobs []amclient.Job) (int, error) {
+	var count int
+	jobs = filterSavedJobs(jobs, jt.savedIDs)
+	for _, job := range jobs {
+		// Wait until a job is complete (or failed) before saving it.
+		if job.Status == amclient.JobStatusProcessing {
+			continue
+		}
+
+		pt := ConvertJobToPreservationTask(job)
+		pt.PreservationActionID = jt.presActionID
+
+		now := sql.NullTime{Time: jt.clock.Now(), Valid: true}
+		pt.StartedAt = now
+		pt.CompletedAt = now
+
+		err := jt.pkgSvc.CreatePreservationTask(ctx, &pt)
+		if err != nil {
+			return 0, err
+		}
+
+		// Add this job ID to the list of savedIDs.
+		jt.savedIDs[job.ID] = struct{}{}
+		count++
+	}
+
+	return count, nil
+}
+
+// filterSavedJobs filters out jobs that have an ID in saved then returns the
+// filtered job list.
+func filterSavedJobs(jobs []amclient.Job, saved map[string]struct{}) []amclient.Job {
+	var unsaved []amclient.Job
+	for _, job := range jobs {
+		if _, ok := saved[job.ID]; !ok {
+			unsaved = append(unsaved, job)
+		}
+	}
+	return unsaved
+}
+
+// ConvertJobToPreservationTask converts an amclient.Job to a
+// package_.PreservationTask.
+func ConvertJobToPreservationTask(job amclient.Job) package_.PreservationTask {
+	return package_.PreservationTask{
+		TaskID: job.ID,
+		Name:   job.Name,
+		Status: jobStatusToPreservationTaskStatus[job.Status],
+	}
+}

--- a/internal/am/job_tracker_test.go
+++ b/internal/am/job_tracker_test.go
@@ -1,0 +1,163 @@
+package am_test
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+	"go.artefactual.dev/amclient"
+	"go.artefactual.dev/amclient/amclienttest"
+	"go.artefactual.dev/tools/mockutil"
+	temporal_tools "go.artefactual.dev/tools/temporal"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/am"
+	fake_package "github.com/artefactual-sdps/enduro/internal/package_/fake"
+)
+
+func TestJobTracker(t *testing.T) {
+	t.Parallel()
+
+	paID := uint(1)
+	unitID := uuid.New().String()
+
+	clock := clockwork.NewFakeClock()
+	nullTime := sql.NullTime{Time: clock.Now(), Valid: true}
+	httpError := func(m *amclienttest.MockJobsServiceMockRecorder, statusCode int) {
+		m.List(
+			mockutil.Context(),
+			unitID,
+			&amclient.JobsListRequest{},
+		).Return(
+			nil,
+			&amclient.Response{Response: &http.Response{StatusCode: statusCode}},
+			&amclient.ErrorResponse{Response: &http.Response{StatusCode: statusCode}},
+		)
+	}
+
+	jobs := []amclient.Job{
+		{
+			ID:           "f60018ac-da79-4769-9509-c6c41d5efe7e",
+			LinkID:       "70669a5b-01e4-4ea0-ac70-10292f87da05",
+			Microservice: "Verify SIP compliance",
+			Name:         "Move to processing directory",
+			Status:       amclient.JobStatusComplete,
+			Tasks: []amclient.Task{
+				{
+					ID:       "c134198c-9485-4f68-8d94-4da1e03b5e1b",
+					ExitCode: 0,
+				},
+			},
+		},
+		{
+			ID:           "c2128d39-2ace-47c5-8cac-39ded8d9c9ef",
+			LinkID:       "208d441b-6938-44f9-b54a-bd73f05bc764",
+			Microservice: "Verify SIP compliance",
+			Name:         "Verify SIP compliance",
+			Status:       amclient.JobStatusComplete,
+			Tasks: []amclient.Task{
+				{
+					ID:       "6f5beca3-71ad-446c-8f19-3bc4dea16c9b",
+					ExitCode: 0,
+				},
+			},
+		},
+	}
+
+	type test struct {
+		name       string
+		jobRec     func(*amclienttest.MockJobsServiceMockRecorder, int)
+		pkgRec     func(*fake_package.MockServiceMockRecorder)
+		statusCode int
+
+		want         int
+		wantErr      string
+		retryableErr bool
+	}
+	for _, tt := range []test{
+		{
+			name: "Updates preservation action tasks",
+			jobRec: func(m *amclienttest.MockJobsServiceMockRecorder, statusCode int) {
+				m.List(
+					mockutil.Context(),
+					unitID,
+					&amclient.JobsListRequest{},
+				).Return(
+					jobs,
+					&amclient.Response{
+						Response: &http.Response{StatusCode: http.StatusOK, Status: "200 OK"},
+					},
+					nil,
+				)
+			},
+			pkgRec: func(m *fake_package.MockServiceMockRecorder) {
+				for _, job := range jobs {
+					pt := am.ConvertJobToPreservationTask(job)
+					pt.PreservationActionID = paID
+					pt.StartedAt = nullTime
+					pt.CompletedAt = nullTime
+					m.CreatePreservationTask(mockutil.Context(), &pt).Return(nil)
+				}
+			},
+			want: 2,
+		},
+		{
+			name: "Retryable error when AM returns 400 Bad Request",
+			jobRec: func(m *amclienttest.MockJobsServiceMockRecorder, statusCode int) {
+				// AM sometimes returns a "400 Bad Request" error when a
+				// transfer is processing.
+				m.List(
+					mockutil.Context(),
+					unitID,
+					&amclient.JobsListRequest{},
+				).Return(
+					nil,
+					&amclient.Response{
+						Response: &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad request"},
+					},
+					&amclient.ErrorResponse{
+						Response: &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad request"},
+					},
+				)
+			},
+			wantErr:      am.ErrBadRequest.Error(),
+			retryableErr: true,
+		},
+		{
+			name:       "Non-retryable error from http invalid credentials",
+			jobRec:     httpError,
+			statusCode: http.StatusUnauthorized,
+			wantErr:    "invalid Archivematica credentials",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			jobsSvc := amclienttest.NewMockJobsService(ctrl)
+			if tt.jobRec != nil {
+				tt.jobRec(jobsSvc.EXPECT(), tt.statusCode)
+			}
+			pkgSvc := fake_package.NewMockService(ctrl)
+			if tt.pkgRec != nil {
+				tt.pkgRec(pkgSvc.EXPECT())
+			}
+
+			pa := am.NewJobTracker(clock, jobsSvc, pkgSvc, paID)
+			got, err := pa.SavePreservationTasks(context.Background(), unitID)
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				assert.Assert(t, temporal_tools.NonRetryableError(err) != tt.retryableErr)
+
+				return
+			}
+
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/internal/am/poll_ingest.go
+++ b/internal/am/poll_ingest.go
@@ -50,7 +50,7 @@ func (a *PollIngestActivity) Execute(ctx context.Context, params *PollIngestActi
 		case <-ticker.C:
 			reqCtx, cancel := context.WithTimeout(ctx, a.cfg.PollInterval/2)
 			resp, httpResp, err := a.poll(reqCtx, params.SIPID, cancel)
-			if err == errWorkOngoing {
+			if err == ErrWorkOngoing {
 				// Send a heartbeat then continue polling after the poll interval.
 				temporalsdk_activity.RecordHeartbeat(ctx, fmt.Sprintf("Last HTTP response: %v", httpResp.Status))
 				continue
@@ -83,8 +83,8 @@ func (a *PollIngestActivity) poll(ctx context.Context, transferID string, cancel
 		amErr := convertAMClientError(httpResp, err)
 
 		// Continue polling on a "400 Bad request" response.
-		if amErr == errBadRequest {
-			return resp, httpResp, errWorkOngoing
+		if amErr == ErrBadRequest {
+			return resp, httpResp, ErrWorkOngoing
 		}
 
 		return resp, httpResp, amErr
@@ -98,5 +98,5 @@ func (a *PollIngestActivity) poll(ctx context.Context, transferID string, cancel
 		return resp, httpResp, nil
 	}
 
-	return resp, httpResp, errWorkOngoing
+	return resp, httpResp, ErrWorkOngoing
 }

--- a/internal/am/poll_transfer.go
+++ b/internal/am/poll_transfer.go
@@ -7,42 +7,73 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/jonboulle/clockwork"
 	"go.artefactual.dev/amclient"
 	temporal_tools "go.artefactual.dev/tools/temporal"
 	temporalsdk_activity "go.temporal.io/sdk/activity"
+
+	"github.com/artefactual-sdps/enduro/internal/package_"
 )
 
 const PollTransferActivityName = "poll-transfer-activity"
 
 type PollTransferActivityParams struct {
-	TransferID string
+	PresActionID uint
+	TransferID   string
 }
 
 type PollTransferActivity struct {
 	logger logr.Logger
 	cfg    *Config
-	amts   amclient.TransferService
+	clock  clockwork.Clock
+	jobSvc amclient.JobsService
+	pkgSvc package_.Service
+	tfrSvc amclient.TransferService
 }
 
 type PollTransferActivityResult struct {
-	SIPID string
-	Path  string
+	SIPID         string
+	Path          string
+	PresTaskCount int
 }
 
-func NewPollTransferActivity(logger logr.Logger, cfg *Config, amts amclient.TransferService) *PollTransferActivity {
-	return &PollTransferActivity{logger: logger, cfg: cfg, amts: amts}
+func NewPollTransferActivity(
+	logger logr.Logger,
+	cfg *Config,
+	clock clockwork.Clock,
+	jobSvc amclient.JobsService,
+	pkgSvc package_.Service,
+	tfrSvc amclient.TransferService,
+) *PollTransferActivity {
+	return &PollTransferActivity{
+		logger: logger,
+		cfg:    cfg,
+		clock:  clock,
+		jobSvc: jobSvc,
+		pkgSvc: pkgSvc,
+		tfrSvc: tfrSvc,
+	}
 }
 
 // Execute polls Archivematica for the status of a transfer and returns when
 // the transfer is complete or returns an error status. Execute sends an
 // activity heartbeat after each poll.
 //
+// On each poll, Execute requests an updated list of AM jobs performed and saves
+// the job data to the package service as preservation tasks.
+//
 // A transfer status of "REJECTED", "FAILED", "USER_INPUT", or "BACKLOG" returns
 // a temporal.NonRetryableApplicationError to indicate that processing can not
 // continue.
 func (a *PollTransferActivity) Execute(ctx context.Context, params *PollTransferActivityParams) (*PollTransferActivityResult, error) {
-	a.logger.V(1).Info("Executing PollTransferActivity", "TransferID", params.TransferID)
+	var taskCount int
 
+	a.logger.V(1).Info("Executing PollTransferActivity",
+		"PresActionID", params.PresActionID,
+		"TransferID", params.TransferID,
+	)
+
+	jobTracker := NewJobTracker(a.clock, a.jobSvc, a.pkgSvc, params.PresActionID)
 	ticker := time.NewTicker(a.cfg.PollInterval)
 	defer ticker.Stop()
 
@@ -51,59 +82,90 @@ func (a *PollTransferActivity) Execute(ctx context.Context, params *PollTransfer
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-ticker.C:
-			reqCtx, cancel := context.WithTimeout(ctx, a.cfg.PollInterval/2)
-			resp, httpResp, err := a.poll(reqCtx, params.TransferID, cancel)
-			if err == errWorkOngoing {
+			resp, count, err := a.poll(ctx, jobTracker, params.TransferID)
+			if err == ErrWorkOngoing {
+				taskCount += count
+
 				// Send a heartbeat then continue polling after the poll interval.
-				temporalsdk_activity.RecordHeartbeat(ctx, fmt.Sprintf("Last HTTP response: %v", httpResp.Status))
+				temporalsdk_activity.RecordHeartbeat(ctx, fmt.Sprintf("preservation tasks completed: %d", taskCount))
 				continue
 			}
 			if err != nil {
 				return nil, err
 			}
 
-			return &PollTransferActivityResult{SIPID: resp.SIPID, Path: resp.Path}, nil
+			taskCount += count
+
+			return &PollTransferActivityResult{SIPID: resp.SIPID, Path: resp.Path, PresTaskCount: taskCount}, nil
 		}
 	}
 }
 
-// poll polls the Archivematica transfer status endpoint, returning a non-nil
-// result if transfer processing is complete. An errWorkOngoing error indicates
-// work is ongoing and polling should continue. All other errors should
-// terminate polling.
-func (a *PollTransferActivity) poll(ctx context.Context, transferID string, cancel context.CancelFunc) (*amclient.TransferStatusResponse, *amclient.Response, error) {
-	// Cancel the context timer when we return so it doesn't wait for the
-	// timeout deadline to expire.
+// poll queries Archivematica for transfer status and job progress, returning a
+// non-nil result if transfer processing is ongoing or complete. An
+// ErrWorkOngoing error indicates work is ongoing and polling should continue.
+// All other errors should terminate polling.
+//
+// If the transfer is still in progress or completed successfully, poll saves
+// the AM jobs progress as preservation tasks via JobTracker.
+func (a *PollTransferActivity) poll(ctx context.Context, jobTracker *JobTracker, transferID string) (*amclient.TransferStatusResponse, int, error) {
+	var stillWorking bool
+
+	// Add a context timeout to prevent missing the heartbeat deadline.
+	ctx, cancel := context.WithTimeout(ctx, a.cfg.PollInterval)
 	defer cancel()
 
-	resp, httpResp, err := a.amts.Status(ctx, transferID)
+	resp, err := a.transferStatus(ctx, transferID)
 	if err != nil {
-		a.logger.V(2).Info("Poll transfer error",
-			"StatusCode", httpResp.StatusCode,
-			"Status", httpResp.Status,
-		)
-
-		amErr := convertAMClientError(httpResp, err)
-
-		// Continue polling on a "400 Bad request" response.
-		if amErr == errBadRequest {
-			return resp, httpResp, errWorkOngoing
+		switch err {
+		case ErrBadRequest:
+			// Continue polling on a "400 Bad request" response, but don't try
+			// and save jobs progress; the jobs endpoint will most likely return
+			// a 400 error or an empty jobs list.
+			return resp, 0, ErrWorkOngoing
+		case ErrWorkOngoing:
+			// Save job progress before returning.
+			stillWorking = true
+		default:
+			return nil, 0, err
 		}
+	}
 
-		return resp, httpResp, amErr
+	// Save job progress as preservation tasks.
+	count, err := jobTracker.SavePreservationTasks(ctx, transferID)
+	if err == ErrBadRequest {
+		// Continue polling on a "400 Bad request" response.
+		return resp, 0, ErrWorkOngoing
+	}
+	if err != nil {
+		return nil, 0, fmt.Errorf("save preservation tasks: %v", err)
+	}
+
+	// Continue polling.
+	if stillWorking {
+		return resp, count, ErrWorkOngoing
+	}
+
+	return resp, count, nil
+}
+
+func (a *PollTransferActivity) transferStatus(ctx context.Context, transferID string) (*amclient.TransferStatusResponse, error) {
+	resp, httpResp, err := a.tfrSvc.Status(ctx, transferID)
+	if err != nil {
+		return resp, convertAMClientError(httpResp, err)
 	}
 
 	complete, err := isComplete(resp.Status)
 	if err != nil {
-		return resp, httpResp, err
+		return resp, err
 	}
 	if complete {
 		if resp.SIPID == "BACKLOG" {
-			return resp, httpResp, temporal_tools.NewNonRetryableError(errors.New("Archivematica SIP sent to backlog"))
+			return resp, temporal_tools.NewNonRetryableError(errors.New("Archivematica SIP sent to backlog"))
 		}
 
-		return resp, httpResp, nil
+		return resp, nil
 	}
 
-	return resp, httpResp, errWorkOngoing
+	return resp, ErrWorkOngoing
 }

--- a/internal/am/poll_transfer_test.go
+++ b/internal/am/poll_transfer_test.go
@@ -1,12 +1,14 @@
 package am_test
 
 import (
+	"database/sql"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
 	"go.artefactual.dev/amclient"
 	"go.artefactual.dev/amclient/amclienttest"
 	"go.artefactual.dev/tools/mockutil"
@@ -17,27 +19,62 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/artefactual-sdps/enduro/internal/am"
+	fake_package "github.com/artefactual-sdps/enduro/internal/package_/fake"
+)
+
+var (
+	http200Resp = http.Response{StatusCode: http.StatusOK, Status: "200 OK"}
+	http400Resp = http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad request"}
 )
 
 func TestPollTransferActivity(t *testing.T) {
+	t.Parallel()
+
 	transferID := uuid.New().String()
+	presActionID := uint(1)
 	sipID := uuid.New().String()
 	path := "/var/archivematica/fake/sip"
-	httpError := func(m *amclienttest.MockTransferServiceMockRecorder, statusCode int) {
-		m.Status(
-			mockutil.Context(),
-			transferID,
-		).Return(
-			nil,
-			&amclient.Response{Response: &http.Response{StatusCode: statusCode}},
-			&amclient.ErrorResponse{Response: &http.Response{StatusCode: statusCode}},
-		)
+	ttime, err := time.Parse(time.RFC3339, "2023-12-05T12:02:00Z")
+	if err != nil {
+		t.Fatal("Invalid test time")
+	}
+	nullTime := sql.NullTime{Time: ttime, Valid: true}
+
+	jobs := []amclient.Job{
+		{
+			ID:           "f60018ac-da79-4769-9509-c6c41d5efe7e",
+			LinkID:       "70669a5b-01e4-4ea0-ac70-10292f87da05",
+			Microservice: "Verify SIP compliance",
+			Name:         "Move to processing directory",
+			Status:       amclient.JobStatusComplete,
+			Tasks: []amclient.Task{
+				{
+					ID:       "c134198c-9485-4f68-8d94-4da1e03b5e1b",
+					ExitCode: 0,
+				},
+			},
+		},
+		{
+			ID:           "c2128d39-2ace-47c5-8cac-39ded8d9c9ef",
+			LinkID:       "208d441b-6938-44f9-b54a-bd73f05bc764",
+			Microservice: "Verify SIP compliance",
+			Name:         "Verify SIP compliance",
+			Status:       amclient.JobStatusComplete,
+			Tasks: []amclient.Task{
+				{
+					ID:       "6f5beca3-71ad-446c-8f19-3bc4dea16c9b",
+					ExitCode: 0,
+				},
+			},
+		},
 	}
 
 	type test struct {
 		name         string
-		statusCode   int
-		mockr        func(*amclienttest.MockTransferServiceMockRecorder, int)
+		params       *am.PollTransferActivityParams
+		tfrRec       func(*amclienttest.MockTransferServiceMockRecorder)
+		jobRec       func(*amclienttest.MockJobsServiceMockRecorder)
+		pkgRec       func(*fake_package.MockServiceMockRecorder)
 		want         am.PollTransferActivityResult
 		wantErr      string
 		retryableErr bool
@@ -45,49 +82,86 @@ func TestPollTransferActivity(t *testing.T) {
 	for _, tt := range []test{
 		{
 			name: "Polls twice then returns successfully",
-			mockr: func(m *amclienttest.MockTransferServiceMockRecorder, statusCode int) {
-				// AM sometimes returns a "400 Bad Request" error when a
+			params: &am.PollTransferActivityParams{
+				PresActionID: presActionID,
+				TransferID:   transferID,
+			},
+			tfrRec: func(m *amclienttest.MockTransferServiceMockRecorder) {
+				// First poll. AM sometimes returns a "400 Bad Request" error
+				// when transfer processing has just started.
+				m.Status(
+					mockutil.Context(),
+					transferID,
+				).Return(
+					nil,
+					&amclient.Response{Response: &http400Resp},
+					&amclient.ErrorResponse{Response: &http400Resp},
+				)
+
+				// Second poll. AM usually returns a "200 OK" response when a
 				// transfer is processing.
 				m.Status(
 					mockutil.Context(),
 					transferID,
 				).Return(
+					&amclient.TransferStatusResponse{Status: "PROCESSING"},
+					&amclient.Response{Response: &http200Resp},
 					nil,
-					&amclient.Response{
-						Response: &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad request"},
-					},
-					&amclient.ErrorResponse{
-						Response: &http.Response{StatusCode: http.StatusBadRequest, Status: "400 Bad request"},
-					},
 				)
 
-				// AM sometimes returns a "200 OK" response when a transfer is
-				// processing.
-				m.Status(
-					mockutil.Context(),
-					transferID,
-				).Return(
-					&amclient.TransferStatusResponse{Status: "PROCESSING"},
-					&amclient.Response{
-						Response: &http.Response{StatusCode: http.StatusOK, Status: "200 OK"},
-					},
-					nil,
-				)
+				// Third poll. Complete transfer.
 				m.Status(
 					mockutil.Context(),
 					transferID,
 				).Return(
 					&amclient.TransferStatusResponse{Status: "COMPLETE", SIPID: sipID, Path: path},
-					nil,
+					&amclient.Response{Response: &http200Resp},
 					nil,
 				)
 			},
-			want:         am.PollTransferActivityResult{SIPID: sipID, Path: path},
-			retryableErr: true,
+			jobRec: func(m *amclienttest.MockJobsServiceMockRecorder) {
+				// Second poll.
+				m.List(
+					mockutil.Context(),
+					transferID,
+					&amclient.JobsListRequest{},
+				).Return(
+					jobs,
+					&amclient.Response{Response: &http200Resp},
+					nil,
+				)
+
+				// Third poll. These jobs were saved on the previous poll, so
+				// they shouldn't be saved again.
+				m.List(
+					mockutil.Context(),
+					transferID,
+					&amclient.JobsListRequest{},
+				).Return(
+					jobs,
+					&amclient.Response{Response: &http200Resp},
+					nil,
+				)
+			},
+			pkgRec: func(m *fake_package.MockServiceMockRecorder) {
+				// Second poll.
+				for _, job := range jobs {
+					pt := am.ConvertJobToPreservationTask(job)
+					pt.PreservationActionID = presActionID
+					pt.CompletedAt = nullTime
+					pt.StartedAt = nullTime
+					m.CreatePreservationTask(mockutil.Context(), &pt).Return(nil)
+				}
+			},
+			want: am.PollTransferActivityResult{
+				SIPID:         sipID,
+				Path:          path,
+				PresTaskCount: 2,
+			},
 		},
 		{
 			name: "Non-retryable error because SIP is in BACKLOG",
-			mockr: func(m *amclienttest.MockTransferServiceMockRecorder, statusCode int) {
+			tfrRec: func(m *amclienttest.MockTransferServiceMockRecorder) {
 				m.Status(
 					mockutil.Context(),
 					transferID,
@@ -101,7 +175,7 @@ func TestPollTransferActivity(t *testing.T) {
 		},
 		{
 			name: "Non-retryable error from an unknown response status",
-			mockr: func(m *amclienttest.MockTransferServiceMockRecorder, statusCode int) {
+			tfrRec: func(m *amclienttest.MockTransferServiceMockRecorder) {
 				m.Status(
 					mockutil.Context(),
 					transferID,
@@ -115,7 +189,7 @@ func TestPollTransferActivity(t *testing.T) {
 		},
 		{
 			name: "Non-retryable error because transfer failed",
-			mockr: func(m *amclienttest.MockTransferServiceMockRecorder, statusCode int) {
+			tfrRec: func(m *amclienttest.MockTransferServiceMockRecorder) {
 				m.Status(
 					mockutil.Context(),
 					transferID,
@@ -128,22 +202,68 @@ func TestPollTransferActivity(t *testing.T) {
 			wantErr: "Archivematica response status: FAILED",
 		},
 		{
-			name:       "Non-retryable error from http invalid credentials",
-			mockr:      httpError,
-			statusCode: http.StatusUnauthorized,
-			wantErr:    "invalid Archivematica credentials",
+			name: "Retryable error on 500 Internal Server Error",
+			tfrRec: func(m *amclienttest.MockTransferServiceMockRecorder) {
+				httpResp := http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Status:     "500 Internal Server Error",
+				}
+				m.Status(
+					mockutil.Context(),
+					transferID,
+				).Return(
+					nil,
+					&amclient.Response{Response: &httpResp},
+					&amclient.ErrorResponse{Response: &httpResp},
+				)
+			},
+			wantErr:      "Archivematica error: 500 Internal Server Error",
+			retryableErr: true,
 		},
 		{
-			name:       "Non-retryable error from http insufficient permissions",
-			mockr:      httpError,
-			statusCode: http.StatusForbidden,
-			wantErr:    "insufficient Archivematica permissions",
+			name: "Non-retryable error from http invalid credentials",
+			tfrRec: func(m *amclienttest.MockTransferServiceMockRecorder) {
+				httpResp := http.Response{StatusCode: http.StatusUnauthorized}
+				m.Status(
+					mockutil.Context(),
+					transferID,
+				).Return(
+					nil,
+					&amclient.Response{Response: &httpResp},
+					&amclient.ErrorResponse{Response: &httpResp},
+				)
+			},
+			wantErr: "invalid Archivematica credentials",
 		},
 		{
-			name:       "Non-retryable error from http not found response",
-			mockr:      httpError,
-			statusCode: http.StatusNotFound,
-			wantErr:    "Archivematica resource not found",
+			name: "Non-retryable error from http insufficient permissions",
+			tfrRec: func(m *amclienttest.MockTransferServiceMockRecorder) {
+				httpResp := http.Response{StatusCode: http.StatusForbidden}
+				m.Status(
+					mockutil.Context(),
+					transferID,
+				).Return(
+					nil,
+					&amclient.Response{Response: &httpResp},
+					&amclient.ErrorResponse{Response: &httpResp},
+				)
+			},
+			wantErr: "insufficient Archivematica permissions",
+		},
+		{
+			name: "Non-retryable error from http not found response",
+			tfrRec: func(m *amclienttest.MockTransferServiceMockRecorder) {
+				httpResp := http.Response{StatusCode: http.StatusNotFound}
+				m.Status(
+					mockutil.Context(),
+					transferID,
+				).Return(
+					nil,
+					&amclient.Response{Response: &httpResp},
+					&amclient.ErrorResponse{Response: &httpResp},
+				)
+			},
+			wantErr: "Archivematica resource not found",
 		},
 	} {
 		tt := tt
@@ -153,17 +273,30 @@ func TestPollTransferActivity(t *testing.T) {
 			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
 			env := ts.NewTestActivityEnvironment()
 			ctrl := gomock.NewController(t)
-			amts := amclienttest.NewMockTransferService(ctrl)
 
-			if tt.mockr != nil {
-				tt.mockr(amts.EXPECT(), tt.statusCode)
+			trfSvc := amclienttest.NewMockTransferService(ctrl)
+			if tt.tfrRec != nil {
+				tt.tfrRec(trfSvc.EXPECT())
+			}
+
+			jobSvc := amclienttest.NewMockJobsService(ctrl)
+			if tt.jobRec != nil {
+				tt.jobRec(jobSvc.EXPECT())
+			}
+
+			pkgSvc := fake_package.NewMockService(ctrl)
+			if tt.pkgRec != nil {
+				tt.pkgRec(pkgSvc.EXPECT())
 			}
 
 			env.RegisterActivityWithOptions(
 				am.NewPollTransferActivity(
 					logr.Discard(),
 					&am.Config{PollInterval: time.Millisecond * 10},
-					amts,
+					clockwork.NewFakeClockAt(ttime),
+					jobSvc,
+					pkgSvc,
+					trfSvc,
 				).Execute,
 				temporalsdk_activity.RegisterOptions{
 					Name: am.PollTransferActivityName,
@@ -172,11 +305,14 @@ func TestPollTransferActivity(t *testing.T) {
 
 			enc, err := env.ExecuteActivity(
 				am.PollTransferActivityName,
-				am.PollTransferActivityParams{TransferID: transferID},
+				am.PollTransferActivityParams{
+					PresActionID: presActionID,
+					TransferID:   transferID,
+				},
 			)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
-				assert.Assert(t, temporal_tools.NonRetryableError(err))
+				assert.Assert(t, temporal_tools.NonRetryableError(err) != tt.retryableErr)
 
 				return
 			}

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -712,7 +712,10 @@ func (w *ProcessingWorkflow) transferAM(sessCtx temporalsdk_workflow.Context, ti
 	err = temporalsdk_workflow.ExecuteActivity(
 		pollOpts,
 		am.PollTransferActivityName,
-		am.PollTransferActivityParams{TransferID: transferResult.TransferID}, //nolint:gosimple
+		am.PollTransferActivityParams{
+			PresActionID: tinfo.PreservationActionID,
+			TransferID:   transferResult.TransferID,
+		},
 	).Get(pollOpts, &pollTransferResult)
 	if err != nil {
 		return err


### PR DESCRIPTION
Related issue #783.

- Create an `am.Jobs` package to query the AM jobs endpoint, and save the data to the package service as preservation tasks
- Integrate `am.Jobs` into PollTransferActivity
- Set the preservation task `startedAt` and `completedAt` to the current time when saving the data to the database becuase the Enduro dashboard won't show tasks that don't have a `startedAt` time