### PR TITLE
Fix download activity parameters and returns

### DIFF
--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -135,7 +135,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		w.RegisterActivityWithOptions(activities.NewDownloadActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{Name: activities.DownloadActivityName})
+		w.RegisterActivityWithOptions(activities.NewDownloadActivity(logger, wsvc).Execute, temporalsdk_activity.RegisterOptions{Name: activities.DownloadActivityName})
 		w.RegisterActivityWithOptions(activities.NewBundleActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{Name: activities.BundleActivityName})
 		w.RegisterActivityWithOptions(a3m.NewCreateAIPActivity(logger, &cfg.A3m, pkgsvc).Execute, temporalsdk_activity.RegisterOptions{Name: a3m.CreateAIPActivityName})
 		w.RegisterActivityWithOptions(activities.NewCleanUpActivity().Execute, temporalsdk_activity.RegisterOptions{Name: activities.CleanUpActivityName})

--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -140,7 +140,7 @@ func main() {
 		amc := amclient.NewClient(httpClient, cfg.AM.Address, cfg.AM.User, cfg.AM.APIKey)
 
 		w.RegisterActivityWithOptions(
-			activities.NewDownloadActivity(wsvc).Execute,
+			activities.NewDownloadActivity(logger, wsvc).Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.DownloadActivityName},
 		)
 		w.RegisterActivityWithOptions(

--- a/internal/workflow/activities/download_test.go
+++ b/internal/workflow/activities/download_test.go
@@ -1,0 +1,97 @@
+package activities_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"go.artefactual.dev/tools/mockutil"
+	"go.artefactual.dev/tools/temporal"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+
+	watcherfake "github.com/artefactual-sdps/enduro/internal/watcher/fake"
+	"github.com/artefactual-sdps/enduro/internal/workflow/activities"
+)
+
+func TestDownloadActivity(t *testing.T) {
+	key := "transfer.zip"
+	watcherName := "watcher"
+
+	type test struct {
+		name    string
+		params  *activities.DownloadActivityParams
+		rec     func(*watcherfake.MockServiceMockRecorder)
+		want    string
+		wantErr string
+	}
+	for _, tt := range []test{
+		{
+			name: "Downloads blob to a temp dir",
+			params: &activities.DownloadActivityParams{
+				Key:         key,
+				WatcherName: watcherName,
+			},
+			rec: func(r *watcherfake.MockServiceMockRecorder) {
+				r.Download(mockutil.Context(), gomock.AssignableToTypeOf((*os.File)(nil)), watcherName, key).
+					DoAndReturn(func(ctx context.Context, w io.Writer, watcherName, key string) error {
+						_, err := w.Write([]byte("’Twas brillig, and the slithy toves Did gyre and gimble in the wabe:"))
+						return err
+					})
+			},
+			want: "’Twas brillig, and the slithy toves Did gyre and gimble in the wabe:",
+		},
+		{
+			name: "Non-retryable error when download fails",
+			params: &activities.DownloadActivityParams{
+				Key:         key,
+				WatcherName: watcherName,
+			},
+			rec: func(r *watcherfake.MockServiceMockRecorder) {
+				r.Download(mockutil.Context(), gomock.AssignableToTypeOf((*os.File)(nil)), watcherName, key).Return(
+					fmt.Errorf("error loading watcher: unknown watcher %s", watcherName),
+				)
+			},
+			wantErr: fmt.Sprintf("activity error (type: download-activity, scheduledEventID: 0, startedEventID: 0, identity: ): download blob: error loading watcher: unknown watcher %s", watcherName),
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			wsvc := watcherfake.NewMockService(gomock.NewController(t))
+			if tt.rec != nil {
+				tt.rec(wsvc.EXPECT())
+			}
+
+			env.RegisterActivityWithOptions(
+				activities.NewDownloadActivity(logr.Discard(), wsvc).Execute,
+				temporalsdk_activity.RegisterOptions{
+					Name: activities.DownloadActivityName,
+				},
+			)
+
+			enc, err := env.ExecuteActivity(activities.DownloadActivityName, tt.params)
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				assert.Assert(t, temporal.NonRetryableError(err))
+				return
+			}
+			assert.NilError(t, err)
+
+			var res activities.DownloadActivityResult
+			_ = enc.Get(&res)
+
+			got, err := os.ReadFile(res.Path)
+			assert.NilError(t, err)
+			assert.Equal(t, string(got), tt.want)
+		})
+	}
+}

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -298,11 +298,16 @@ func (w *ProcessingWorkflow) SessionHandler(sessCtx temporalsdk_workflow.Context
 			// session retry where a different worker is doing the work. In that
 			// case, the activity whould be executed again.
 			if tinfo.TempFile == "" {
+				var downloadResult activities.DownloadActivityResult
 				activityOpts := withActivityOptsForLongLivedRequest(sessCtx)
-				err := temporalsdk_workflow.ExecuteActivity(activityOpts, activities.DownloadActivityName, tinfo.req.WatcherName, tinfo.req.Key).Get(activityOpts, &tinfo.TempFile)
+				err := temporalsdk_workflow.ExecuteActivity(activityOpts, activities.DownloadActivityName, &activities.DownloadActivityParams{
+					Key:         tinfo.req.Key,
+					WatcherName: tinfo.req.WatcherName,
+				}).Get(activityOpts, &downloadResult)
 				if err != nil {
 					return err
 				}
+				tinfo.TempFile = downloadResult.Path
 			}
 		}
 	}


### PR DESCRIPTION
- Use structs for the activity parameters and return value for future safety
- Change watcher server `Download()` method so it accepts a destination filepath (string) instead of a file writer to allow testing without needing to pass an open file writer
- Add a logger and log the download activity execution parameters
- Add unit tests
- Update workflow tests