### PR TITLE
Don't retry SSH connection when auth fails

### DIFF
--- a/internal/am/upload_transfer_test.go
+++ b/internal/am/upload_transfer_test.go
@@ -94,12 +94,12 @@ func TestUploadTransferActivity(t *testing.T) {
 				).Return(
 					0,
 					"",
-					sftp.NewAuthError(
-						errors.New("ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"),
-					),
+					&sftp.AuthError{
+						Message: "ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain",
+					},
 				)
 			},
-			wantErr:         "activity error (type: UploadTransferActivity, scheduledEventID: 0, startedEventID: 0, identity: ): UploadTransferActivity: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain",
+			wantErr:         "activity error (type: UploadTransferActivity, scheduledEventID: 0, startedEventID: 0, identity: ): UploadTransferActivity: auth: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain",
 			wantNonRetryErr: true,
 		},
 	} {

--- a/internal/sftp/client.go
+++ b/internal/sftp/client.go
@@ -2,23 +2,20 @@ package sftp
 
 import (
 	"context"
+	"fmt"
 	"io"
 )
 
 type AuthError struct {
-	err error
+	Message string
 }
 
 func (e *AuthError) Error() string {
-	return e.err.Error()
+	return fmt.Sprintf("auth: %s", e.Message)
 }
 
-func (e *AuthError) Unwrap() error {
-	return e.err
-}
-
-func NewAuthError(e error) *AuthError {
-	return &AuthError{err: e}
+func NewAuthError(e error) error {
+	return &AuthError{Message: e.Error()}
 }
 
 // A Client manages the transmission of data over SFTP.

--- a/internal/sftp/client.go
+++ b/internal/sftp/client.go
@@ -5,6 +5,22 @@ import (
 	"io"
 )
 
+type AuthError struct {
+	err error
+}
+
+func (e *AuthError) Error() string {
+	return e.err.Error()
+}
+
+func (e *AuthError) Unwrap() error {
+	return e.err
+}
+
+func NewAuthError(e error) *AuthError {
+	return &AuthError{err: e}
+}
+
 // A Client manages the transmission of data over SFTP.
 //
 // Implementations of the Client interface handle the connection details,

--- a/internal/sftp/goclient.go
+++ b/internal/sftp/goclient.go
@@ -101,7 +101,7 @@ func (c *GoClient) dial(ctx context.Context) (*connection, error) {
 
 	conn.ssh, err = sshConnect(ctx, c.logger, c.cfg)
 	if err != nil {
-		return nil, fmt.Errorf("SSH: %v", err)
+		return nil, err
 	}
 
 	conn.sftp, err = sftp.NewClient(conn.ssh)

--- a/internal/sftp/goclient_test.go
+++ b/internal/sftp/goclient_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -233,9 +232,9 @@ func TestUpload(t *testing.T) {
 				src:  strings.NewReader("Testing 1-2-3"),
 				dest: "test.txt",
 			},
-			wantErr: sftp.NewAuthError(
-				errors.New("ssh: parse private key with passphrase: x509: decryption password incorrect"),
-			),
+			wantErr: &sftp.AuthError{
+				Message: "ssh: parse private key with passphrase: x509: decryption password incorrect",
+			},
 		},
 		{
 			name: "Errors when the SFTP server isn't there",
@@ -266,9 +265,9 @@ func TestUpload(t *testing.T) {
 					Path: "./testdata/clientkeys/test_unk_ed25519",
 				},
 			},
-			wantErr: sftp.NewAuthError(
-				errors.New("ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"),
-			),
+			wantErr: &sftp.AuthError{
+				Message: "ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain",
+			},
 		},
 		{
 			name: "Errors when the host key is not in known_hosts",
@@ -280,9 +279,9 @@ func TestUpload(t *testing.T) {
 					Path: "./testdata/clientkeys/test_ed25519",
 				},
 			},
-			wantErr: sftp.NewAuthError(
-				errors.New("ssh: handshake failed: knownhosts: key is unknown"),
-			),
+			wantErr: &sftp.AuthError{
+				Message: "ssh: handshake failed: knownhosts: key is unknown",
+			},
 		},
 		{
 			name: "Errors when the known_hosts file doesn't exist",
@@ -294,9 +293,9 @@ func TestUpload(t *testing.T) {
 					Path: "./testdata/clientkeys/test_ed25519",
 				},
 			},
-			wantErr: sftp.NewAuthError(
-				errors.New("ssh: parse known_hosts: open testdata/missing: no such file or directory"),
-			),
+			wantErr: &sftp.AuthError{
+				Message: "ssh: parse known_hosts: open testdata/missing: no such file or directory",
+			},
 		},
 	} {
 		tc := tc

--- a/internal/sftp/ssh.go
+++ b/internal/sftp/ssh.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -17,12 +18,12 @@ import (
 // returns a client connection.
 //
 // Only private key authentication is currently supported, with or without a
-// passphrase.
+// passphrase.SSH: %v",
 func sshConnect(ctx context.Context, logger logr.Logger, cfg Config) (*ssh.Client, error) {
 	// Load private key for authentication.
 	keyBytes, err := os.ReadFile(filepath.Clean(cfg.PrivateKey.Path)) // #nosec G304 -- File data is validated below
 	if err != nil {
-		return nil, fmt.Errorf("read private key: %v", err)
+		return nil, NewAuthError(fmt.Errorf("ssh: read private key: %v", err))
 	}
 
 	// Create a signer from the private key, with or without a passphrase.
@@ -30,19 +31,19 @@ func sshConnect(ctx context.Context, logger logr.Logger, cfg Config) (*ssh.Clien
 	if cfg.PrivateKey.Passphrase != "" {
 		signer, err = ssh.ParsePrivateKeyWithPassphrase(keyBytes, []byte(cfg.PrivateKey.Passphrase))
 		if err != nil {
-			return nil, fmt.Errorf("parse private key with passphrase: %v", err)
+			return nil, NewAuthError(fmt.Errorf("ssh: parse private key with passphrase: %v", err))
 		}
 	} else {
 		signer, err = ssh.ParsePrivateKey(keyBytes)
 		if err != nil {
-			return nil, fmt.Errorf("parse private key: %v", err)
+			return nil, NewAuthError(fmt.Errorf("ssh: parse private key: %v", err))
 		}
 	}
 
 	// Check that the host key is in the client's known_hosts file.
 	hostcallback, err := knownhosts.New(filepath.Clean(cfg.KnownHostsFile))
 	if err != nil {
-		return nil, fmt.Errorf("parse known_hosts: %v", err)
+		return nil, NewAuthError(fmt.Errorf("ssh: parse known_hosts: %v", err))
 	}
 
 	// Configure the SSH client.
@@ -61,14 +62,18 @@ func sshConnect(ctx context.Context, logger logr.Logger, cfg Config) (*ssh.Clien
 	dialer := &net.Dialer{}
 	conn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
-		logger.V(2).Info("SSH dial failed", "address", address, "user", cfg.User)
-		return nil, fmt.Errorf("connect: %v", err)
+		logger.V(2).Info("ssh: dial failed", "address", address, "user", cfg.User)
+		return nil, fmt.Errorf("ssh: connect: %v", err)
 	}
 
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, address, sshConfig)
 	if err != nil {
-		logger.V(2).Info("SSH dial failed", "address", address, "user", cfg.User)
-		return nil, fmt.Errorf("connect: %v", err)
+		if strings.Contains(err.Error(), "ssh: unable to authenticate") || strings.Contains(err.Error(), "knownhosts: key is unknown") {
+			logger.V(2).Info("ssh: authentication failed", "address", address, "user", cfg.User)
+			return nil, NewAuthError(err)
+		}
+		logger.V(2).Info("ssh: failed to connect", "address", address, "user", cfg.User)
+		return nil, err
 	}
 
 	return ssh.NewClient(sshConn, chans, reqs), nil


### PR DESCRIPTION
Authentication failures can not be resolved by retrying the connection with the same credentials.