### PR TITLE
Use location and PackageReader for Download

### DIFF
--- a/internal/api/auth/fake/mock_ticket_store.go
+++ b/internal/api/auth/fake/mock_ticket_store.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -typed -destination=./internal/api/auth/fake/mock_ticket_store.go -package=fake github.com/artefactual-sdps/enduro/internal/api/auth TicketStore
 //
+
 // Package fake is a generated GoMock package.
 package fake
 
@@ -48,31 +49,31 @@ func (m *MockTicketStore) Close() error {
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockTicketStoreMockRecorder) Close() *TicketStoreCloseCall {
+func (mr *MockTicketStoreMockRecorder) Close() *MockTicketStoreCloseCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockTicketStore)(nil).Close))
-	return &TicketStoreCloseCall{Call: call}
+	return &MockTicketStoreCloseCall{Call: call}
 }
 
-// TicketStoreCloseCall wrap *gomock.Call
-type TicketStoreCloseCall struct {
+// MockTicketStoreCloseCall wrap *gomock.Call
+type MockTicketStoreCloseCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *TicketStoreCloseCall) Return(arg0 error) *TicketStoreCloseCall {
+func (c *MockTicketStoreCloseCall) Return(arg0 error) *MockTicketStoreCloseCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *TicketStoreCloseCall) Do(f func() error) *TicketStoreCloseCall {
+func (c *MockTicketStoreCloseCall) Do(f func() error) *MockTicketStoreCloseCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *TicketStoreCloseCall) DoAndReturn(f func() error) *TicketStoreCloseCall {
+func (c *MockTicketStoreCloseCall) DoAndReturn(f func() error) *MockTicketStoreCloseCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -86,31 +87,31 @@ func (m *MockTicketStore) GetDel(arg0 context.Context, arg1 string) error {
 }
 
 // GetDel indicates an expected call of GetDel.
-func (mr *MockTicketStoreMockRecorder) GetDel(arg0, arg1 any) *TicketStoreGetDelCall {
+func (mr *MockTicketStoreMockRecorder) GetDel(arg0, arg1 any) *MockTicketStoreGetDelCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDel", reflect.TypeOf((*MockTicketStore)(nil).GetDel), arg0, arg1)
-	return &TicketStoreGetDelCall{Call: call}
+	return &MockTicketStoreGetDelCall{Call: call}
 }
 
-// TicketStoreGetDelCall wrap *gomock.Call
-type TicketStoreGetDelCall struct {
+// MockTicketStoreGetDelCall wrap *gomock.Call
+type MockTicketStoreGetDelCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *TicketStoreGetDelCall) Return(arg0 error) *TicketStoreGetDelCall {
+func (c *MockTicketStoreGetDelCall) Return(arg0 error) *MockTicketStoreGetDelCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *TicketStoreGetDelCall) Do(f func(context.Context, string) error) *TicketStoreGetDelCall {
+func (c *MockTicketStoreGetDelCall) Do(f func(context.Context, string) error) *MockTicketStoreGetDelCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *TicketStoreGetDelCall) DoAndReturn(f func(context.Context, string) error) *TicketStoreGetDelCall {
+func (c *MockTicketStoreGetDelCall) DoAndReturn(f func(context.Context, string) error) *MockTicketStoreGetDelCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -124,31 +125,31 @@ func (m *MockTicketStore) SetEx(arg0 context.Context, arg1 string, arg2 time.Dur
 }
 
 // SetEx indicates an expected call of SetEx.
-func (mr *MockTicketStoreMockRecorder) SetEx(arg0, arg1, arg2 any) *TicketStoreSetExCall {
+func (mr *MockTicketStoreMockRecorder) SetEx(arg0, arg1, arg2 any) *MockTicketStoreSetExCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEx", reflect.TypeOf((*MockTicketStore)(nil).SetEx), arg0, arg1, arg2)
-	return &TicketStoreSetExCall{Call: call}
+	return &MockTicketStoreSetExCall{Call: call}
 }
 
-// TicketStoreSetExCall wrap *gomock.Call
-type TicketStoreSetExCall struct {
+// MockTicketStoreSetExCall wrap *gomock.Call
+type MockTicketStoreSetExCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *TicketStoreSetExCall) Return(arg0 error) *TicketStoreSetExCall {
+func (c *MockTicketStoreSetExCall) Return(arg0 error) *MockTicketStoreSetExCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *TicketStoreSetExCall) Do(f func(context.Context, string, time.Duration) error) *TicketStoreSetExCall {
+func (c *MockTicketStoreSetExCall) Do(f func(context.Context, string, time.Duration) error) *MockTicketStoreSetExCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *TicketStoreSetExCall) DoAndReturn(f func(context.Context, string, time.Duration) error) *TicketStoreSetExCall {
+func (c *MockTicketStoreSetExCall) DoAndReturn(f func(context.Context, string, time.Duration) error) *MockTicketStoreSetExCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/package_/fake/mock_package_.go
+++ b/internal/package_/fake/mock_package_.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -typed -destination=./internal/package_/fake/mock_package_.go -package=fake github.com/artefactual-sdps/enduro/internal/package_ Service
 //
+
 // Package fake is a generated GoMock package.
 package fake
 
@@ -51,31 +52,31 @@ func (m *MockService) CompletePreservationAction(arg0 context.Context, arg1 uint
 }
 
 // CompletePreservationAction indicates an expected call of CompletePreservationAction.
-func (mr *MockServiceMockRecorder) CompletePreservationAction(arg0, arg1, arg2, arg3 any) *ServiceCompletePreservationActionCall {
+func (mr *MockServiceMockRecorder) CompletePreservationAction(arg0, arg1, arg2, arg3 any) *MockServiceCompletePreservationActionCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompletePreservationAction", reflect.TypeOf((*MockService)(nil).CompletePreservationAction), arg0, arg1, arg2, arg3)
-	return &ServiceCompletePreservationActionCall{Call: call}
+	return &MockServiceCompletePreservationActionCall{Call: call}
 }
 
-// ServiceCompletePreservationActionCall wrap *gomock.Call
-type ServiceCompletePreservationActionCall struct {
+// MockServiceCompletePreservationActionCall wrap *gomock.Call
+type MockServiceCompletePreservationActionCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceCompletePreservationActionCall) Return(arg0 error) *ServiceCompletePreservationActionCall {
+func (c *MockServiceCompletePreservationActionCall) Return(arg0 error) *MockServiceCompletePreservationActionCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceCompletePreservationActionCall) Do(f func(context.Context, uint, package_0.PreservationActionStatus, time.Time) error) *ServiceCompletePreservationActionCall {
+func (c *MockServiceCompletePreservationActionCall) Do(f func(context.Context, uint, package_0.PreservationActionStatus, time.Time) error) *MockServiceCompletePreservationActionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceCompletePreservationActionCall) DoAndReturn(f func(context.Context, uint, package_0.PreservationActionStatus, time.Time) error) *ServiceCompletePreservationActionCall {
+func (c *MockServiceCompletePreservationActionCall) DoAndReturn(f func(context.Context, uint, package_0.PreservationActionStatus, time.Time) error) *MockServiceCompletePreservationActionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -89,31 +90,31 @@ func (m *MockService) CompletePreservationTask(arg0 context.Context, arg1 uint, 
 }
 
 // CompletePreservationTask indicates an expected call of CompletePreservationTask.
-func (mr *MockServiceMockRecorder) CompletePreservationTask(arg0, arg1, arg2, arg3, arg4 any) *ServiceCompletePreservationTaskCall {
+func (mr *MockServiceMockRecorder) CompletePreservationTask(arg0, arg1, arg2, arg3, arg4 any) *MockServiceCompletePreservationTaskCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompletePreservationTask", reflect.TypeOf((*MockService)(nil).CompletePreservationTask), arg0, arg1, arg2, arg3, arg4)
-	return &ServiceCompletePreservationTaskCall{Call: call}
+	return &MockServiceCompletePreservationTaskCall{Call: call}
 }
 
-// ServiceCompletePreservationTaskCall wrap *gomock.Call
-type ServiceCompletePreservationTaskCall struct {
+// MockServiceCompletePreservationTaskCall wrap *gomock.Call
+type MockServiceCompletePreservationTaskCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceCompletePreservationTaskCall) Return(arg0 error) *ServiceCompletePreservationTaskCall {
+func (c *MockServiceCompletePreservationTaskCall) Return(arg0 error) *MockServiceCompletePreservationTaskCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceCompletePreservationTaskCall) Do(f func(context.Context, uint, package_0.PreservationTaskStatus, time.Time, *string) error) *ServiceCompletePreservationTaskCall {
+func (c *MockServiceCompletePreservationTaskCall) Do(f func(context.Context, uint, package_0.PreservationTaskStatus, time.Time, *string) error) *MockServiceCompletePreservationTaskCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceCompletePreservationTaskCall) DoAndReturn(f func(context.Context, uint, package_0.PreservationTaskStatus, time.Time, *string) error) *ServiceCompletePreservationTaskCall {
+func (c *MockServiceCompletePreservationTaskCall) DoAndReturn(f func(context.Context, uint, package_0.PreservationTaskStatus, time.Time, *string) error) *MockServiceCompletePreservationTaskCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -127,31 +128,31 @@ func (m *MockService) Create(arg0 context.Context, arg1 *package_0.Package) erro
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockServiceMockRecorder) Create(arg0, arg1 any) *ServiceCreateCall {
+func (mr *MockServiceMockRecorder) Create(arg0, arg1 any) *MockServiceCreateCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockService)(nil).Create), arg0, arg1)
-	return &ServiceCreateCall{Call: call}
+	return &MockServiceCreateCall{Call: call}
 }
 
-// ServiceCreateCall wrap *gomock.Call
-type ServiceCreateCall struct {
+// MockServiceCreateCall wrap *gomock.Call
+type MockServiceCreateCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceCreateCall) Return(arg0 error) *ServiceCreateCall {
+func (c *MockServiceCreateCall) Return(arg0 error) *MockServiceCreateCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceCreateCall) Do(f func(context.Context, *package_0.Package) error) *ServiceCreateCall {
+func (c *MockServiceCreateCall) Do(f func(context.Context, *package_0.Package) error) *MockServiceCreateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceCreateCall) DoAndReturn(f func(context.Context, *package_0.Package) error) *ServiceCreateCall {
+func (c *MockServiceCreateCall) DoAndReturn(f func(context.Context, *package_0.Package) error) *MockServiceCreateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -165,31 +166,31 @@ func (m *MockService) CreatePreservationAction(arg0 context.Context, arg1 *packa
 }
 
 // CreatePreservationAction indicates an expected call of CreatePreservationAction.
-func (mr *MockServiceMockRecorder) CreatePreservationAction(arg0, arg1 any) *ServiceCreatePreservationActionCall {
+func (mr *MockServiceMockRecorder) CreatePreservationAction(arg0, arg1 any) *MockServiceCreatePreservationActionCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePreservationAction", reflect.TypeOf((*MockService)(nil).CreatePreservationAction), arg0, arg1)
-	return &ServiceCreatePreservationActionCall{Call: call}
+	return &MockServiceCreatePreservationActionCall{Call: call}
 }
 
-// ServiceCreatePreservationActionCall wrap *gomock.Call
-type ServiceCreatePreservationActionCall struct {
+// MockServiceCreatePreservationActionCall wrap *gomock.Call
+type MockServiceCreatePreservationActionCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceCreatePreservationActionCall) Return(arg0 error) *ServiceCreatePreservationActionCall {
+func (c *MockServiceCreatePreservationActionCall) Return(arg0 error) *MockServiceCreatePreservationActionCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceCreatePreservationActionCall) Do(f func(context.Context, *package_0.PreservationAction) error) *ServiceCreatePreservationActionCall {
+func (c *MockServiceCreatePreservationActionCall) Do(f func(context.Context, *package_0.PreservationAction) error) *MockServiceCreatePreservationActionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceCreatePreservationActionCall) DoAndReturn(f func(context.Context, *package_0.PreservationAction) error) *ServiceCreatePreservationActionCall {
+func (c *MockServiceCreatePreservationActionCall) DoAndReturn(f func(context.Context, *package_0.PreservationAction) error) *MockServiceCreatePreservationActionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -203,31 +204,31 @@ func (m *MockService) CreatePreservationTask(arg0 context.Context, arg1 *package
 }
 
 // CreatePreservationTask indicates an expected call of CreatePreservationTask.
-func (mr *MockServiceMockRecorder) CreatePreservationTask(arg0, arg1 any) *ServiceCreatePreservationTaskCall {
+func (mr *MockServiceMockRecorder) CreatePreservationTask(arg0, arg1 any) *MockServiceCreatePreservationTaskCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePreservationTask", reflect.TypeOf((*MockService)(nil).CreatePreservationTask), arg0, arg1)
-	return &ServiceCreatePreservationTaskCall{Call: call}
+	return &MockServiceCreatePreservationTaskCall{Call: call}
 }
 
-// ServiceCreatePreservationTaskCall wrap *gomock.Call
-type ServiceCreatePreservationTaskCall struct {
+// MockServiceCreatePreservationTaskCall wrap *gomock.Call
+type MockServiceCreatePreservationTaskCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceCreatePreservationTaskCall) Return(arg0 error) *ServiceCreatePreservationTaskCall {
+func (c *MockServiceCreatePreservationTaskCall) Return(arg0 error) *MockServiceCreatePreservationTaskCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceCreatePreservationTaskCall) Do(f func(context.Context, *package_0.PreservationTask) error) *ServiceCreatePreservationTaskCall {
+func (c *MockServiceCreatePreservationTaskCall) Do(f func(context.Context, *package_0.PreservationTask) error) *MockServiceCreatePreservationTaskCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceCreatePreservationTaskCall) DoAndReturn(f func(context.Context, *package_0.PreservationTask) error) *ServiceCreatePreservationTaskCall {
+func (c *MockServiceCreatePreservationTaskCall) DoAndReturn(f func(context.Context, *package_0.PreservationTask) error) *MockServiceCreatePreservationTaskCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -241,31 +242,31 @@ func (m *MockService) Goa() package_.Service {
 }
 
 // Goa indicates an expected call of Goa.
-func (mr *MockServiceMockRecorder) Goa() *ServiceGoaCall {
+func (mr *MockServiceMockRecorder) Goa() *MockServiceGoaCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Goa", reflect.TypeOf((*MockService)(nil).Goa))
-	return &ServiceGoaCall{Call: call}
+	return &MockServiceGoaCall{Call: call}
 }
 
-// ServiceGoaCall wrap *gomock.Call
-type ServiceGoaCall struct {
+// MockServiceGoaCall wrap *gomock.Call
+type MockServiceGoaCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceGoaCall) Return(arg0 package_.Service) *ServiceGoaCall {
+func (c *MockServiceGoaCall) Return(arg0 package_.Service) *MockServiceGoaCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceGoaCall) Do(f func() package_.Service) *ServiceGoaCall {
+func (c *MockServiceGoaCall) Do(f func() package_.Service) *MockServiceGoaCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceGoaCall) DoAndReturn(f func() package_.Service) *ServiceGoaCall {
+func (c *MockServiceGoaCall) DoAndReturn(f func() package_.Service) *MockServiceGoaCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -279,31 +280,31 @@ func (m *MockService) SetLocationID(arg0 context.Context, arg1 uint, arg2 uuid.U
 }
 
 // SetLocationID indicates an expected call of SetLocationID.
-func (mr *MockServiceMockRecorder) SetLocationID(arg0, arg1, arg2 any) *ServiceSetLocationIDCall {
+func (mr *MockServiceMockRecorder) SetLocationID(arg0, arg1, arg2 any) *MockServiceSetLocationIDCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLocationID", reflect.TypeOf((*MockService)(nil).SetLocationID), arg0, arg1, arg2)
-	return &ServiceSetLocationIDCall{Call: call}
+	return &MockServiceSetLocationIDCall{Call: call}
 }
 
-// ServiceSetLocationIDCall wrap *gomock.Call
-type ServiceSetLocationIDCall struct {
+// MockServiceSetLocationIDCall wrap *gomock.Call
+type MockServiceSetLocationIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceSetLocationIDCall) Return(arg0 error) *ServiceSetLocationIDCall {
+func (c *MockServiceSetLocationIDCall) Return(arg0 error) *MockServiceSetLocationIDCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceSetLocationIDCall) Do(f func(context.Context, uint, uuid.UUID) error) *ServiceSetLocationIDCall {
+func (c *MockServiceSetLocationIDCall) Do(f func(context.Context, uint, uuid.UUID) error) *MockServiceSetLocationIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceSetLocationIDCall) DoAndReturn(f func(context.Context, uint, uuid.UUID) error) *ServiceSetLocationIDCall {
+func (c *MockServiceSetLocationIDCall) DoAndReturn(f func(context.Context, uint, uuid.UUID) error) *MockServiceSetLocationIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -317,31 +318,31 @@ func (m *MockService) SetPreservationActionStatus(arg0 context.Context, arg1 uin
 }
 
 // SetPreservationActionStatus indicates an expected call of SetPreservationActionStatus.
-func (mr *MockServiceMockRecorder) SetPreservationActionStatus(arg0, arg1, arg2 any) *ServiceSetPreservationActionStatusCall {
+func (mr *MockServiceMockRecorder) SetPreservationActionStatus(arg0, arg1, arg2 any) *MockServiceSetPreservationActionStatusCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPreservationActionStatus", reflect.TypeOf((*MockService)(nil).SetPreservationActionStatus), arg0, arg1, arg2)
-	return &ServiceSetPreservationActionStatusCall{Call: call}
+	return &MockServiceSetPreservationActionStatusCall{Call: call}
 }
 
-// ServiceSetPreservationActionStatusCall wrap *gomock.Call
-type ServiceSetPreservationActionStatusCall struct {
+// MockServiceSetPreservationActionStatusCall wrap *gomock.Call
+type MockServiceSetPreservationActionStatusCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceSetPreservationActionStatusCall) Return(arg0 error) *ServiceSetPreservationActionStatusCall {
+func (c *MockServiceSetPreservationActionStatusCall) Return(arg0 error) *MockServiceSetPreservationActionStatusCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceSetPreservationActionStatusCall) Do(f func(context.Context, uint, package_0.PreservationActionStatus) error) *ServiceSetPreservationActionStatusCall {
+func (c *MockServiceSetPreservationActionStatusCall) Do(f func(context.Context, uint, package_0.PreservationActionStatus) error) *MockServiceSetPreservationActionStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceSetPreservationActionStatusCall) DoAndReturn(f func(context.Context, uint, package_0.PreservationActionStatus) error) *ServiceSetPreservationActionStatusCall {
+func (c *MockServiceSetPreservationActionStatusCall) DoAndReturn(f func(context.Context, uint, package_0.PreservationActionStatus) error) *MockServiceSetPreservationActionStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -355,31 +356,31 @@ func (m *MockService) SetStatus(arg0 context.Context, arg1 uint, arg2 package_0.
 }
 
 // SetStatus indicates an expected call of SetStatus.
-func (mr *MockServiceMockRecorder) SetStatus(arg0, arg1, arg2 any) *ServiceSetStatusCall {
+func (mr *MockServiceMockRecorder) SetStatus(arg0, arg1, arg2 any) *MockServiceSetStatusCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockService)(nil).SetStatus), arg0, arg1, arg2)
-	return &ServiceSetStatusCall{Call: call}
+	return &MockServiceSetStatusCall{Call: call}
 }
 
-// ServiceSetStatusCall wrap *gomock.Call
-type ServiceSetStatusCall struct {
+// MockServiceSetStatusCall wrap *gomock.Call
+type MockServiceSetStatusCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceSetStatusCall) Return(arg0 error) *ServiceSetStatusCall {
+func (c *MockServiceSetStatusCall) Return(arg0 error) *MockServiceSetStatusCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceSetStatusCall) Do(f func(context.Context, uint, package_0.Status) error) *ServiceSetStatusCall {
+func (c *MockServiceSetStatusCall) Do(f func(context.Context, uint, package_0.Status) error) *MockServiceSetStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceSetStatusCall) DoAndReturn(f func(context.Context, uint, package_0.Status) error) *ServiceSetStatusCall {
+func (c *MockServiceSetStatusCall) DoAndReturn(f func(context.Context, uint, package_0.Status) error) *MockServiceSetStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -393,31 +394,31 @@ func (m *MockService) SetStatusInProgress(arg0 context.Context, arg1 uint, arg2 
 }
 
 // SetStatusInProgress indicates an expected call of SetStatusInProgress.
-func (mr *MockServiceMockRecorder) SetStatusInProgress(arg0, arg1, arg2 any) *ServiceSetStatusInProgressCall {
+func (mr *MockServiceMockRecorder) SetStatusInProgress(arg0, arg1, arg2 any) *MockServiceSetStatusInProgressCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatusInProgress", reflect.TypeOf((*MockService)(nil).SetStatusInProgress), arg0, arg1, arg2)
-	return &ServiceSetStatusInProgressCall{Call: call}
+	return &MockServiceSetStatusInProgressCall{Call: call}
 }
 
-// ServiceSetStatusInProgressCall wrap *gomock.Call
-type ServiceSetStatusInProgressCall struct {
+// MockServiceSetStatusInProgressCall wrap *gomock.Call
+type MockServiceSetStatusInProgressCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceSetStatusInProgressCall) Return(arg0 error) *ServiceSetStatusInProgressCall {
+func (c *MockServiceSetStatusInProgressCall) Return(arg0 error) *MockServiceSetStatusInProgressCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceSetStatusInProgressCall) Do(f func(context.Context, uint, time.Time) error) *ServiceSetStatusInProgressCall {
+func (c *MockServiceSetStatusInProgressCall) Do(f func(context.Context, uint, time.Time) error) *MockServiceSetStatusInProgressCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceSetStatusInProgressCall) DoAndReturn(f func(context.Context, uint, time.Time) error) *ServiceSetStatusInProgressCall {
+func (c *MockServiceSetStatusInProgressCall) DoAndReturn(f func(context.Context, uint, time.Time) error) *MockServiceSetStatusInProgressCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -431,31 +432,31 @@ func (m *MockService) SetStatusPending(arg0 context.Context, arg1 uint) error {
 }
 
 // SetStatusPending indicates an expected call of SetStatusPending.
-func (mr *MockServiceMockRecorder) SetStatusPending(arg0, arg1 any) *ServiceSetStatusPendingCall {
+func (mr *MockServiceMockRecorder) SetStatusPending(arg0, arg1 any) *MockServiceSetStatusPendingCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatusPending", reflect.TypeOf((*MockService)(nil).SetStatusPending), arg0, arg1)
-	return &ServiceSetStatusPendingCall{Call: call}
+	return &MockServiceSetStatusPendingCall{Call: call}
 }
 
-// ServiceSetStatusPendingCall wrap *gomock.Call
-type ServiceSetStatusPendingCall struct {
+// MockServiceSetStatusPendingCall wrap *gomock.Call
+type MockServiceSetStatusPendingCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceSetStatusPendingCall) Return(arg0 error) *ServiceSetStatusPendingCall {
+func (c *MockServiceSetStatusPendingCall) Return(arg0 error) *MockServiceSetStatusPendingCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceSetStatusPendingCall) Do(f func(context.Context, uint) error) *ServiceSetStatusPendingCall {
+func (c *MockServiceSetStatusPendingCall) Do(f func(context.Context, uint) error) *MockServiceSetStatusPendingCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceSetStatusPendingCall) DoAndReturn(f func(context.Context, uint) error) *ServiceSetStatusPendingCall {
+func (c *MockServiceSetStatusPendingCall) DoAndReturn(f func(context.Context, uint) error) *MockServiceSetStatusPendingCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -469,31 +470,31 @@ func (m *MockService) UpdateWorkflowStatus(arg0 context.Context, arg1 uint, arg2
 }
 
 // UpdateWorkflowStatus indicates an expected call of UpdateWorkflowStatus.
-func (mr *MockServiceMockRecorder) UpdateWorkflowStatus(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 any) *ServiceUpdateWorkflowStatusCall {
+func (mr *MockServiceMockRecorder) UpdateWorkflowStatus(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 any) *MockServiceUpdateWorkflowStatusCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowStatus", reflect.TypeOf((*MockService)(nil).UpdateWorkflowStatus), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-	return &ServiceUpdateWorkflowStatusCall{Call: call}
+	return &MockServiceUpdateWorkflowStatusCall{Call: call}
 }
 
-// ServiceUpdateWorkflowStatusCall wrap *gomock.Call
-type ServiceUpdateWorkflowStatusCall struct {
+// MockServiceUpdateWorkflowStatusCall wrap *gomock.Call
+type MockServiceUpdateWorkflowStatusCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceUpdateWorkflowStatusCall) Return(arg0 error) *ServiceUpdateWorkflowStatusCall {
+func (c *MockServiceUpdateWorkflowStatusCall) Return(arg0 error) *MockServiceUpdateWorkflowStatusCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceUpdateWorkflowStatusCall) Do(f func(context.Context, uint, string, string, string, string, package_0.Status, time.Time) error) *ServiceUpdateWorkflowStatusCall {
+func (c *MockServiceUpdateWorkflowStatusCall) Do(f func(context.Context, uint, string, string, string, string, package_0.Status, time.Time) error) *MockServiceUpdateWorkflowStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceUpdateWorkflowStatusCall) DoAndReturn(f func(context.Context, uint, string, string, string, string, package_0.Status, time.Time) error) *ServiceUpdateWorkflowStatusCall {
+func (c *MockServiceUpdateWorkflowStatusCall) DoAndReturn(f func(context.Context, uint, string, string, string, string, package_0.Status, time.Time) error) *MockServiceUpdateWorkflowStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/persistence/fake/mock_persistence.go
+++ b/internal/persistence/fake/mock_persistence.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -typed -destination=./internal/persistence/fake/mock_persistence.go -package=fake github.com/artefactual-sdps/enduro/internal/persistence Service
 //
+
 // Package fake is a generated GoMock package.
 package fake
 
@@ -50,31 +51,31 @@ func (m *MockService) CreatePackage(arg0 context.Context, arg1 *package_.Package
 }
 
 // CreatePackage indicates an expected call of CreatePackage.
-func (mr *MockServiceMockRecorder) CreatePackage(arg0, arg1 any) *ServiceCreatePackageCall {
+func (mr *MockServiceMockRecorder) CreatePackage(arg0, arg1 any) *MockServiceCreatePackageCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePackage", reflect.TypeOf((*MockService)(nil).CreatePackage), arg0, arg1)
-	return &ServiceCreatePackageCall{Call: call}
+	return &MockServiceCreatePackageCall{Call: call}
 }
 
-// ServiceCreatePackageCall wrap *gomock.Call
-type ServiceCreatePackageCall struct {
+// MockServiceCreatePackageCall wrap *gomock.Call
+type MockServiceCreatePackageCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceCreatePackageCall) Return(arg0 *package_.Package, arg1 error) *ServiceCreatePackageCall {
+func (c *MockServiceCreatePackageCall) Return(arg0 *package_.Package, arg1 error) *MockServiceCreatePackageCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceCreatePackageCall) Do(f func(context.Context, *package_.Package) (*package_.Package, error)) *ServiceCreatePackageCall {
+func (c *MockServiceCreatePackageCall) Do(f func(context.Context, *package_.Package) (*package_.Package, error)) *MockServiceCreatePackageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceCreatePackageCall) DoAndReturn(f func(context.Context, *package_.Package) (*package_.Package, error)) *ServiceCreatePackageCall {
+func (c *MockServiceCreatePackageCall) DoAndReturn(f func(context.Context, *package_.Package) (*package_.Package, error)) *MockServiceCreatePackageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -89,31 +90,31 @@ func (m *MockService) UpdatePackage(arg0 context.Context, arg1 uint, arg2 persis
 }
 
 // UpdatePackage indicates an expected call of UpdatePackage.
-func (mr *MockServiceMockRecorder) UpdatePackage(arg0, arg1, arg2 any) *ServiceUpdatePackageCall {
+func (mr *MockServiceMockRecorder) UpdatePackage(arg0, arg1, arg2 any) *MockServiceUpdatePackageCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePackage", reflect.TypeOf((*MockService)(nil).UpdatePackage), arg0, arg1, arg2)
-	return &ServiceUpdatePackageCall{Call: call}
+	return &MockServiceUpdatePackageCall{Call: call}
 }
 
-// ServiceUpdatePackageCall wrap *gomock.Call
-type ServiceUpdatePackageCall struct {
+// MockServiceUpdatePackageCall wrap *gomock.Call
+type MockServiceUpdatePackageCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceUpdatePackageCall) Return(arg0 *package_.Package, arg1 error) *ServiceUpdatePackageCall {
+func (c *MockServiceUpdatePackageCall) Return(arg0 *package_.Package, arg1 error) *MockServiceUpdatePackageCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceUpdatePackageCall) Do(f func(context.Context, uint, persistence.PackageUpdater) (*package_.Package, error)) *ServiceUpdatePackageCall {
+func (c *MockServiceUpdatePackageCall) Do(f func(context.Context, uint, persistence.PackageUpdater) (*package_.Package, error)) *MockServiceUpdatePackageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceUpdatePackageCall) DoAndReturn(f func(context.Context, uint, persistence.PackageUpdater) (*package_.Package, error)) *ServiceUpdatePackageCall {
+func (c *MockServiceUpdatePackageCall) DoAndReturn(f func(context.Context, uint, persistence.PackageUpdater) (*package_.Package, error)) *MockServiceUpdatePackageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/sftp/fake/mock_sftp.go
+++ b/internal/sftp/fake/mock_sftp.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -typed -destination=./internal/sftp/fake/mock_sftp.go -package=fake github.com/artefactual-sdps/enduro/internal/sftp Client
 //
+
 // Package fake is a generated GoMock package.
 package fake
 
@@ -48,31 +49,31 @@ func (m *MockClient) Delete(arg0 context.Context, arg1 string) error {
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockClientMockRecorder) Delete(arg0, arg1 any) *ClientDeleteCall {
+func (mr *MockClientMockRecorder) Delete(arg0, arg1 any) *MockClientDeleteCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), arg0, arg1)
-	return &ClientDeleteCall{Call: call}
+	return &MockClientDeleteCall{Call: call}
 }
 
-// ClientDeleteCall wrap *gomock.Call
-type ClientDeleteCall struct {
+// MockClientDeleteCall wrap *gomock.Call
+type MockClientDeleteCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ClientDeleteCall) Return(arg0 error) *ClientDeleteCall {
+func (c *MockClientDeleteCall) Return(arg0 error) *MockClientDeleteCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ClientDeleteCall) Do(f func(context.Context, string) error) *ClientDeleteCall {
+func (c *MockClientDeleteCall) Do(f func(context.Context, string) error) *MockClientDeleteCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ClientDeleteCall) DoAndReturn(f func(context.Context, string) error) *ClientDeleteCall {
+func (c *MockClientDeleteCall) DoAndReturn(f func(context.Context, string) error) *MockClientDeleteCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -88,31 +89,31 @@ func (m *MockClient) Upload(arg0 context.Context, arg1 io.Reader, arg2 string) (
 }
 
 // Upload indicates an expected call of Upload.
-func (mr *MockClientMockRecorder) Upload(arg0, arg1, arg2 any) *ClientUploadCall {
+func (mr *MockClientMockRecorder) Upload(arg0, arg1, arg2 any) *MockClientUploadCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*MockClient)(nil).Upload), arg0, arg1, arg2)
-	return &ClientUploadCall{Call: call}
+	return &MockClientUploadCall{Call: call}
 }
 
-// ClientUploadCall wrap *gomock.Call
-type ClientUploadCall struct {
+// MockClientUploadCall wrap *gomock.Call
+type MockClientUploadCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ClientUploadCall) Return(arg0 int64, arg1 string, arg2 error) *ClientUploadCall {
+func (c *MockClientUploadCall) Return(arg0 int64, arg1 string, arg2 error) *MockClientUploadCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ClientUploadCall) Do(f func(context.Context, io.Reader, string) (int64, string, error)) *ClientUploadCall {
+func (c *MockClientUploadCall) Do(f func(context.Context, io.Reader, string) (int64, string, error)) *MockClientUploadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ClientUploadCall) DoAndReturn(f func(context.Context, io.Reader, string) (int64, string, error)) *ClientUploadCall {
+func (c *MockClientUploadCall) DoAndReturn(f func(context.Context, io.Reader, string) (int64, string, error)) *MockClientUploadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/storage/activities/copy.go
+++ b/internal/storage/activities/copy.go
@@ -21,7 +21,7 @@ func (a *CopyToPermanentLocationActivity) Execute(ctx context.Context, params *s
 		return err
 	}
 
-	reader, err := a.storagesvc.PackageReader(ctx, p)
+	reader, _, err := a.storagesvc.PackageReader(ctx, p)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/download.go
+++ b/internal/storage/download.go
@@ -62,14 +62,11 @@ func Download(svc Service, mux goahttp.Muxer, dec func(r *http.Request) goahttp.
 		}
 
 		fillResponseBlob(rw, reader, filename)
-		return
-
 	}
 }
 
 // Fill the header and body of the http response with the blob's response information.
 func fillResponseBlob(rw http.ResponseWriter, responseInfo *blob.Reader, filename string) {
-
 	rw.Header().Add("Content-Type", responseInfo.ContentType())
 	rw.Header().Add("Content-Length", strconv.FormatInt(responseInfo.Size(), 10))
 	rw.Header().Add("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
@@ -80,12 +77,10 @@ func fillResponseBlob(rw http.ResponseWriter, responseInfo *blob.Reader, filenam
 		rw.WriteHeader(http.StatusNotFound)
 		return
 	}
-
 }
 
 // Fill the header and body of the http response with the resps's response information.
 func fillResponseResp(rw http.ResponseWriter, responseInfo *http.Response, filename string) {
-
 	rw.Header().Add("Content-Type", responseInfo.Header.Get("Content-Type"))
 	rw.Header().Add("Content-Length", responseInfo.Header.Get("Content-Length"))
 	rw.Header().Add("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
@@ -96,5 +91,4 @@ func fillResponseResp(rw http.ResponseWriter, responseInfo *http.Response, filen
 		rw.WriteHeader(http.StatusNotFound)
 		return
 	}
-
 }

--- a/internal/storage/fake/mock_storage.go
+++ b/internal/storage/fake/mock_storage.go
@@ -5,11 +5,13 @@
 //
 //	mockgen -typed -destination=./internal/storage/fake/mock_storage.go -package=fake github.com/artefactual-sdps/enduro/internal/storage Service
 //
+
 // Package fake is a generated GoMock package.
 package fake
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	storage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
@@ -53,31 +55,31 @@ func (m *MockService) AddLocation(arg0 context.Context, arg1 *storage.AddLocatio
 }
 
 // AddLocation indicates an expected call of AddLocation.
-func (mr *MockServiceMockRecorder) AddLocation(arg0, arg1 any) *ServiceAddLocationCall {
+func (mr *MockServiceMockRecorder) AddLocation(arg0, arg1 any) *MockServiceAddLocationCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLocation", reflect.TypeOf((*MockService)(nil).AddLocation), arg0, arg1)
-	return &ServiceAddLocationCall{Call: call}
+	return &MockServiceAddLocationCall{Call: call}
 }
 
-// ServiceAddLocationCall wrap *gomock.Call
-type ServiceAddLocationCall struct {
+// MockServiceAddLocationCall wrap *gomock.Call
+type MockServiceAddLocationCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceAddLocationCall) Return(arg0 *storage.AddLocationResult, arg1 error) *ServiceAddLocationCall {
+func (c *MockServiceAddLocationCall) Return(arg0 *storage.AddLocationResult, arg1 error) *MockServiceAddLocationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceAddLocationCall) Do(f func(context.Context, *storage.AddLocationPayload) (*storage.AddLocationResult, error)) *ServiceAddLocationCall {
+func (c *MockServiceAddLocationCall) Do(f func(context.Context, *storage.AddLocationPayload) (*storage.AddLocationResult, error)) *MockServiceAddLocationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceAddLocationCall) DoAndReturn(f func(context.Context, *storage.AddLocationPayload) (*storage.AddLocationResult, error)) *ServiceAddLocationCall {
+func (c *MockServiceAddLocationCall) DoAndReturn(f func(context.Context, *storage.AddLocationPayload) (*storage.AddLocationResult, error)) *MockServiceAddLocationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -91,31 +93,31 @@ func (m *MockService) Delete(arg0 context.Context, arg1 uuid.UUID) error {
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockServiceMockRecorder) Delete(arg0, arg1 any) *ServiceDeleteCall {
+func (mr *MockServiceMockRecorder) Delete(arg0, arg1 any) *MockServiceDeleteCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockService)(nil).Delete), arg0, arg1)
-	return &ServiceDeleteCall{Call: call}
+	return &MockServiceDeleteCall{Call: call}
 }
 
-// ServiceDeleteCall wrap *gomock.Call
-type ServiceDeleteCall struct {
+// MockServiceDeleteCall wrap *gomock.Call
+type MockServiceDeleteCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceDeleteCall) Return(arg0 error) *ServiceDeleteCall {
+func (c *MockServiceDeleteCall) Return(arg0 error) *MockServiceDeleteCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceDeleteCall) Do(f func(context.Context, uuid.UUID) error) *ServiceDeleteCall {
+func (c *MockServiceDeleteCall) Do(f func(context.Context, uuid.UUID) error) *MockServiceDeleteCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceDeleteCall) DoAndReturn(f func(context.Context, uuid.UUID) error) *ServiceDeleteCall {
+func (c *MockServiceDeleteCall) DoAndReturn(f func(context.Context, uuid.UUID) error) *MockServiceDeleteCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -130,31 +132,31 @@ func (m *MockService) Download(arg0 context.Context, arg1 *storage.DownloadPaylo
 }
 
 // Download indicates an expected call of Download.
-func (mr *MockServiceMockRecorder) Download(arg0, arg1 any) *ServiceDownloadCall {
+func (mr *MockServiceMockRecorder) Download(arg0, arg1 any) *MockServiceDownloadCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockService)(nil).Download), arg0, arg1)
-	return &ServiceDownloadCall{Call: call}
+	return &MockServiceDownloadCall{Call: call}
 }
 
-// ServiceDownloadCall wrap *gomock.Call
-type ServiceDownloadCall struct {
+// MockServiceDownloadCall wrap *gomock.Call
+type MockServiceDownloadCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceDownloadCall) Return(arg0 []byte, arg1 error) *ServiceDownloadCall {
+func (c *MockServiceDownloadCall) Return(arg0 []byte, arg1 error) *MockServiceDownloadCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceDownloadCall) Do(f func(context.Context, *storage.DownloadPayload) ([]byte, error)) *ServiceDownloadCall {
+func (c *MockServiceDownloadCall) Do(f func(context.Context, *storage.DownloadPayload) ([]byte, error)) *MockServiceDownloadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceDownloadCall) DoAndReturn(f func(context.Context, *storage.DownloadPayload) ([]byte, error)) *ServiceDownloadCall {
+func (c *MockServiceDownloadCall) DoAndReturn(f func(context.Context, *storage.DownloadPayload) ([]byte, error)) *MockServiceDownloadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -169,31 +171,31 @@ func (m *MockService) Location(arg0 context.Context, arg1 uuid.UUID) (storage0.L
 }
 
 // Location indicates an expected call of Location.
-func (mr *MockServiceMockRecorder) Location(arg0, arg1 any) *ServiceLocationCall {
+func (mr *MockServiceMockRecorder) Location(arg0, arg1 any) *MockServiceLocationCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Location", reflect.TypeOf((*MockService)(nil).Location), arg0, arg1)
-	return &ServiceLocationCall{Call: call}
+	return &MockServiceLocationCall{Call: call}
 }
 
-// ServiceLocationCall wrap *gomock.Call
-type ServiceLocationCall struct {
+// MockServiceLocationCall wrap *gomock.Call
+type MockServiceLocationCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceLocationCall) Return(arg0 storage0.Location, arg1 error) *ServiceLocationCall {
+func (c *MockServiceLocationCall) Return(arg0 storage0.Location, arg1 error) *MockServiceLocationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceLocationCall) Do(f func(context.Context, uuid.UUID) (storage0.Location, error)) *ServiceLocationCall {
+func (c *MockServiceLocationCall) Do(f func(context.Context, uuid.UUID) (storage0.Location, error)) *MockServiceLocationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceLocationCall) DoAndReturn(f func(context.Context, uuid.UUID) (storage0.Location, error)) *ServiceLocationCall {
+func (c *MockServiceLocationCall) DoAndReturn(f func(context.Context, uuid.UUID) (storage0.Location, error)) *MockServiceLocationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -208,31 +210,31 @@ func (m *MockService) LocationPackages(arg0 context.Context, arg1 *storage.Locat
 }
 
 // LocationPackages indicates an expected call of LocationPackages.
-func (mr *MockServiceMockRecorder) LocationPackages(arg0, arg1 any) *ServiceLocationPackagesCall {
+func (mr *MockServiceMockRecorder) LocationPackages(arg0, arg1 any) *MockServiceLocationPackagesCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocationPackages", reflect.TypeOf((*MockService)(nil).LocationPackages), arg0, arg1)
-	return &ServiceLocationPackagesCall{Call: call}
+	return &MockServiceLocationPackagesCall{Call: call}
 }
 
-// ServiceLocationPackagesCall wrap *gomock.Call
-type ServiceLocationPackagesCall struct {
+// MockServiceLocationPackagesCall wrap *gomock.Call
+type MockServiceLocationPackagesCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceLocationPackagesCall) Return(arg0 storage.PackageCollection, arg1 error) *ServiceLocationPackagesCall {
+func (c *MockServiceLocationPackagesCall) Return(arg0 storage.PackageCollection, arg1 error) *MockServiceLocationPackagesCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceLocationPackagesCall) Do(f func(context.Context, *storage.LocationPackagesPayload) (storage.PackageCollection, error)) *ServiceLocationPackagesCall {
+func (c *MockServiceLocationPackagesCall) Do(f func(context.Context, *storage.LocationPackagesPayload) (storage.PackageCollection, error)) *MockServiceLocationPackagesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceLocationPackagesCall) DoAndReturn(f func(context.Context, *storage.LocationPackagesPayload) (storage.PackageCollection, error)) *ServiceLocationPackagesCall {
+func (c *MockServiceLocationPackagesCall) DoAndReturn(f func(context.Context, *storage.LocationPackagesPayload) (storage.PackageCollection, error)) *MockServiceLocationPackagesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -247,31 +249,31 @@ func (m *MockService) Locations(arg0 context.Context, arg1 *storage.LocationsPay
 }
 
 // Locations indicates an expected call of Locations.
-func (mr *MockServiceMockRecorder) Locations(arg0, arg1 any) *ServiceLocationsCall {
+func (mr *MockServiceMockRecorder) Locations(arg0, arg1 any) *MockServiceLocationsCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Locations", reflect.TypeOf((*MockService)(nil).Locations), arg0, arg1)
-	return &ServiceLocationsCall{Call: call}
+	return &MockServiceLocationsCall{Call: call}
 }
 
-// ServiceLocationsCall wrap *gomock.Call
-type ServiceLocationsCall struct {
+// MockServiceLocationsCall wrap *gomock.Call
+type MockServiceLocationsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceLocationsCall) Return(arg0 storage.LocationCollection, arg1 error) *ServiceLocationsCall {
+func (c *MockServiceLocationsCall) Return(arg0 storage.LocationCollection, arg1 error) *MockServiceLocationsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceLocationsCall) Do(f func(context.Context, *storage.LocationsPayload) (storage.LocationCollection, error)) *ServiceLocationsCall {
+func (c *MockServiceLocationsCall) Do(f func(context.Context, *storage.LocationsPayload) (storage.LocationCollection, error)) *MockServiceLocationsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceLocationsCall) DoAndReturn(f func(context.Context, *storage.LocationsPayload) (storage.LocationCollection, error)) *ServiceLocationsCall {
+func (c *MockServiceLocationsCall) DoAndReturn(f func(context.Context, *storage.LocationsPayload) (storage.LocationCollection, error)) *MockServiceLocationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -285,31 +287,31 @@ func (m *MockService) Move(arg0 context.Context, arg1 *storage.MovePayload) erro
 }
 
 // Move indicates an expected call of Move.
-func (mr *MockServiceMockRecorder) Move(arg0, arg1 any) *ServiceMoveCall {
+func (mr *MockServiceMockRecorder) Move(arg0, arg1 any) *MockServiceMoveCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Move", reflect.TypeOf((*MockService)(nil).Move), arg0, arg1)
-	return &ServiceMoveCall{Call: call}
+	return &MockServiceMoveCall{Call: call}
 }
 
-// ServiceMoveCall wrap *gomock.Call
-type ServiceMoveCall struct {
+// MockServiceMoveCall wrap *gomock.Call
+type MockServiceMoveCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceMoveCall) Return(arg0 error) *ServiceMoveCall {
+func (c *MockServiceMoveCall) Return(arg0 error) *MockServiceMoveCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceMoveCall) Do(f func(context.Context, *storage.MovePayload) error) *ServiceMoveCall {
+func (c *MockServiceMoveCall) Do(f func(context.Context, *storage.MovePayload) error) *MockServiceMoveCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceMoveCall) DoAndReturn(f func(context.Context, *storage.MovePayload) error) *ServiceMoveCall {
+func (c *MockServiceMoveCall) DoAndReturn(f func(context.Context, *storage.MovePayload) error) *MockServiceMoveCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -324,70 +326,71 @@ func (m *MockService) MoveStatus(arg0 context.Context, arg1 *storage.MoveStatusP
 }
 
 // MoveStatus indicates an expected call of MoveStatus.
-func (mr *MockServiceMockRecorder) MoveStatus(arg0, arg1 any) *ServiceMoveStatusCall {
+func (mr *MockServiceMockRecorder) MoveStatus(arg0, arg1 any) *MockServiceMoveStatusCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveStatus", reflect.TypeOf((*MockService)(nil).MoveStatus), arg0, arg1)
-	return &ServiceMoveStatusCall{Call: call}
+	return &MockServiceMoveStatusCall{Call: call}
 }
 
-// ServiceMoveStatusCall wrap *gomock.Call
-type ServiceMoveStatusCall struct {
+// MockServiceMoveStatusCall wrap *gomock.Call
+type MockServiceMoveStatusCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceMoveStatusCall) Return(arg0 *storage.MoveStatusResult, arg1 error) *ServiceMoveStatusCall {
+func (c *MockServiceMoveStatusCall) Return(arg0 *storage.MoveStatusResult, arg1 error) *MockServiceMoveStatusCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceMoveStatusCall) Do(f func(context.Context, *storage.MoveStatusPayload) (*storage.MoveStatusResult, error)) *ServiceMoveStatusCall {
+func (c *MockServiceMoveStatusCall) Do(f func(context.Context, *storage.MoveStatusPayload) (*storage.MoveStatusResult, error)) *MockServiceMoveStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceMoveStatusCall) DoAndReturn(f func(context.Context, *storage.MoveStatusPayload) (*storage.MoveStatusResult, error)) *ServiceMoveStatusCall {
+func (c *MockServiceMoveStatusCall) DoAndReturn(f func(context.Context, *storage.MoveStatusPayload) (*storage.MoveStatusResult, error)) *MockServiceMoveStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // PackageReader mocks base method.
-func (m *MockService) PackageReader(arg0 context.Context, arg1 *storage.Package) (*blob.Reader, error) {
+func (m *MockService) PackageReader(arg0 context.Context, arg1 *storage.Package) (*blob.Reader, *http.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PackageReader", arg0, arg1)
 	ret0, _ := ret[0].(*blob.Reader)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // PackageReader indicates an expected call of PackageReader.
-func (mr *MockServiceMockRecorder) PackageReader(arg0, arg1 any) *ServicePackageReaderCall {
+func (mr *MockServiceMockRecorder) PackageReader(arg0, arg1 any) *MockServicePackageReaderCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackageReader", reflect.TypeOf((*MockService)(nil).PackageReader), arg0, arg1)
-	return &ServicePackageReaderCall{Call: call}
+	return &MockServicePackageReaderCall{Call: call}
 }
 
-// ServicePackageReaderCall wrap *gomock.Call
-type ServicePackageReaderCall struct {
+// MockServicePackageReaderCall wrap *gomock.Call
+type MockServicePackageReaderCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServicePackageReaderCall) Return(arg0 *blob.Reader, arg1 error) *ServicePackageReaderCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockServicePackageReaderCall) Return(arg0 *blob.Reader, arg1 *http.Response, arg2 error) *MockServicePackageReaderCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServicePackageReaderCall) Do(f func(context.Context, *storage.Package) (*blob.Reader, error)) *ServicePackageReaderCall {
+func (c *MockServicePackageReaderCall) Do(f func(context.Context, *storage.Package) (*blob.Reader, *http.Response, error)) *MockServicePackageReaderCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServicePackageReaderCall) DoAndReturn(f func(context.Context, *storage.Package) (*blob.Reader, error)) *ServicePackageReaderCall {
+func (c *MockServicePackageReaderCall) DoAndReturn(f func(context.Context, *storage.Package) (*blob.Reader, *http.Response, error)) *MockServicePackageReaderCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -402,31 +405,31 @@ func (m *MockService) ReadPackage(arg0 context.Context, arg1 uuid.UUID) (*storag
 }
 
 // ReadPackage indicates an expected call of ReadPackage.
-func (mr *MockServiceMockRecorder) ReadPackage(arg0, arg1 any) *ServiceReadPackageCall {
+func (mr *MockServiceMockRecorder) ReadPackage(arg0, arg1 any) *MockServiceReadPackageCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPackage", reflect.TypeOf((*MockService)(nil).ReadPackage), arg0, arg1)
-	return &ServiceReadPackageCall{Call: call}
+	return &MockServiceReadPackageCall{Call: call}
 }
 
-// ServiceReadPackageCall wrap *gomock.Call
-type ServiceReadPackageCall struct {
+// MockServiceReadPackageCall wrap *gomock.Call
+type MockServiceReadPackageCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceReadPackageCall) Return(arg0 *storage.Package, arg1 error) *ServiceReadPackageCall {
+func (c *MockServiceReadPackageCall) Return(arg0 *storage.Package, arg1 error) *MockServiceReadPackageCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceReadPackageCall) Do(f func(context.Context, uuid.UUID) (*storage.Package, error)) *ServiceReadPackageCall {
+func (c *MockServiceReadPackageCall) Do(f func(context.Context, uuid.UUID) (*storage.Package, error)) *MockServiceReadPackageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceReadPackageCall) DoAndReturn(f func(context.Context, uuid.UUID) (*storage.Package, error)) *ServiceReadPackageCall {
+func (c *MockServiceReadPackageCall) DoAndReturn(f func(context.Context, uuid.UUID) (*storage.Package, error)) *MockServiceReadPackageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -440,31 +443,31 @@ func (m *MockService) Reject(arg0 context.Context, arg1 *storage.RejectPayload) 
 }
 
 // Reject indicates an expected call of Reject.
-func (mr *MockServiceMockRecorder) Reject(arg0, arg1 any) *ServiceRejectCall {
+func (mr *MockServiceMockRecorder) Reject(arg0, arg1 any) *MockServiceRejectCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reject", reflect.TypeOf((*MockService)(nil).Reject), arg0, arg1)
-	return &ServiceRejectCall{Call: call}
+	return &MockServiceRejectCall{Call: call}
 }
 
-// ServiceRejectCall wrap *gomock.Call
-type ServiceRejectCall struct {
+// MockServiceRejectCall wrap *gomock.Call
+type MockServiceRejectCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceRejectCall) Return(arg0 error) *ServiceRejectCall {
+func (c *MockServiceRejectCall) Return(arg0 error) *MockServiceRejectCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceRejectCall) Do(f func(context.Context, *storage.RejectPayload) error) *ServiceRejectCall {
+func (c *MockServiceRejectCall) Do(f func(context.Context, *storage.RejectPayload) error) *MockServiceRejectCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceRejectCall) DoAndReturn(f func(context.Context, *storage.RejectPayload) error) *ServiceRejectCall {
+func (c *MockServiceRejectCall) DoAndReturn(f func(context.Context, *storage.RejectPayload) error) *MockServiceRejectCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -479,31 +482,31 @@ func (m *MockService) Show(arg0 context.Context, arg1 *storage.ShowPayload) (*st
 }
 
 // Show indicates an expected call of Show.
-func (mr *MockServiceMockRecorder) Show(arg0, arg1 any) *ServiceShowCall {
+func (mr *MockServiceMockRecorder) Show(arg0, arg1 any) *MockServiceShowCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Show", reflect.TypeOf((*MockService)(nil).Show), arg0, arg1)
-	return &ServiceShowCall{Call: call}
+	return &MockServiceShowCall{Call: call}
 }
 
-// ServiceShowCall wrap *gomock.Call
-type ServiceShowCall struct {
+// MockServiceShowCall wrap *gomock.Call
+type MockServiceShowCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceShowCall) Return(arg0 *storage.Package, arg1 error) *ServiceShowCall {
+func (c *MockServiceShowCall) Return(arg0 *storage.Package, arg1 error) *MockServiceShowCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceShowCall) Do(f func(context.Context, *storage.ShowPayload) (*storage.Package, error)) *ServiceShowCall {
+func (c *MockServiceShowCall) Do(f func(context.Context, *storage.ShowPayload) (*storage.Package, error)) *MockServiceShowCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceShowCall) DoAndReturn(f func(context.Context, *storage.ShowPayload) (*storage.Package, error)) *ServiceShowCall {
+func (c *MockServiceShowCall) DoAndReturn(f func(context.Context, *storage.ShowPayload) (*storage.Package, error)) *MockServiceShowCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -518,31 +521,31 @@ func (m *MockService) ShowLocation(arg0 context.Context, arg1 *storage.ShowLocat
 }
 
 // ShowLocation indicates an expected call of ShowLocation.
-func (mr *MockServiceMockRecorder) ShowLocation(arg0, arg1 any) *ServiceShowLocationCall {
+func (mr *MockServiceMockRecorder) ShowLocation(arg0, arg1 any) *MockServiceShowLocationCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShowLocation", reflect.TypeOf((*MockService)(nil).ShowLocation), arg0, arg1)
-	return &ServiceShowLocationCall{Call: call}
+	return &MockServiceShowLocationCall{Call: call}
 }
 
-// ServiceShowLocationCall wrap *gomock.Call
-type ServiceShowLocationCall struct {
+// MockServiceShowLocationCall wrap *gomock.Call
+type MockServiceShowLocationCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceShowLocationCall) Return(arg0 *storage.Location, arg1 error) *ServiceShowLocationCall {
+func (c *MockServiceShowLocationCall) Return(arg0 *storage.Location, arg1 error) *MockServiceShowLocationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceShowLocationCall) Do(f func(context.Context, *storage.ShowLocationPayload) (*storage.Location, error)) *ServiceShowLocationCall {
+func (c *MockServiceShowLocationCall) Do(f func(context.Context, *storage.ShowLocationPayload) (*storage.Location, error)) *MockServiceShowLocationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceShowLocationCall) DoAndReturn(f func(context.Context, *storage.ShowLocationPayload) (*storage.Location, error)) *ServiceShowLocationCall {
+func (c *MockServiceShowLocationCall) DoAndReturn(f func(context.Context, *storage.ShowLocationPayload) (*storage.Location, error)) *MockServiceShowLocationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -557,31 +560,31 @@ func (m *MockService) Submit(arg0 context.Context, arg1 *storage.SubmitPayload) 
 }
 
 // Submit indicates an expected call of Submit.
-func (mr *MockServiceMockRecorder) Submit(arg0, arg1 any) *ServiceSubmitCall {
+func (mr *MockServiceMockRecorder) Submit(arg0, arg1 any) *MockServiceSubmitCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Submit", reflect.TypeOf((*MockService)(nil).Submit), arg0, arg1)
-	return &ServiceSubmitCall{Call: call}
+	return &MockServiceSubmitCall{Call: call}
 }
 
-// ServiceSubmitCall wrap *gomock.Call
-type ServiceSubmitCall struct {
+// MockServiceSubmitCall wrap *gomock.Call
+type MockServiceSubmitCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceSubmitCall) Return(arg0 *storage.SubmitResult, arg1 error) *ServiceSubmitCall {
+func (c *MockServiceSubmitCall) Return(arg0 *storage.SubmitResult, arg1 error) *MockServiceSubmitCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceSubmitCall) Do(f func(context.Context, *storage.SubmitPayload) (*storage.SubmitResult, error)) *ServiceSubmitCall {
+func (c *MockServiceSubmitCall) Do(f func(context.Context, *storage.SubmitPayload) (*storage.SubmitResult, error)) *MockServiceSubmitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceSubmitCall) DoAndReturn(f func(context.Context, *storage.SubmitPayload) (*storage.SubmitResult, error)) *ServiceSubmitCall {
+func (c *MockServiceSubmitCall) DoAndReturn(f func(context.Context, *storage.SubmitPayload) (*storage.SubmitResult, error)) *MockServiceSubmitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -595,31 +598,31 @@ func (m *MockService) Update(arg0 context.Context, arg1 *storage.UpdatePayload) 
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockServiceMockRecorder) Update(arg0, arg1 any) *ServiceUpdateCall {
+func (mr *MockServiceMockRecorder) Update(arg0, arg1 any) *MockServiceUpdateCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockService)(nil).Update), arg0, arg1)
-	return &ServiceUpdateCall{Call: call}
+	return &MockServiceUpdateCall{Call: call}
 }
 
-// ServiceUpdateCall wrap *gomock.Call
-type ServiceUpdateCall struct {
+// MockServiceUpdateCall wrap *gomock.Call
+type MockServiceUpdateCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceUpdateCall) Return(arg0 error) *ServiceUpdateCall {
+func (c *MockServiceUpdateCall) Return(arg0 error) *MockServiceUpdateCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceUpdateCall) Do(f func(context.Context, *storage.UpdatePayload) error) *ServiceUpdateCall {
+func (c *MockServiceUpdateCall) Do(f func(context.Context, *storage.UpdatePayload) error) *MockServiceUpdateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceUpdateCall) DoAndReturn(f func(context.Context, *storage.UpdatePayload) error) *ServiceUpdateCall {
+func (c *MockServiceUpdateCall) DoAndReturn(f func(context.Context, *storage.UpdatePayload) error) *MockServiceUpdateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -633,31 +636,31 @@ func (m *MockService) UpdatePackageLocationID(arg0 context.Context, arg1, arg2 u
 }
 
 // UpdatePackageLocationID indicates an expected call of UpdatePackageLocationID.
-func (mr *MockServiceMockRecorder) UpdatePackageLocationID(arg0, arg1, arg2 any) *ServiceUpdatePackageLocationIDCall {
+func (mr *MockServiceMockRecorder) UpdatePackageLocationID(arg0, arg1, arg2 any) *MockServiceUpdatePackageLocationIDCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePackageLocationID", reflect.TypeOf((*MockService)(nil).UpdatePackageLocationID), arg0, arg1, arg2)
-	return &ServiceUpdatePackageLocationIDCall{Call: call}
+	return &MockServiceUpdatePackageLocationIDCall{Call: call}
 }
 
-// ServiceUpdatePackageLocationIDCall wrap *gomock.Call
-type ServiceUpdatePackageLocationIDCall struct {
+// MockServiceUpdatePackageLocationIDCall wrap *gomock.Call
+type MockServiceUpdatePackageLocationIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceUpdatePackageLocationIDCall) Return(arg0 error) *ServiceUpdatePackageLocationIDCall {
+func (c *MockServiceUpdatePackageLocationIDCall) Return(arg0 error) *MockServiceUpdatePackageLocationIDCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceUpdatePackageLocationIDCall) Do(f func(context.Context, uuid.UUID, uuid.UUID) error) *ServiceUpdatePackageLocationIDCall {
+func (c *MockServiceUpdatePackageLocationIDCall) Do(f func(context.Context, uuid.UUID, uuid.UUID) error) *MockServiceUpdatePackageLocationIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceUpdatePackageLocationIDCall) DoAndReturn(f func(context.Context, uuid.UUID, uuid.UUID) error) *ServiceUpdatePackageLocationIDCall {
+func (c *MockServiceUpdatePackageLocationIDCall) DoAndReturn(f func(context.Context, uuid.UUID, uuid.UUID) error) *MockServiceUpdatePackageLocationIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -671,31 +674,31 @@ func (m *MockService) UpdatePackageStatus(arg0 context.Context, arg1 uuid.UUID, 
 }
 
 // UpdatePackageStatus indicates an expected call of UpdatePackageStatus.
-func (mr *MockServiceMockRecorder) UpdatePackageStatus(arg0, arg1, arg2 any) *ServiceUpdatePackageStatusCall {
+func (mr *MockServiceMockRecorder) UpdatePackageStatus(arg0, arg1, arg2 any) *MockServiceUpdatePackageStatusCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePackageStatus", reflect.TypeOf((*MockService)(nil).UpdatePackageStatus), arg0, arg1, arg2)
-	return &ServiceUpdatePackageStatusCall{Call: call}
+	return &MockServiceUpdatePackageStatusCall{Call: call}
 }
 
-// ServiceUpdatePackageStatusCall wrap *gomock.Call
-type ServiceUpdatePackageStatusCall struct {
+// MockServiceUpdatePackageStatusCall wrap *gomock.Call
+type MockServiceUpdatePackageStatusCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceUpdatePackageStatusCall) Return(arg0 error) *ServiceUpdatePackageStatusCall {
+func (c *MockServiceUpdatePackageStatusCall) Return(arg0 error) *MockServiceUpdatePackageStatusCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceUpdatePackageStatusCall) Do(f func(context.Context, uuid.UUID, types.PackageStatus) error) *ServiceUpdatePackageStatusCall {
+func (c *MockServiceUpdatePackageStatusCall) Do(f func(context.Context, uuid.UUID, types.PackageStatus) error) *MockServiceUpdatePackageStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceUpdatePackageStatusCall) DoAndReturn(f func(context.Context, uuid.UUID, types.PackageStatus) error) *ServiceUpdatePackageStatusCall {
+func (c *MockServiceUpdatePackageStatusCall) DoAndReturn(f func(context.Context, uuid.UUID, types.PackageStatus) error) *MockServiceUpdatePackageStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/storage/location.go
+++ b/internal/storage/location.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/google/uuid"
 	"gocloud.dev/blob"
@@ -15,6 +16,9 @@ import (
 type Location interface {
 	UUID() uuid.UUID
 	OpenBucket(ctx context.Context) (*blob.Bucket, error)
+	// OpenSS or Open Storage Service is like Open Bucket but instead of a bucket it returns the
+	// http response from the external storage service it has requested content from.
+	OpenSS(ctx context.Context) (*http.Response, error)
 }
 
 type locationImpl struct {
@@ -87,4 +91,21 @@ func (l *locationImpl) OpenBucket(ctx context.Context) (*blob.Bucket, error) {
 		return nil, err
 	}
 	return b, nil
+}
+
+type NotExternLocation error
+
+func (l *locationImpl) OpenSS(ctx context.Context) (*http.Response, error) {
+	// Open ss takes the location url on the config and resolves the location via a new request to that url
+	// not sure if I can even get this, it is a bit confusing to understand how to grab the config
+	// url := l
+	// resp, err, := http.NewRequestWithContext(ctx, l, nil)
+	// return resp, nil
+
+	var foo bool
+	if !foo {
+		var err NotExternLocation
+		return nil, err
+	}
+	panic("not implemented")
 }

--- a/internal/storage/persistence/fake/mock_persistence.go
+++ b/internal/storage/persistence/fake/mock_persistence.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -typed -destination=./internal/storage/persistence/fake/mock_persistence.go -package=fake github.com/artefactual-sdps/enduro/internal/storage/persistence Storage
 //
+
 // Package fake is a generated GoMock package.
 package fake
 
@@ -51,31 +52,31 @@ func (m *MockStorage) CreateLocation(arg0 context.Context, arg1 *storage.Locatio
 }
 
 // CreateLocation indicates an expected call of CreateLocation.
-func (mr *MockStorageMockRecorder) CreateLocation(arg0, arg1, arg2 any) *StorageCreateLocationCall {
+func (mr *MockStorageMockRecorder) CreateLocation(arg0, arg1, arg2 any) *MockStorageCreateLocationCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLocation", reflect.TypeOf((*MockStorage)(nil).CreateLocation), arg0, arg1, arg2)
-	return &StorageCreateLocationCall{Call: call}
+	return &MockStorageCreateLocationCall{Call: call}
 }
 
-// StorageCreateLocationCall wrap *gomock.Call
-type StorageCreateLocationCall struct {
+// MockStorageCreateLocationCall wrap *gomock.Call
+type MockStorageCreateLocationCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *StorageCreateLocationCall) Return(arg0 *storage.Location, arg1 error) *StorageCreateLocationCall {
+func (c *MockStorageCreateLocationCall) Return(arg0 *storage.Location, arg1 error) *MockStorageCreateLocationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *StorageCreateLocationCall) Do(f func(context.Context, *storage.Location, *types.LocationConfig) (*storage.Location, error)) *StorageCreateLocationCall {
+func (c *MockStorageCreateLocationCall) Do(f func(context.Context, *storage.Location, *types.LocationConfig) (*storage.Location, error)) *MockStorageCreateLocationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *StorageCreateLocationCall) DoAndReturn(f func(context.Context, *storage.Location, *types.LocationConfig) (*storage.Location, error)) *StorageCreateLocationCall {
+func (c *MockStorageCreateLocationCall) DoAndReturn(f func(context.Context, *storage.Location, *types.LocationConfig) (*storage.Location, error)) *MockStorageCreateLocationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -90,31 +91,31 @@ func (m *MockStorage) CreatePackage(arg0 context.Context, arg1 *storage.Package)
 }
 
 // CreatePackage indicates an expected call of CreatePackage.
-func (mr *MockStorageMockRecorder) CreatePackage(arg0, arg1 any) *StorageCreatePackageCall {
+func (mr *MockStorageMockRecorder) CreatePackage(arg0, arg1 any) *MockStorageCreatePackageCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePackage", reflect.TypeOf((*MockStorage)(nil).CreatePackage), arg0, arg1)
-	return &StorageCreatePackageCall{Call: call}
+	return &MockStorageCreatePackageCall{Call: call}
 }
 
-// StorageCreatePackageCall wrap *gomock.Call
-type StorageCreatePackageCall struct {
+// MockStorageCreatePackageCall wrap *gomock.Call
+type MockStorageCreatePackageCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *StorageCreatePackageCall) Return(arg0 *storage.Package, arg1 error) *StorageCreatePackageCall {
+func (c *MockStorageCreatePackageCall) Return(arg0 *storage.Package, arg1 error) *MockStorageCreatePackageCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *StorageCreatePackageCall) Do(f func(context.Context, *storage.Package) (*storage.Package, error)) *StorageCreatePackageCall {
+func (c *MockStorageCreatePackageCall) Do(f func(context.Context, *storage.Package) (*storage.Package, error)) *MockStorageCreatePackageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *StorageCreatePackageCall) DoAndReturn(f func(context.Context, *storage.Package) (*storage.Package, error)) *StorageCreatePackageCall {
+func (c *MockStorageCreatePackageCall) DoAndReturn(f func(context.Context, *storage.Package) (*storage.Package, error)) *MockStorageCreatePackageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -129,31 +130,31 @@ func (m *MockStorage) ListLocations(arg0 context.Context) (storage.LocationColle
 }
 
 // ListLocations indicates an expected call of ListLocations.
-func (mr *MockStorageMockRecorder) ListLocations(arg0 any) *StorageListLocationsCall {
+func (mr *MockStorageMockRecorder) ListLocations(arg0 any) *MockStorageListLocationsCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLocations", reflect.TypeOf((*MockStorage)(nil).ListLocations), arg0)
-	return &StorageListLocationsCall{Call: call}
+	return &MockStorageListLocationsCall{Call: call}
 }
 
-// StorageListLocationsCall wrap *gomock.Call
-type StorageListLocationsCall struct {
+// MockStorageListLocationsCall wrap *gomock.Call
+type MockStorageListLocationsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *StorageListLocationsCall) Return(arg0 storage.LocationCollection, arg1 error) *StorageListLocationsCall {
+func (c *MockStorageListLocationsCall) Return(arg0 storage.LocationCollection, arg1 error) *MockStorageListLocationsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *StorageListLocationsCall) Do(f func(context.Context) (storage.LocationCollection, error)) *StorageListLocationsCall {
+func (c *MockStorageListLocationsCall) Do(f func(context.Context) (storage.LocationCollection, error)) *MockStorageListLocationsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *StorageListLocationsCall) DoAndReturn(f func(context.Context) (storage.LocationCollection, error)) *StorageListLocationsCall {
+func (c *MockStorageListLocationsCall) DoAndReturn(f func(context.Context) (storage.LocationCollection, error)) *MockStorageListLocationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -168,31 +169,31 @@ func (m *MockStorage) ListPackages(arg0 context.Context) (storage.PackageCollect
 }
 
 // ListPackages indicates an expected call of ListPackages.
-func (mr *MockStorageMockRecorder) ListPackages(arg0 any) *StorageListPackagesCall {
+func (mr *MockStorageMockRecorder) ListPackages(arg0 any) *MockStorageListPackagesCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPackages", reflect.TypeOf((*MockStorage)(nil).ListPackages), arg0)
-	return &StorageListPackagesCall{Call: call}
+	return &MockStorageListPackagesCall{Call: call}
 }
 
-// StorageListPackagesCall wrap *gomock.Call
-type StorageListPackagesCall struct {
+// MockStorageListPackagesCall wrap *gomock.Call
+type MockStorageListPackagesCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *StorageListPackagesCall) Return(arg0 storage.PackageCollection, arg1 error) *StorageListPackagesCall {
+func (c *MockStorageListPackagesCall) Return(arg0 storage.PackageCollection, arg1 error) *MockStorageListPackagesCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *StorageListPackagesCall) Do(f func(context.Context) (storage.PackageCollection, error)) *StorageListPackagesCall {
+func (c *MockStorageListPackagesCall) Do(f func(context.Context) (storage.PackageCollection, error)) *MockStorageListPackagesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *StorageListPackagesCall) DoAndReturn(f func(context.Context) (storage.PackageCollection, error)) *StorageListPackagesCall {
+func (c *MockStorageListPackagesCall) DoAndReturn(f func(context.Context) (storage.PackageCollection, error)) *MockStorageListPackagesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -207,31 +208,31 @@ func (m *MockStorage) LocationPackages(arg0 context.Context, arg1 uuid.UUID) (st
 }
 
 // LocationPackages indicates an expected call of LocationPackages.
-func (mr *MockStorageMockRecorder) LocationPackages(arg0, arg1 any) *StorageLocationPackagesCall {
+func (mr *MockStorageMockRecorder) LocationPackages(arg0, arg1 any) *MockStorageLocationPackagesCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocationPackages", reflect.TypeOf((*MockStorage)(nil).LocationPackages), arg0, arg1)
-	return &StorageLocationPackagesCall{Call: call}
+	return &MockStorageLocationPackagesCall{Call: call}
 }
 
-// StorageLocationPackagesCall wrap *gomock.Call
-type StorageLocationPackagesCall struct {
+// MockStorageLocationPackagesCall wrap *gomock.Call
+type MockStorageLocationPackagesCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *StorageLocationPackagesCall) Return(arg0 storage.PackageCollection, arg1 error) *StorageLocationPackagesCall {
+func (c *MockStorageLocationPackagesCall) Return(arg0 storage.PackageCollection, arg1 error) *MockStorageLocationPackagesCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *StorageLocationPackagesCall) Do(f func(context.Context, uuid.UUID) (storage.PackageCollection, error)) *StorageLocationPackagesCall {
+func (c *MockStorageLocationPackagesCall) Do(f func(context.Context, uuid.UUID) (storage.PackageCollection, error)) *MockStorageLocationPackagesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *StorageLocationPackagesCall) DoAndReturn(f func(context.Context, uuid.UUID) (storage.PackageCollection, error)) *StorageLocationPackagesCall {
+func (c *MockStorageLocationPackagesCall) DoAndReturn(f func(context.Context, uuid.UUID) (storage.PackageCollection, error)) *MockStorageLocationPackagesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -246,31 +247,31 @@ func (m *MockStorage) ReadLocation(arg0 context.Context, arg1 uuid.UUID) (*stora
 }
 
 // ReadLocation indicates an expected call of ReadLocation.
-func (mr *MockStorageMockRecorder) ReadLocation(arg0, arg1 any) *StorageReadLocationCall {
+func (mr *MockStorageMockRecorder) ReadLocation(arg0, arg1 any) *MockStorageReadLocationCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadLocation", reflect.TypeOf((*MockStorage)(nil).ReadLocation), arg0, arg1)
-	return &StorageReadLocationCall{Call: call}
+	return &MockStorageReadLocationCall{Call: call}
 }
 
-// StorageReadLocationCall wrap *gomock.Call
-type StorageReadLocationCall struct {
+// MockStorageReadLocationCall wrap *gomock.Call
+type MockStorageReadLocationCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *StorageReadLocationCall) Return(arg0 *storage.Location, arg1 error) *StorageReadLocationCall {
+func (c *MockStorageReadLocationCall) Return(arg0 *storage.Location, arg1 error) *MockStorageReadLocationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *StorageReadLocationCall) Do(f func(context.Context, uuid.UUID) (*storage.Location, error)) *StorageReadLocationCall {
+func (c *MockStorageReadLocationCall) Do(f func(context.Context, uuid.UUID) (*storage.Location, error)) *MockStorageReadLocationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *StorageReadLocationCall) DoAndReturn(f func(context.Context, uuid.UUID) (*storage.Location, error)) *StorageReadLocationCall {
+func (c *MockStorageReadLocationCall) DoAndReturn(f func(context.Context, uuid.UUID) (*storage.Location, error)) *MockStorageReadLocationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -285,31 +286,31 @@ func (m *MockStorage) ReadPackage(arg0 context.Context, arg1 uuid.UUID) (*storag
 }
 
 // ReadPackage indicates an expected call of ReadPackage.
-func (mr *MockStorageMockRecorder) ReadPackage(arg0, arg1 any) *StorageReadPackageCall {
+func (mr *MockStorageMockRecorder) ReadPackage(arg0, arg1 any) *MockStorageReadPackageCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPackage", reflect.TypeOf((*MockStorage)(nil).ReadPackage), arg0, arg1)
-	return &StorageReadPackageCall{Call: call}
+	return &MockStorageReadPackageCall{Call: call}
 }
 
-// StorageReadPackageCall wrap *gomock.Call
-type StorageReadPackageCall struct {
+// MockStorageReadPackageCall wrap *gomock.Call
+type MockStorageReadPackageCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *StorageReadPackageCall) Return(arg0 *storage.Package, arg1 error) *StorageReadPackageCall {
+func (c *MockStorageReadPackageCall) Return(arg0 *storage.Package, arg1 error) *MockStorageReadPackageCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *StorageReadPackageCall) Do(f func(context.Context, uuid.UUID) (*storage.Package, error)) *StorageReadPackageCall {
+func (c *MockStorageReadPackageCall) Do(f func(context.Context, uuid.UUID) (*storage.Package, error)) *MockStorageReadPackageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *StorageReadPackageCall) DoAndReturn(f func(context.Context, uuid.UUID) (*storage.Package, error)) *StorageReadPackageCall {
+func (c *MockStorageReadPackageCall) DoAndReturn(f func(context.Context, uuid.UUID) (*storage.Package, error)) *MockStorageReadPackageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -323,31 +324,31 @@ func (m *MockStorage) UpdatePackageLocationID(arg0 context.Context, arg1, arg2 u
 }
 
 // UpdatePackageLocationID indicates an expected call of UpdatePackageLocationID.
-func (mr *MockStorageMockRecorder) UpdatePackageLocationID(arg0, arg1, arg2 any) *StorageUpdatePackageLocationIDCall {
+func (mr *MockStorageMockRecorder) UpdatePackageLocationID(arg0, arg1, arg2 any) *MockStorageUpdatePackageLocationIDCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePackageLocationID", reflect.TypeOf((*MockStorage)(nil).UpdatePackageLocationID), arg0, arg1, arg2)
-	return &StorageUpdatePackageLocationIDCall{Call: call}
+	return &MockStorageUpdatePackageLocationIDCall{Call: call}
 }
 
-// StorageUpdatePackageLocationIDCall wrap *gomock.Call
-type StorageUpdatePackageLocationIDCall struct {
+// MockStorageUpdatePackageLocationIDCall wrap *gomock.Call
+type MockStorageUpdatePackageLocationIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *StorageUpdatePackageLocationIDCall) Return(arg0 error) *StorageUpdatePackageLocationIDCall {
+func (c *MockStorageUpdatePackageLocationIDCall) Return(arg0 error) *MockStorageUpdatePackageLocationIDCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *StorageUpdatePackageLocationIDCall) Do(f func(context.Context, uuid.UUID, uuid.UUID) error) *StorageUpdatePackageLocationIDCall {
+func (c *MockStorageUpdatePackageLocationIDCall) Do(f func(context.Context, uuid.UUID, uuid.UUID) error) *MockStorageUpdatePackageLocationIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *StorageUpdatePackageLocationIDCall) DoAndReturn(f func(context.Context, uuid.UUID, uuid.UUID) error) *StorageUpdatePackageLocationIDCall {
+func (c *MockStorageUpdatePackageLocationIDCall) DoAndReturn(f func(context.Context, uuid.UUID, uuid.UUID) error) *MockStorageUpdatePackageLocationIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -361,31 +362,31 @@ func (m *MockStorage) UpdatePackageStatus(arg0 context.Context, arg1 uuid.UUID, 
 }
 
 // UpdatePackageStatus indicates an expected call of UpdatePackageStatus.
-func (mr *MockStorageMockRecorder) UpdatePackageStatus(arg0, arg1, arg2 any) *StorageUpdatePackageStatusCall {
+func (mr *MockStorageMockRecorder) UpdatePackageStatus(arg0, arg1, arg2 any) *MockStorageUpdatePackageStatusCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePackageStatus", reflect.TypeOf((*MockStorage)(nil).UpdatePackageStatus), arg0, arg1, arg2)
-	return &StorageUpdatePackageStatusCall{Call: call}
+	return &MockStorageUpdatePackageStatusCall{Call: call}
 }
 
-// StorageUpdatePackageStatusCall wrap *gomock.Call
-type StorageUpdatePackageStatusCall struct {
+// MockStorageUpdatePackageStatusCall wrap *gomock.Call
+type MockStorageUpdatePackageStatusCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *StorageUpdatePackageStatusCall) Return(arg0 error) *StorageUpdatePackageStatusCall {
+func (c *MockStorageUpdatePackageStatusCall) Return(arg0 error) *MockStorageUpdatePackageStatusCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *StorageUpdatePackageStatusCall) Do(f func(context.Context, uuid.UUID, types.PackageStatus) error) *StorageUpdatePackageStatusCall {
+func (c *MockStorageUpdatePackageStatusCall) Do(f func(context.Context, uuid.UUID, types.PackageStatus) error) *MockStorageUpdatePackageStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *StorageUpdatePackageStatusCall) DoAndReturn(f func(context.Context, uuid.UUID, types.PackageStatus) error) *StorageUpdatePackageStatusCall {
+func (c *MockStorageUpdatePackageStatusCall) DoAndReturn(f func(context.Context, uuid.UUID, types.PackageStatus) error) *MockStorageUpdatePackageStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/storage/service_test.go
+++ b/internal/storage/service_test.go
@@ -830,7 +830,7 @@ func TestPackageReader(t *testing.T) {
 			).
 			Times(1)
 
-		reader, err := svc.PackageReader(ctx, &goastorage.Package{
+		reader, _, err := svc.PackageReader(ctx, &goastorage.Package{
 			AipID:      aipID,
 			ObjectKey:  aipID,
 			LocationID: &locationID,
@@ -864,7 +864,7 @@ func TestPackageReader(t *testing.T) {
 			).
 			Times(1)
 
-		_, err := svc.PackageReader(ctx, &goastorage.Package{
+		_, _, err := svc.PackageReader(ctx, &goastorage.Package{
 			AipID:      AIPID,
 			ObjectKey:  AIPID,
 			LocationID: &locationID,
@@ -899,7 +899,7 @@ func TestPackageReader(t *testing.T) {
 			).
 			Times(1)
 
-		_, err := svc.PackageReader(ctx, &goastorage.Package{
+		_, _, err := svc.PackageReader(ctx, &goastorage.Package{
 			AipID:      aipID,
 			ObjectKey:  aipID,
 			LocationID: &locationID,

--- a/internal/upload/fake/mock_upload.go
+++ b/internal/upload/fake/mock_upload.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -typed -destination=./internal/upload/fake/mock_upload.go -package=fake github.com/artefactual-sdps/enduro/internal/upload Service
 //
+
 // Package fake is a generated GoMock package.
 package fake
 
@@ -50,31 +51,31 @@ func (m *MockService) Bucket() *blob.Bucket {
 }
 
 // Bucket indicates an expected call of Bucket.
-func (mr *MockServiceMockRecorder) Bucket() *ServiceBucketCall {
+func (mr *MockServiceMockRecorder) Bucket() *MockServiceBucketCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bucket", reflect.TypeOf((*MockService)(nil).Bucket))
-	return &ServiceBucketCall{Call: call}
+	return &MockServiceBucketCall{Call: call}
 }
 
-// ServiceBucketCall wrap *gomock.Call
-type ServiceBucketCall struct {
+// MockServiceBucketCall wrap *gomock.Call
+type MockServiceBucketCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceBucketCall) Return(arg0 *blob.Bucket) *ServiceBucketCall {
+func (c *MockServiceBucketCall) Return(arg0 *blob.Bucket) *MockServiceBucketCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceBucketCall) Do(f func() *blob.Bucket) *ServiceBucketCall {
+func (c *MockServiceBucketCall) Do(f func() *blob.Bucket) *MockServiceBucketCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceBucketCall) DoAndReturn(f func() *blob.Bucket) *ServiceBucketCall {
+func (c *MockServiceBucketCall) DoAndReturn(f func() *blob.Bucket) *MockServiceBucketCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -88,31 +89,31 @@ func (m *MockService) Close() error {
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockServiceMockRecorder) Close() *ServiceCloseCall {
+func (mr *MockServiceMockRecorder) Close() *MockServiceCloseCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockService)(nil).Close))
-	return &ServiceCloseCall{Call: call}
+	return &MockServiceCloseCall{Call: call}
 }
 
-// ServiceCloseCall wrap *gomock.Call
-type ServiceCloseCall struct {
+// MockServiceCloseCall wrap *gomock.Call
+type MockServiceCloseCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceCloseCall) Return(arg0 error) *ServiceCloseCall {
+func (c *MockServiceCloseCall) Return(arg0 error) *MockServiceCloseCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceCloseCall) Do(f func() error) *ServiceCloseCall {
+func (c *MockServiceCloseCall) Do(f func() error) *MockServiceCloseCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceCloseCall) DoAndReturn(f func() error) *ServiceCloseCall {
+func (c *MockServiceCloseCall) DoAndReturn(f func() error) *MockServiceCloseCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -126,31 +127,31 @@ func (m *MockService) Upload(arg0 context.Context, arg1 *upload.UploadPayload, a
 }
 
 // Upload indicates an expected call of Upload.
-func (mr *MockServiceMockRecorder) Upload(arg0, arg1, arg2 any) *ServiceUploadCall {
+func (mr *MockServiceMockRecorder) Upload(arg0, arg1, arg2 any) *MockServiceUploadCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*MockService)(nil).Upload), arg0, arg1, arg2)
-	return &ServiceUploadCall{Call: call}
+	return &MockServiceUploadCall{Call: call}
 }
 
-// ServiceUploadCall wrap *gomock.Call
-type ServiceUploadCall struct {
+// MockServiceUploadCall wrap *gomock.Call
+type MockServiceUploadCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceUploadCall) Return(arg0 error) *ServiceUploadCall {
+func (c *MockServiceUploadCall) Return(arg0 error) *MockServiceUploadCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceUploadCall) Do(f func(context.Context, *upload.UploadPayload, io.ReadCloser) error) *ServiceUploadCall {
+func (c *MockServiceUploadCall) Do(f func(context.Context, *upload.UploadPayload, io.ReadCloser) error) *MockServiceUploadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceUploadCall) DoAndReturn(f func(context.Context, *upload.UploadPayload, io.ReadCloser) error) *ServiceUploadCall {
+func (c *MockServiceUploadCall) DoAndReturn(f func(context.Context, *upload.UploadPayload, io.ReadCloser) error) *MockServiceUploadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/watcher/fake/mock_service.go
+++ b/internal/watcher/fake/mock_service.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -typed -destination=./internal/watcher/fake/mock_service.go -package=fake github.com/artefactual-sdps/enduro/internal/watcher Service
 //
+
 // Package fake is a generated GoMock package.
 package fake
 
@@ -50,31 +51,31 @@ func (m *MockService) ByName(arg0 string) (watcher.Watcher, error) {
 }
 
 // ByName indicates an expected call of ByName.
-func (mr *MockServiceMockRecorder) ByName(arg0 any) *ServiceByNameCall {
+func (mr *MockServiceMockRecorder) ByName(arg0 any) *MockServiceByNameCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ByName", reflect.TypeOf((*MockService)(nil).ByName), arg0)
-	return &ServiceByNameCall{Call: call}
+	return &MockServiceByNameCall{Call: call}
 }
 
-// ServiceByNameCall wrap *gomock.Call
-type ServiceByNameCall struct {
+// MockServiceByNameCall wrap *gomock.Call
+type MockServiceByNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceByNameCall) Return(arg0 watcher.Watcher, arg1 error) *ServiceByNameCall {
+func (c *MockServiceByNameCall) Return(arg0 watcher.Watcher, arg1 error) *MockServiceByNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceByNameCall) Do(f func(string) (watcher.Watcher, error)) *ServiceByNameCall {
+func (c *MockServiceByNameCall) Do(f func(string) (watcher.Watcher, error)) *MockServiceByNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceByNameCall) DoAndReturn(f func(string) (watcher.Watcher, error)) *ServiceByNameCall {
+func (c *MockServiceByNameCall) DoAndReturn(f func(string) (watcher.Watcher, error)) *MockServiceByNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -88,31 +89,31 @@ func (m *MockService) Delete(arg0 context.Context, arg1, arg2 string) error {
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockServiceMockRecorder) Delete(arg0, arg1, arg2 any) *ServiceDeleteCall {
+func (mr *MockServiceMockRecorder) Delete(arg0, arg1, arg2 any) *MockServiceDeleteCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockService)(nil).Delete), arg0, arg1, arg2)
-	return &ServiceDeleteCall{Call: call}
+	return &MockServiceDeleteCall{Call: call}
 }
 
-// ServiceDeleteCall wrap *gomock.Call
-type ServiceDeleteCall struct {
+// MockServiceDeleteCall wrap *gomock.Call
+type MockServiceDeleteCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceDeleteCall) Return(arg0 error) *ServiceDeleteCall {
+func (c *MockServiceDeleteCall) Return(arg0 error) *MockServiceDeleteCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceDeleteCall) Do(f func(context.Context, string, string) error) *ServiceDeleteCall {
+func (c *MockServiceDeleteCall) Do(f func(context.Context, string, string) error) *MockServiceDeleteCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceDeleteCall) DoAndReturn(f func(context.Context, string, string) error) *ServiceDeleteCall {
+func (c *MockServiceDeleteCall) DoAndReturn(f func(context.Context, string, string) error) *MockServiceDeleteCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -126,31 +127,31 @@ func (m *MockService) Dispose(arg0 context.Context, arg1, arg2 string) error {
 }
 
 // Dispose indicates an expected call of Dispose.
-func (mr *MockServiceMockRecorder) Dispose(arg0, arg1, arg2 any) *ServiceDisposeCall {
+func (mr *MockServiceMockRecorder) Dispose(arg0, arg1, arg2 any) *MockServiceDisposeCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dispose", reflect.TypeOf((*MockService)(nil).Dispose), arg0, arg1, arg2)
-	return &ServiceDisposeCall{Call: call}
+	return &MockServiceDisposeCall{Call: call}
 }
 
-// ServiceDisposeCall wrap *gomock.Call
-type ServiceDisposeCall struct {
+// MockServiceDisposeCall wrap *gomock.Call
+type MockServiceDisposeCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceDisposeCall) Return(arg0 error) *ServiceDisposeCall {
+func (c *MockServiceDisposeCall) Return(arg0 error) *MockServiceDisposeCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceDisposeCall) Do(f func(context.Context, string, string) error) *ServiceDisposeCall {
+func (c *MockServiceDisposeCall) Do(f func(context.Context, string, string) error) *MockServiceDisposeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceDisposeCall) DoAndReturn(f func(context.Context, string, string) error) *ServiceDisposeCall {
+func (c *MockServiceDisposeCall) DoAndReturn(f func(context.Context, string, string) error) *MockServiceDisposeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -164,31 +165,31 @@ func (m *MockService) Download(arg0 context.Context, arg1 io.Writer, arg2, arg3 
 }
 
 // Download indicates an expected call of Download.
-func (mr *MockServiceMockRecorder) Download(arg0, arg1, arg2, arg3 any) *ServiceDownloadCall {
+func (mr *MockServiceMockRecorder) Download(arg0, arg1, arg2, arg3 any) *MockServiceDownloadCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockService)(nil).Download), arg0, arg1, arg2, arg3)
-	return &ServiceDownloadCall{Call: call}
+	return &MockServiceDownloadCall{Call: call}
 }
 
-// ServiceDownloadCall wrap *gomock.Call
-type ServiceDownloadCall struct {
+// MockServiceDownloadCall wrap *gomock.Call
+type MockServiceDownloadCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceDownloadCall) Return(arg0 error) *ServiceDownloadCall {
+func (c *MockServiceDownloadCall) Return(arg0 error) *MockServiceDownloadCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceDownloadCall) Do(f func(context.Context, io.Writer, string, string) error) *ServiceDownloadCall {
+func (c *MockServiceDownloadCall) Do(f func(context.Context, io.Writer, string, string) error) *MockServiceDownloadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceDownloadCall) DoAndReturn(f func(context.Context, io.Writer, string, string) error) *ServiceDownloadCall {
+func (c *MockServiceDownloadCall) DoAndReturn(f func(context.Context, io.Writer, string, string) error) *MockServiceDownloadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -202,31 +203,31 @@ func (m *MockService) Watchers() []watcher.Watcher {
 }
 
 // Watchers indicates an expected call of Watchers.
-func (mr *MockServiceMockRecorder) Watchers() *ServiceWatchersCall {
+func (mr *MockServiceMockRecorder) Watchers() *MockServiceWatchersCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watchers", reflect.TypeOf((*MockService)(nil).Watchers))
-	return &ServiceWatchersCall{Call: call}
+	return &MockServiceWatchersCall{Call: call}
 }
 
-// ServiceWatchersCall wrap *gomock.Call
-type ServiceWatchersCall struct {
+// MockServiceWatchersCall wrap *gomock.Call
+type MockServiceWatchersCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *ServiceWatchersCall) Return(arg0 []watcher.Watcher) *ServiceWatchersCall {
+func (c *MockServiceWatchersCall) Return(arg0 []watcher.Watcher) *MockServiceWatchersCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *ServiceWatchersCall) Do(f func() []watcher.Watcher) *ServiceWatchersCall {
+func (c *MockServiceWatchersCall) Do(f func() []watcher.Watcher) *MockServiceWatchersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *ServiceWatchersCall) DoAndReturn(f func() []watcher.Watcher) *ServiceWatchersCall {
+func (c *MockServiceWatchersCall) DoAndReturn(f func() []watcher.Watcher) *MockServiceWatchersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/watcher/fake/mock_watcher.go
+++ b/internal/watcher/fake/mock_watcher.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -typed -destination=./internal/watcher/fake/mock_watcher.go -package=fake github.com/artefactual-sdps/enduro/internal/watcher Watcher
 //
+
 // Package fake is a generated GoMock package.
 package fake
 
@@ -50,31 +51,31 @@ func (m *MockWatcher) CompletedDir() string {
 }
 
 // CompletedDir indicates an expected call of CompletedDir.
-func (mr *MockWatcherMockRecorder) CompletedDir() *WatcherCompletedDirCall {
+func (mr *MockWatcherMockRecorder) CompletedDir() *MockWatcherCompletedDirCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompletedDir", reflect.TypeOf((*MockWatcher)(nil).CompletedDir))
-	return &WatcherCompletedDirCall{Call: call}
+	return &MockWatcherCompletedDirCall{Call: call}
 }
 
-// WatcherCompletedDirCall wrap *gomock.Call
-type WatcherCompletedDirCall struct {
+// MockWatcherCompletedDirCall wrap *gomock.Call
+type MockWatcherCompletedDirCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *WatcherCompletedDirCall) Return(arg0 string) *WatcherCompletedDirCall {
+func (c *MockWatcherCompletedDirCall) Return(arg0 string) *MockWatcherCompletedDirCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *WatcherCompletedDirCall) Do(f func() string) *WatcherCompletedDirCall {
+func (c *MockWatcherCompletedDirCall) Do(f func() string) *MockWatcherCompletedDirCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *WatcherCompletedDirCall) DoAndReturn(f func() string) *WatcherCompletedDirCall {
+func (c *MockWatcherCompletedDirCall) DoAndReturn(f func() string) *MockWatcherCompletedDirCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -89,31 +90,31 @@ func (m *MockWatcher) OpenBucket(arg0 context.Context) (*blob.Bucket, error) {
 }
 
 // OpenBucket indicates an expected call of OpenBucket.
-func (mr *MockWatcherMockRecorder) OpenBucket(arg0 any) *WatcherOpenBucketCall {
+func (mr *MockWatcherMockRecorder) OpenBucket(arg0 any) *MockWatcherOpenBucketCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenBucket", reflect.TypeOf((*MockWatcher)(nil).OpenBucket), arg0)
-	return &WatcherOpenBucketCall{Call: call}
+	return &MockWatcherOpenBucketCall{Call: call}
 }
 
-// WatcherOpenBucketCall wrap *gomock.Call
-type WatcherOpenBucketCall struct {
+// MockWatcherOpenBucketCall wrap *gomock.Call
+type MockWatcherOpenBucketCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *WatcherOpenBucketCall) Return(arg0 *blob.Bucket, arg1 error) *WatcherOpenBucketCall {
+func (c *MockWatcherOpenBucketCall) Return(arg0 *blob.Bucket, arg1 error) *MockWatcherOpenBucketCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *WatcherOpenBucketCall) Do(f func(context.Context) (*blob.Bucket, error)) *WatcherOpenBucketCall {
+func (c *MockWatcherOpenBucketCall) Do(f func(context.Context) (*blob.Bucket, error)) *MockWatcherOpenBucketCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *WatcherOpenBucketCall) DoAndReturn(f func(context.Context) (*blob.Bucket, error)) *WatcherOpenBucketCall {
+func (c *MockWatcherOpenBucketCall) DoAndReturn(f func(context.Context) (*blob.Bucket, error)) *MockWatcherOpenBucketCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -127,31 +128,31 @@ func (m *MockWatcher) Path() string {
 }
 
 // Path indicates an expected call of Path.
-func (mr *MockWatcherMockRecorder) Path() *WatcherPathCall {
+func (mr *MockWatcherMockRecorder) Path() *MockWatcherPathCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Path", reflect.TypeOf((*MockWatcher)(nil).Path))
-	return &WatcherPathCall{Call: call}
+	return &MockWatcherPathCall{Call: call}
 }
 
-// WatcherPathCall wrap *gomock.Call
-type WatcherPathCall struct {
+// MockWatcherPathCall wrap *gomock.Call
+type MockWatcherPathCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *WatcherPathCall) Return(arg0 string) *WatcherPathCall {
+func (c *MockWatcherPathCall) Return(arg0 string) *MockWatcherPathCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *WatcherPathCall) Do(f func() string) *WatcherPathCall {
+func (c *MockWatcherPathCall) Do(f func() string) *MockWatcherPathCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *WatcherPathCall) DoAndReturn(f func() string) *WatcherPathCall {
+func (c *MockWatcherPathCall) DoAndReturn(f func() string) *MockWatcherPathCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -165,31 +166,31 @@ func (m *MockWatcher) RetentionPeriod() *time.Duration {
 }
 
 // RetentionPeriod indicates an expected call of RetentionPeriod.
-func (mr *MockWatcherMockRecorder) RetentionPeriod() *WatcherRetentionPeriodCall {
+func (mr *MockWatcherMockRecorder) RetentionPeriod() *MockWatcherRetentionPeriodCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetentionPeriod", reflect.TypeOf((*MockWatcher)(nil).RetentionPeriod))
-	return &WatcherRetentionPeriodCall{Call: call}
+	return &MockWatcherRetentionPeriodCall{Call: call}
 }
 
-// WatcherRetentionPeriodCall wrap *gomock.Call
-type WatcherRetentionPeriodCall struct {
+// MockWatcherRetentionPeriodCall wrap *gomock.Call
+type MockWatcherRetentionPeriodCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *WatcherRetentionPeriodCall) Return(arg0 *time.Duration) *WatcherRetentionPeriodCall {
+func (c *MockWatcherRetentionPeriodCall) Return(arg0 *time.Duration) *MockWatcherRetentionPeriodCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *WatcherRetentionPeriodCall) Do(f func() *time.Duration) *WatcherRetentionPeriodCall {
+func (c *MockWatcherRetentionPeriodCall) Do(f func() *time.Duration) *MockWatcherRetentionPeriodCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *WatcherRetentionPeriodCall) DoAndReturn(f func() *time.Duration) *WatcherRetentionPeriodCall {
+func (c *MockWatcherRetentionPeriodCall) DoAndReturn(f func() *time.Duration) *MockWatcherRetentionPeriodCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -203,31 +204,31 @@ func (m *MockWatcher) String() string {
 }
 
 // String indicates an expected call of String.
-func (mr *MockWatcherMockRecorder) String() *WatcherStringCall {
+func (mr *MockWatcherMockRecorder) String() *MockWatcherStringCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockWatcher)(nil).String))
-	return &WatcherStringCall{Call: call}
+	return &MockWatcherStringCall{Call: call}
 }
 
-// WatcherStringCall wrap *gomock.Call
-type WatcherStringCall struct {
+// MockWatcherStringCall wrap *gomock.Call
+type MockWatcherStringCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *WatcherStringCall) Return(arg0 string) *WatcherStringCall {
+func (c *MockWatcherStringCall) Return(arg0 string) *MockWatcherStringCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *WatcherStringCall) Do(f func() string) *WatcherStringCall {
+func (c *MockWatcherStringCall) Do(f func() string) *MockWatcherStringCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *WatcherStringCall) DoAndReturn(f func() string) *WatcherStringCall {
+func (c *MockWatcherStringCall) DoAndReturn(f func() string) *MockWatcherStringCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -241,31 +242,31 @@ func (m *MockWatcher) StripTopLevelDir() bool {
 }
 
 // StripTopLevelDir indicates an expected call of StripTopLevelDir.
-func (mr *MockWatcherMockRecorder) StripTopLevelDir() *WatcherStripTopLevelDirCall {
+func (mr *MockWatcherMockRecorder) StripTopLevelDir() *MockWatcherStripTopLevelDirCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StripTopLevelDir", reflect.TypeOf((*MockWatcher)(nil).StripTopLevelDir))
-	return &WatcherStripTopLevelDirCall{Call: call}
+	return &MockWatcherStripTopLevelDirCall{Call: call}
 }
 
-// WatcherStripTopLevelDirCall wrap *gomock.Call
-type WatcherStripTopLevelDirCall struct {
+// MockWatcherStripTopLevelDirCall wrap *gomock.Call
+type MockWatcherStripTopLevelDirCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *WatcherStripTopLevelDirCall) Return(arg0 bool) *WatcherStripTopLevelDirCall {
+func (c *MockWatcherStripTopLevelDirCall) Return(arg0 bool) *MockWatcherStripTopLevelDirCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *WatcherStripTopLevelDirCall) Do(f func() bool) *WatcherStripTopLevelDirCall {
+func (c *MockWatcherStripTopLevelDirCall) Do(f func() bool) *MockWatcherStripTopLevelDirCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *WatcherStripTopLevelDirCall) DoAndReturn(f func() bool) *WatcherStripTopLevelDirCall {
+func (c *MockWatcherStripTopLevelDirCall) DoAndReturn(f func() bool) *MockWatcherStripTopLevelDirCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -281,31 +282,31 @@ func (m *MockWatcher) Watch(arg0 context.Context) (*watcher.BlobEvent, watcher.C
 }
 
 // Watch indicates an expected call of Watch.
-func (mr *MockWatcherMockRecorder) Watch(arg0 any) *WatcherWatchCall {
+func (mr *MockWatcherMockRecorder) Watch(arg0 any) *MockWatcherWatchCall {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockWatcher)(nil).Watch), arg0)
-	return &WatcherWatchCall{Call: call}
+	return &MockWatcherWatchCall{Call: call}
 }
 
-// WatcherWatchCall wrap *gomock.Call
-type WatcherWatchCall struct {
+// MockWatcherWatchCall wrap *gomock.Call
+type MockWatcherWatchCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *WatcherWatchCall) Return(arg0 *watcher.BlobEvent, arg1 watcher.Cleanup, arg2 error) *WatcherWatchCall {
+func (c *MockWatcherWatchCall) Return(arg0 *watcher.BlobEvent, arg1 watcher.Cleanup, arg2 error) *MockWatcherWatchCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *WatcherWatchCall) Do(f func(context.Context) (*watcher.BlobEvent, watcher.Cleanup, error)) *WatcherWatchCall {
+func (c *MockWatcherWatchCall) Do(f func(context.Context) (*watcher.BlobEvent, watcher.Cleanup, error)) *MockWatcherWatchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *WatcherWatchCall) DoAndReturn(f func(context.Context) (*watcher.BlobEvent, watcher.Cleanup, error)) *WatcherWatchCall {
+func (c *MockWatcherWatchCall) DoAndReturn(f func(context.Context) (*watcher.BlobEvent, watcher.Cleanup, error)) *MockWatcherWatchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
This implementation does not use the preservation config for determining
the correct call to download, instead it leverages the package reader
function and the Location interface to manage the correct storage service
to use.

This is partially implemented. Not sure how to actually snag the url from
the location configuration. I really need guidance there. This also seems
rather complex compared to the other implementation.

Closes https://github.com/artefactual-sdps/enduro/issues/820.
