### PR TITLE
Add path activation script

### DIFF
--- a/hack/activate.fish
+++ b/hack/activate.fish
@@ -1,0 +1,46 @@
+# This file must be used with "source hack/activate.fish" *from fish*
+# (https://fishshell.com/). You cannot run it directly.
+
+function deactivate -d "Exit virtual environment and return to normal shell environment"
+    if test -n "$_OLD_VIRTUAL_PATH"
+        set -gx PATH $_OLD_VIRTUAL_PATH
+        set -e _OLD_VIRTUAL_PATH
+    end
+
+    if test -n "$_OLD_FISH_PROMPT_OVERRIDE"
+        set -e _OLD_FISH_PROMPT_OVERRIDE
+        # prevents error when using nested fish instances (Issue #93858)
+        if functions -q _old_fish_prompt
+            functions -e fish_prompt
+            functions -c _old_fish_prompt fish_prompt
+            functions -e _old_fish_prompt
+        end
+    end
+
+    set -e VIRTUAL_ENV
+    set -e VIRTUAL_ENV_PROMPT
+    if test "$argv[1]" != "nondestructive"
+        # Self-destruct!
+        functions -e deactivate
+    end
+end
+
+# Unset irrelevant variables.
+deactivate nondestructive
+
+set -gx VIRTUAL_ENV "$HOME/.cache/enduro-sdps/Linux/x86_64/bin"
+
+set -gx _OLD_VIRTUAL_PATH $PATH
+set -gx PATH "$VIRTUAL_ENV" $PATH
+
+if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
+    functions -c fish_prompt _old_fish_prompt
+    function fish_prompt
+        set -l old_status $status
+        printf "%s%s%s" (set_color 4B8BBE) "(.venv) " (set_color normal)
+        echo "exit $old_status" | .
+        _old_fish_prompt
+    end
+    set -gx _OLD_FISH_PROMPT_OVERRIDE "$VIRTUAL_ENV"
+    set -gx VIRTUAL_ENV_PROMPT "(.venv) "
+end

--- a/hack/activate.fish
+++ b/hack/activate.fish
@@ -1,5 +1,6 @@
 # This file must be used with "source hack/activate.fish" *from fish*
-# (https://fishshell.com/). You cannot run it directly.
+# (https://fishshell.com/docs/current/cmds/source.html). You cannot run it
+# directly.
 
 function deactivate -d "Exit virtual environment and return to normal shell environment"
     if test -n "$_OLD_VIRTUAL_PATH"
@@ -9,7 +10,7 @@ function deactivate -d "Exit virtual environment and return to normal shell envi
 
     if test -n "$_OLD_FISH_PROMPT_OVERRIDE"
         set -e _OLD_FISH_PROMPT_OVERRIDE
-        # prevents error when using nested fish instances (Issue #93858)
+        # Prevents error when using nested fish instances (Issue #93858).
         if functions -q _old_fish_prompt
             functions -e fish_prompt
             functions -c _old_fish_prompt fish_prompt


### PR DESCRIPTION
This pull request includes a path activation script for the fish shell inspired by Python's virtual environments.

Usage:

    source hack/activate.fish

It adds the local binary cache directory of the project to the PATH environment string. Now you can use tools like ent, goa, golangci-lint, gomajor, gosec, gotestsum, mockgen, shfmt or tparse with the confidence of using the versions required by this project as opposed to any global version you have installed previously.

If you're using devbox, the equivalent would be to execute `devbox shell`.

