### PR TITLE
dev/fix indenting lint rules

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -7,4 +7,7 @@
     "code_blocks": false,
     "tables": false,
   },
+  "MD007": {
+    "indent": 4
+  }
 }

--- a/docs/src/dev-manual/README.md
+++ b/docs/src/dev-manual/README.md
@@ -5,7 +5,7 @@ This is the developer manual for Enduro SDPS.
 - [Documentation](docs.md)
 - [Dependency management](deps.md)
 - [Environment setup](devel.md)
-  - [Working with Archivematica](archivematica.md)
+    - [Working with Archivematica](archivematica.md)
 - [Logging](logging.md)
 - [Makefile](make.md)
 - [Testing](testing.md)

--- a/docs/src/dev-manual/archivematica.md
+++ b/docs/src/dev-manual/archivematica.md
@@ -20,7 +20,7 @@ inside the cluster, and they are not tracked in the repository.
 
 ### Quick checklist for configuration files
 
-#### `.am.secret` file
+#### `.am.secret`
 
 - Location: `hack/kube/overlays/dev-am/.am.secret`
 - **Contents to check:**
@@ -30,7 +30,7 @@ inside the cluster, and they are not tracked in the repository.
   details (`sftp_host=`, `sftp_port=`, `sftp_user=`,
   `sftp_remote_dir=`, `sftp_private_key_passphrase=`).
 
-#### `.id_ed25519.secret` file
+#### `.id_ed25519.secret`
 
 - Location: `hack/kube/overlays/dev-am/.id_ed25519.secret`
 - **Contents to check:**
@@ -38,7 +38,7 @@ inside the cluster, and they are not tracked in the repository.
   OPENSSH PRIVATE KEY-----` and ends with `-----END
   OPENSSH PRIVATE KEY-----`)
 
-#### `.known_hosts.secret` file
+#### `.known_hosts.secret`
 
 - Location: `hack/kube/overlays/dev-am/.known_hosts.secret`
 - **Contents to check:**
@@ -46,13 +46,13 @@ inside the cluster, and they are not tracked in the repository.
       `|1|` and containing `ssh-rsa`, `ecdsa-sha2-nistp256`,
       `ssh-ed25519` etc.)
 
-#### `.tilt.env` file
+#### `.tilt.env`
 
 - Location: `root/`
 - **Contents to check:**
     - `ENDURO_PRES_SYSTEM = "am"`
 
-#### `enduro.toml` file
+#### `enduro.toml`
 
 - Location: `root/`
 - **Contents to check:**

--- a/docs/src/dev-manual/archivematica.md
+++ b/docs/src/dev-manual/archivematica.md
@@ -20,7 +20,7 @@ inside the cluster, and they are not tracked in the repository.
 
 ### Quick Checklist for Configuration Files
 
-#### .am.secret File
+#### `.am.secret` file
 
 - Location: `hack/kube/overlays/dev-am/.am.secret`
 - **Contents to Check:**
@@ -30,7 +30,7 @@ inside the cluster, and they are not tracked in the repository.
   details (`sftp_host=`, `sftp_port=`, `sftp_user=`,
   `sftp_remote_dir=`, `sftp_private_key_passphrase=`).
 
-#### .id_ed25519.secret File
+#### `.id_ed25519.secret` file
 
 - Location: `hack/kube/overlays/dev-am/.id_ed25519.secret`
 - **Contents to Check:**
@@ -38,7 +38,7 @@ inside the cluster, and they are not tracked in the repository.
   OPENSSH PRIVATE KEY-----` and ends with `-----END
   OPENSSH PRIVATE KEY-----`)
 
-#### .known_hosts.secret File
+#### `.known_hosts.secret` file
 
 - Location: `hack/kube/overlays/dev-am/.known_hosts.secret`
 - **Contents to Check:**
@@ -46,13 +46,13 @@ inside the cluster, and they are not tracked in the repository.
       `|1|` and containing `ssh-rsa`, `ecdsa-sha2-nistp256`,
       `ssh-ed25519` etc.)
 
-#### .tilt.env File
+#### `.tilt.env` file
 
 - Location: `root/`
 - **Contents to check:**
   - ENDURO_PRES_SYSTEM = "am"
 
-#### enduro.toml File
+#### `enduro.toml` file
 
 - Location: `root/`
 - **Contents to check:**

--- a/docs/src/dev-manual/archivematica.md
+++ b/docs/src/dev-manual/archivematica.md
@@ -42,9 +42,9 @@ inside the cluster, and they are not tracked in the repository.
 
 - Location: `hack/kube/overlays/dev-am/.known_hosts.secret`
 - **Contents to Check:**
-  - Known hosts entries (Look for entries starting with
-  `|1|` and containing `ssh-rsa`, `ecdsa-sha2-nistp256`,
-  `ssh-ed25519` etc.)
+    - Known hosts entries (Look for entries starting with
+      `|1|` and containing `ssh-rsa`, `ecdsa-sha2-nistp256`,
+      `ssh-ed25519` etc.)
 
 #### .tilt.env File
 

--- a/docs/src/dev-manual/archivematica.md
+++ b/docs/src/dev-manual/archivematica.md
@@ -20,7 +20,7 @@ inside the cluster, and they are not tracked in the repository.
 
 ### Quick Checklist for Configuration Files
 
-- .am.secret File:
+#### .am.secret File:
   - Location: `hack/kube/overlays/dev-am/.am.secret`
   - **Contents to Check:**
     - AM API address (e.g.,`http://host.k3d.internal:62080`)
@@ -28,23 +28,23 @@ inside the cluster, and they are not tracked in the repository.
     - SFTP configuration
     details (`sftp_host=`, `sftp_port=`, `sftp_user=`,
     `sftp_remote_dir=`, `sftp_private_key_passphrase=`).
-- .id_ed25519.secret File:
+#### .id_ed25519.secret File:
   - Location: `hack/kube/overlays/dev-am/.id_ed25519.secret`
   - **Contents to Check:**
     - SSH private key (Ensure it starts with `-----BEGIN
     OPENSSH PRIVATE KEY-----` and ends with `-----END
     OPENSSH PRIVATE KEY-----`)
-- .known_hosts.secret File:
+#### .known_hosts.secret File:
   - Location: `hack/kube/overlays/dev-am/.known_hosts.secret`
   - **Contents to Check:**
     - Known hosts entries (Look for entries starting with
     `|1|` and containing `ssh-rsa`, `ecdsa-sha2-nistp256`,
     `ssh-ed25519` etc.)
-- .tilt.env File:
+#### .tilt.env File:
   - Location: `root/`
   - **Contents to Check:**
     - ENDURO_PRES_SYSTEM = "am"
-- enduro.toml File:
+#### enduro.toml File:
   - Location: `root/`
   - **Contents to Check:**
     - Preservation Taskqueue variable must be set to "am"

--- a/docs/src/dev-manual/archivematica.md
+++ b/docs/src/dev-manual/archivematica.md
@@ -25,7 +25,7 @@ inside the cluster, and they are not tracked in the repository.
 - Location: `hack/kube/overlays/dev-am/.am.secret`
 - **Contents to Check:**
   - AM API address (e.g.,`http://host.k3d.internal:62080`)
-  - User credentials(`user=test`, `api_key=test`)
+  - User credentials (`user=test`, `api_key=test`)
   - SFTP configuration
   details (`sftp_host=`, `sftp_port=`, `sftp_user=`,
   `sftp_remote_dir=`, `sftp_private_key_passphrase=`).
@@ -49,13 +49,13 @@ inside the cluster, and they are not tracked in the repository.
 #### .tilt.env File
 
 - Location: `root/`
-- **Contents to Check:**
+- **Contents to check:**
   - ENDURO_PRES_SYSTEM = "am"
 
 #### enduro.toml File
 
 - Location: `root/`
-- **Contents to Check:**
+- **Contents to check:**
   - Preservation Taskqueue variable must be set to "am"
 
 !!! note

--- a/docs/src/dev-manual/archivematica.md
+++ b/docs/src/dev-manual/archivematica.md
@@ -105,8 +105,8 @@ There is more information on the configuration of the [Tilt Environment].
 
 Preservation system value needed for workflow to be Archvimatica specific:
 
-	[Preservation]
-	taskqueue = "am"
+    [Preservation]
+    taskqueue = "am"
 
 [kustomize secret generator]: https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kustomize/#create-a-secret
 [tilt environment]: (devel.md#-tilt-enviroment-configuration)

--- a/docs/src/dev-manual/archivematica.md
+++ b/docs/src/dev-manual/archivematica.md
@@ -20,7 +20,7 @@ inside the cluster, and they are not tracked in the repository.
 
 ### Quick Checklist for Configuration Files
 
-- [ ] .am.secret File:
+- .am.secret File:
   - Location: `hack/kube/overlays/dev-am/.am.secret`
   - **Contents to Check:**
     - AM API address (e.g.,`http://host.k3d.internal:62080`)
@@ -28,23 +28,23 @@ inside the cluster, and they are not tracked in the repository.
     - SFTP configuration
     details (`sftp_host=`, `sftp_port=`, `sftp_user=`,
     `sftp_remote_dir=`, `sftp_private_key_passphrase=`).
-- [ ] .id_ed25519.secret File:
+- .id_ed25519.secret File:
   - Location: `hack/kube/overlays/dev-am/.id_ed25519.secret`
   - **Contents to Check:**
     - SSH private key (Ensure it starts with `-----BEGIN
     OPENSSH PRIVATE KEY-----` and ends with `-----END
     OPENSSH PRIVATE KEY-----`)
-- [ ] .known_hosts.secret File:
+- .known_hosts.secret File:
   - Location: `hack/kube/overlays/dev-am/.known_hosts.secret`
   - **Contents to Check:**
     - Known hosts entries (Look for entries starting with
     `|1|` and containing `ssh-rsa`, `ecdsa-sha2-nistp256`,
     `ssh-ed25519` etc.)
-- [ ] .tilt.env File:
+- .tilt.env File:
   - Location: `root/`
   - **Contents to Check:**
     - ENDURO_PRES_SYSTEM = "am"
-- [ ] enduro.toml File:
+- enduro.toml File:
   - Location: `root/`
   - **Contents to Check:**
     - Preservation Taskqueue variable must be set to "am"

--- a/docs/src/dev-manual/archivematica.md
+++ b/docs/src/dev-manual/archivematica.md
@@ -20,34 +20,43 @@ inside the cluster, and they are not tracked in the repository.
 
 ### Quick Checklist for Configuration Files
 
-#### .am.secret File:
-  - Location: `hack/kube/overlays/dev-am/.am.secret`
-  - **Contents to Check:**
-    - AM API address (e.g.,`http://host.k3d.internal:62080`)
-    - User credentials(`user=test`, `api_key=test`)
-    - SFTP configuration
-    details (`sftp_host=`, `sftp_port=`, `sftp_user=`,
-    `sftp_remote_dir=`, `sftp_private_key_passphrase=`).
-#### .id_ed25519.secret File:
-  - Location: `hack/kube/overlays/dev-am/.id_ed25519.secret`
-  - **Contents to Check:**
-    - SSH private key (Ensure it starts with `-----BEGIN
-    OPENSSH PRIVATE KEY-----` and ends with `-----END
-    OPENSSH PRIVATE KEY-----`)
-#### .known_hosts.secret File:
-  - Location: `hack/kube/overlays/dev-am/.known_hosts.secret`
-  - **Contents to Check:**
-    - Known hosts entries (Look for entries starting with
-    `|1|` and containing `ssh-rsa`, `ecdsa-sha2-nistp256`,
-    `ssh-ed25519` etc.)
-#### .tilt.env File:
-  - Location: `root/`
-  - **Contents to Check:**
-    - ENDURO_PRES_SYSTEM = "am"
-#### enduro.toml File:
-  - Location: `root/`
-  - **Contents to Check:**
-    - Preservation Taskqueue variable must be set to "am"
+#### .am.secret File
+
+- Location: `hack/kube/overlays/dev-am/.am.secret`
+- **Contents to Check:**
+  - AM API address (e.g.,`http://host.k3d.internal:62080`)
+  - User credentials(`user=test`, `api_key=test`)
+  - SFTP configuration
+  details (`sftp_host=`, `sftp_port=`, `sftp_user=`,
+  `sftp_remote_dir=`, `sftp_private_key_passphrase=`).
+
+#### .id_ed25519.secret File
+
+- Location: `hack/kube/overlays/dev-am/.id_ed25519.secret`
+- **Contents to Check:**
+  - SSH private key (Ensure it starts with `-----BEGIN
+  OPENSSH PRIVATE KEY-----` and ends with `-----END
+  OPENSSH PRIVATE KEY-----`)
+
+#### .known_hosts.secret File
+
+- Location: `hack/kube/overlays/dev-am/.known_hosts.secret`
+- **Contents to Check:**
+  - Known hosts entries (Look for entries starting with
+  `|1|` and containing `ssh-rsa`, `ecdsa-sha2-nistp256`,
+  `ssh-ed25519` etc.)
+
+#### .tilt.env File
+
+- Location: `root/`
+- **Contents to Check:**
+  - ENDURO_PRES_SYSTEM = "am"
+
+#### enduro.toml File
+
+- Location: `root/`
+- **Contents to Check:**
+  - Preservation Taskqueue variable must be set to "am"
 
 !!! note
 

--- a/docs/src/dev-manual/archivematica.md
+++ b/docs/src/dev-manual/archivematica.md
@@ -50,7 +50,7 @@ inside the cluster, and they are not tracked in the repository.
 
 - Location: `root/`
 - **Contents to check:**
-    - ENDURO_PRES_SYSTEM = "am"
+    - `ENDURO_PRES_SYSTEM = "am"`
 
 #### `enduro.toml` file
 

--- a/docs/src/dev-manual/archivematica.md
+++ b/docs/src/dev-manual/archivematica.md
@@ -23,25 +23,25 @@ inside the cluster, and they are not tracked in the repository.
 #### `.am.secret` file
 
 - Location: `hack/kube/overlays/dev-am/.am.secret`
-- **Contents to Check:**
-  - AM API address (e.g.,`http://host.k3d.internal:62080`)
-  - User credentials (`user=test`, `api_key=test`)
-  - SFTP configuration
+- **Contents to check:**
+    - AM API address (e.g.,`http://host.k3d.internal:62080`)
+    - User credentials (`user=test`, `api_key=test`)
+    - SFTP configuration
   details (`sftp_host=`, `sftp_port=`, `sftp_user=`,
   `sftp_remote_dir=`, `sftp_private_key_passphrase=`).
 
 #### `.id_ed25519.secret` file
 
 - Location: `hack/kube/overlays/dev-am/.id_ed25519.secret`
-- **Contents to Check:**
-  - SSH private key (Ensure it starts with `-----BEGIN
+- **Contents to check:**
+    - SSH private key (Ensure it starts with `-----BEGIN
   OPENSSH PRIVATE KEY-----` and ends with `-----END
   OPENSSH PRIVATE KEY-----`)
 
 #### `.known_hosts.secret` file
 
 - Location: `hack/kube/overlays/dev-am/.known_hosts.secret`
-- **Contents to Check:**
+- **Contents to check:**
     - Known hosts entries (Look for entries starting with
       `|1|` and containing `ssh-rsa`, `ecdsa-sha2-nistp256`,
       `ssh-ed25519` etc.)
@@ -50,13 +50,13 @@ inside the cluster, and they are not tracked in the repository.
 
 - Location: `root/`
 - **Contents to check:**
-  - ENDURO_PRES_SYSTEM = "am"
+    - ENDURO_PRES_SYSTEM = "am"
 
 #### `enduro.toml` file
 
 - Location: `root/`
 - **Contents to check:**
-  - Preservation Taskqueue variable must be set to "am"
+    - Preservation Taskqueue variable must be set to "am"
 
 !!! note
 

--- a/docs/src/dev-manual/archivematica.md
+++ b/docs/src/dev-manual/archivematica.md
@@ -18,7 +18,7 @@ inside the cluster, and they are not tracked in the repository.
     the Kubernetes commands for these operations. Understanding the way these
     files are used is NOT required to work with Archivematica.
 
-### Quick Checklist for Configuration Files
+### Quick checklist for configuration files
 
 #### `.am.secret` file
 


### PR DESCRIPTION
- remove checklist
- use subheaders instead
- fix lint error
- Update docs/src/dev-manual/archivematica.md
- fix spacing, case
- fix spacing, case
- fix indenting, breaks markdownlint
- remove hardtabs
- make consistent use of ``
- Update docs/src/dev-manual/archivematica.md
- make consistent use of ``
- Fix markdownlint rules to format indenting
