### PR TITLE
Add activate for bash/zsh

### DIFF
--- a/hack/activate/bash
+++ b/hack/activate/bash
@@ -1,0 +1,55 @@
+# This file must be used with "source hack/activate/bash" *from bash*. You
+# cannot run it directly
+
+deactivate () {
+    # Reset old environment variables.
+    if [ -n "${_OLD_VIRTUAL_PATH:-}" ] ; then
+        PATH="${_OLD_VIRTUAL_PATH:-}"
+        export PATH
+        unset _OLD_VIRTUAL_PATH
+    fi
+
+    # This should detect bash and zsh, which have a hash command that must be
+    # called to get it to forget past commands. Without forgetting past commands
+    # the $PATH changes we made may not be respected.
+    if [ -n "${BASH:-}" -o -n "${ZSH_VERSION:-}" ] ; then
+        hash -r 2> /dev/null
+    fi
+
+    if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
+        PS1="${_OLD_VIRTUAL_PS1:-}"
+        export PS1
+        unset _OLD_VIRTUAL_PS1
+    fi
+
+    unset VIRTUAL_ENV
+    unset VIRTUAL_ENV_PROMPT
+    if [ ! "${1:-}" = "nondestructive" ] ; then
+    # Self destruct!
+        unset -f deactivate
+    fi
+}
+
+# Unset irrelevant variables.
+deactivate nondestructive
+
+export VIRTUAL_ENV="$HOME/.cache/enduro-sdps/Linux/$(uname -m)/bin"
+
+_OLD_VIRTUAL_PATH="$PATH"
+PATH="$VIRTUAL_ENV:$PATH"
+export PATH
+
+if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT:-}" ] ; then
+    _OLD_VIRTUAL_PS1="${PS1:-}"
+    PS1="(.venv) ${PS1:-}"
+    export PS1
+    VIRTUAL_ENV_PROMPT="(.venv) "
+    export VIRTUAL_ENV_PROMPT
+fi
+
+# This should detect bash and zsh, which have a hash command that must be called
+# to get it to forget past commands. Without forgetting past commands the $PATH
+# changes we made may not be respected.
+if [ -n "${BASH:-}" -o -n "${ZSH_VERSION:-}" ] ; then
+    hash -r 2> /dev/null
+fi

--- a/hack/activate/fish
+++ b/hack/activate/fish
@@ -29,7 +29,8 @@ end
 # Unset irrelevant variables.
 deactivate nondestructive
 
-set -gx VIRTUAL_ENV "$HOME/.cache/enduro-sdps/Linux/x86_64/bin"
+set -l arch (uname -m)
+set -gx VIRTUAL_ENV "$HOME/.cache/enduro-sdps/Linux/$arch/bin"
 
 set -gx _OLD_VIRTUAL_PATH $PATH
 set -gx PATH "$VIRTUAL_ENV" $PATH

--- a/hack/activate/fish
+++ b/hack/activate/fish
@@ -1,4 +1,4 @@
-# This file must be used with "source hack/activate.fish" *from fish*
+# This file must be used with "source hack/activate/fish" *from fish*
 # (https://fishshell.com/docs/current/cmds/source.html). You cannot run it
 # directly.
 


### PR DESCRIPTION
Please give it a test! It's copied again from Python's venv with a few simplifications.

Usage: 

```
$ source hack/activate/bash
$ which gotestsum
/home/jesus/.cache/enduro-sdps/Linux/x86_64/bin/gotestsum
```