### PR TITLE
Remove extra loop var copies

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,3 +42,6 @@ linters-settings:
     exclude-generated: false
     severity: low
     confidence: low
+  govet:
+    disable:
+      - loopclosure

--- a/internal/am/delete_transfer_test.go
+++ b/internal/am/delete_transfer_test.go
@@ -82,7 +82,6 @@ func TestDeleteTransferActivity(t *testing.T) {
 			errMsg: fmt.Sprintf("delete transfer: path: %q: %v", td.Join(filename), errors.New("SSH: failed to connect: dial tcp 127.0.0.1:2200: connect: connection refused")),
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/am/job_tracker_test.go
+++ b/internal/am/job_tracker_test.go
@@ -147,7 +147,6 @@ func TestJobTracker(t *testing.T) {
 			wantErr:    "invalid Archivematica credentials",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -270,7 +269,6 @@ func TestConvertJobToPreservationTask(t *testing.T) {
 			want: package_.PreservationTask{},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/am/poll_ingest_test.go
+++ b/internal/am/poll_ingest_test.go
@@ -239,7 +239,6 @@ func TestPollIngestActivity(t *testing.T) {
 			wantErr:    "Archivematica resource not found",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/am/poll_transfer_test.go
+++ b/internal/am/poll_transfer_test.go
@@ -271,7 +271,6 @@ func TestPollTransferActivity(t *testing.T) {
 			wantErr: "Archivematica resource not found",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/am/start_transfer_test.go
+++ b/internal/am/start_transfer_test.go
@@ -89,7 +89,6 @@ func TestStartTransferActivity(t *testing.T) {
 			errMsg: "Archivematica resource not found",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/am/upload_transfer_test.go
+++ b/internal/am/upload_transfer_test.go
@@ -136,7 +136,6 @@ func TestUploadTransferActivity(t *testing.T) {
 			wantNonRetryErr: true,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/package_/status_test.go
+++ b/internal/package_/status_test.go
@@ -45,7 +45,6 @@ func TestStatus(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(fmt.Sprintf("Status_%s", tc.str), func(t *testing.T) {
 			s := NewStatus(tc.str)
 			assert.Assert(t, s != StatusUnknown)

--- a/internal/persistence/ent/client/client_test.go
+++ b/internal/persistence/ent/client/client_test.go
@@ -183,7 +183,6 @@ func TestCreatePackage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -370,7 +369,6 @@ func TestUpdatePackage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/sftp/goclient_test.go
+++ b/internal/sftp/goclient_test.go
@@ -298,7 +298,6 @@ func TestUpload(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -379,7 +378,6 @@ func TestDelete(t *testing.T) {
 			wantErr: "SFTP: unable to remove file \"restricted/test.txt\": permission denied",
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/storage/location_test.go
+++ b/internal/storage/location_test.go
@@ -37,8 +37,6 @@ func TestNewInternalLocation(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -108,8 +106,6 @@ func TestNewLocation(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -158,8 +154,6 @@ func TestLocation_Bucket(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/storage/types/location_config_test.go
+++ b/internal/storage/types/location_config_test.go
@@ -94,7 +94,6 @@ func TestLocationConfigEncoding(t *testing.T) {
 			wantErr: "json: error calling MarshalJSON for type types.LocationConfig: unsupported config type: <nil>",
 		},
 	} {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -210,7 +209,6 @@ func TestLocationConfigDecoding(t *testing.T) {
 			wantErr: "multiple config values have been assigned",
 		},
 	} {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/storage/types/status_test.go
+++ b/internal/storage/types/status_test.go
@@ -38,7 +38,6 @@ func TestPackageStatus(t *testing.T) {
 			status: types.StatusMoving,
 		},
 	} {
-		tt := tt
 		t.Run(tt.code, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -95,7 +95,6 @@ func New(ctx context.Context, logger logr.Logger, c *Config) (*serviceImpl, erro
 	minioConfigs := append(c.Minio, c.Embedded)
 
 	for _, item := range minioConfigs {
-		item := item
 		w, err := NewMinioWatcher(ctx, logger, item)
 		if err != nil {
 			return nil, err
@@ -105,7 +104,6 @@ func New(ctx context.Context, logger logr.Logger, c *Config) (*serviceImpl, erro
 	}
 
 	for _, item := range c.Filesystem {
-		item := item
 		w, err := NewFilesystemWatcher(ctx, item)
 		if err != nil {
 			return nil, err
@@ -127,7 +125,6 @@ func (svc *serviceImpl) Watchers() []Watcher {
 
 	ww := []Watcher{}
 	for _, item := range svc.watchers {
-		item := item
 		ww = append(ww, item)
 	}
 

--- a/internal/workflow/activities/bundle_test.go
+++ b/internal/workflow/activities/bundle_test.go
@@ -154,7 +154,6 @@ e91f941be5973ff71f1dccbdd1a32d598881893a7f21be516aca743da38b1689 bagit.txt
 			),
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/workflow/activities/download_test.go
+++ b/internal/workflow/activities/download_test.go
@@ -60,7 +60,6 @@ func TestDownloadActivity(t *testing.T) {
 			wantErr: fmt.Sprintf("activity error (type: download-activity, scheduledEventID: 0, startedEventID: 0, identity: ): download blob: error loading watcher: unknown watcher %s", watcherName),
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/workflow/activities/zip_test.go
+++ b/internal/workflow/activities/zip_test.go
@@ -53,7 +53,6 @@ func TestZipActivity(t *testing.T) {
 			wantErr: fmt.Sprintf("ZipActivity: create: open %s: permission denied", restrictedDir.Join(transferName+".zip")),
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
In preparation for the go1.22 release, this pull request removes the copy of the loop variable that we used to need to prevent sharing in per-iteration closures or goroutines. I haven't found yet a tool that can remove these automatically, for now I find them in vscode using `\b(\w+)\s*:=\s*\1\b$`. Or:

    grep --recursive --include=\*.go --perl-regexp '\b(\w+)\s*:=\s*\1\b$' .

I'll keep this as a draft until go1.22 is released.

Context: https://go.dev/wiki/LoopvarExperiment.