### PR TITLE
Return error for multiple config options set

### DIFF
--- a/internal/storage/types/location_config.go
+++ b/internal/storage/types/location_config.go
@@ -47,14 +47,22 @@ func (c LocationConfig) MarshalJSON() ([]byte, error) {
 }
 
 func (c *LocationConfig) UnmarshalJSON(blob []byte) error {
-	types := configTypes{}
+	// Raise an error if the doc describes multiple configs.
+	keys := map[string]json.RawMessage{}
+	err := json.Unmarshal(blob, &keys)
+	if err != nil {
+		return err
+	}
+	if len(keys) > 1 {
+		return errors.New("multiple config values have been assigned")
+	}
 
+	types := configTypes{}
 	if err := json.Unmarshal(blob, &types); err != nil {
 		return err
 	}
 
 	switch {
-	// TODO: return error if we have more than one config assigned (mutually exclusive)
 	case types.S3 != nil:
 		c.Value = types.S3
 	case types.SFTPConfig != nil:

--- a/internal/storage/types/location_config_test.go
+++ b/internal/storage/types/location_config_test.go
@@ -109,6 +109,26 @@ func TestLocationConfig(t *testing.T) {
 		err = json.Unmarshal(blob, &cfg)
 		assert.Error(t, err, "undefined configuration document")
 		assert.DeepEqual(t, cfg, types.LocationConfig{})
+
+		// It rejects multiple configs.
+		blob = []byte(`{
+			"s3":{"bucket":"perma-aips-1","region":"eu-west-1"},
+			"sftp":{"address":"sftp:22","username":"user","password":"secret","directory":"upload"}
+		}`)
+		cfg = types.LocationConfig{}
+		err = json.Unmarshal(blob, &cfg)
+		assert.Error(t, err, "multiple config values have been assigned")
+		assert.DeepEqual(t, cfg, types.LocationConfig{})
+
+		// It rejects multiple configs (2).
+		blob = []byte(`{
+			"sftp":{"address":"sftp:22","username":"user","password":"secret","directory":"upload"},
+			"s3":{"bucket":"perma-aips-1","region":"eu-west-1"}
+		}`)
+		cfg = types.LocationConfig{}
+		err = json.Unmarshal(blob, &cfg)
+		assert.Error(t, err, "multiple config values have been assigned")
+		assert.DeepEqual(t, cfg, types.LocationConfig{})
 	})
 }
 


### PR DESCRIPTION
An error is now returned when a more than one storage configuration has
been set. Previously, this would not return an error and simply use what
-ever the user had set that was first in the storage switch options.

Closes #853
