### PR TITLE
Add bucket package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,10 @@ require (
 	chainguard.dev/go-oidctest v0.2.0
 	entgo.io/ent v0.12.5
 	github.com/alicebob/miniredis/v2 v2.31.0
-	github.com/aws/aws-sdk-go v1.49.7
+	github.com/aws/aws-sdk-go-v2 v1.24.0
+	github.com/aws/aws-sdk-go-v2/config v1.26.2
+	github.com/aws/aws-sdk-go-v2/credentials v1.16.13
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.47.7
 	github.com/coreos/go-oidc/v3 v3.9.0
 	github.com/cyphar/filepath-securejoin v0.2.4
 	github.com/dolmen-go/contextio v1.0.0
@@ -64,10 +67,8 @@ require (
 	github.com/andybalholm/brotli v1.0.6 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.24.0 // indirect
+	github.com/aws/aws-sdk-go v1.49.7 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.4 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.26.2 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.16.13 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.15.9 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.9 // indirect
@@ -78,7 +79,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.2.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.16.9 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.47.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.18.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.26.6 // indirect

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -1,0 +1,89 @@
+// Package bucket provides a mechanism to open buckets using configuration.
+package bucket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"gocloud.dev/blob"
+	"gocloud.dev/blob/s3blob"
+)
+
+type Config struct {
+	// Bucket URL as described in https://gocloud.dev/howto/blob/.
+	URL string
+
+	// Alternatively, a less flexible way to access S3-compatible buckets.
+	Endpoint  string
+	Bucket    string
+	AccessKey string
+	SecretKey string
+	Token     string
+	Profile   string
+	Region    string
+	PathStyle bool
+}
+
+// Open a bucket provided its configuration. Unless specified in the URL field,
+// it will open buckets with s3blob.OpenBucketV2.
+func Open(ctx context.Context, c *Config) (*blob.Bucket, error) {
+	if c == nil {
+		return nil, errors.New("config is undefined")
+	}
+
+	if c.URL != "" {
+		b, err := blob.OpenBucket(ctx, c.URL)
+		if err != nil {
+			return nil, fmt.Errorf("open bucket from URL %q: %v", c.URL, err)
+		}
+		return b, nil
+	}
+
+	addr := c.Endpoint
+	if u, err := url.Parse(c.Endpoint); err == nil {
+		if !strings.HasPrefix(u.Scheme, "http") {
+			addr = "http://" + addr
+		}
+	}
+
+	awscfg, err := config.LoadDefaultConfig(
+		ctx,
+		config.WithSharedConfigProfile(c.Profile),
+		config.WithRegion(c.Region),
+		config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(
+				c.AccessKey, c.SecretKey, c.Token,
+			),
+		),
+		config.WithEndpointResolverWithOptions(
+			aws.EndpointResolverWithOptionsFunc(
+				func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+					if service == s3.ServiceID {
+						return aws.Endpoint{URL: addr}, nil
+					}
+					return aws.Endpoint{}, &aws.EndpointNotFoundError{}
+				},
+			),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load AWS default config: %v", err)
+	}
+
+	client := s3.NewFromConfig(awscfg, func(opts *s3.Options) {
+		opts.UsePathStyle = c.PathStyle
+	})
+	b, err := s3blob.OpenBucketV2(ctx, client, c.Bucket, nil)
+	if err != nil {
+		return nil, fmt.Errorf("open bucket: %v", err)
+	}
+
+	return b, nil
+}

--- a/internal/bucket/bucket_test.go
+++ b/internal/bucket/bucket_test.go
@@ -69,14 +69,16 @@ func TestOpen(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
 			b, err := bucket.Open(context.Background(), tc.config)
+			// We should definitely close buckets when we are testing!
+			// This throws a lint error which should be ignored!
+			defer b.Close()
 
 			if tc.errMsg != "" {
-				assert.Assert(t, b == nil)
+				assert.Equal(t, b, nil)
 				assert.Error(t, err, tc.errMsg)
 				return
 			}

--- a/internal/bucket/bucket_test.go
+++ b/internal/bucket/bucket_test.go
@@ -1,0 +1,90 @@
+package bucket_test
+
+import (
+	"context"
+	"testing"
+
+	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/memblob"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/bucket"
+)
+
+func TestOpen(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		config  *bucket.Config
+		errMsg  string
+		require func(*blob.Bucket)
+	}
+	tests := map[string]test{
+		"Opens URL-based config": {
+			config: &bucket.Config{
+				URL: "mem://",
+			},
+		},
+		"Opens attr-based config": {
+			config: &bucket.Config{
+				Endpoint:  "http://foobar:12345",
+				Bucket:    "name",
+				Region:    "region",
+				AccessKey: "access",
+				SecretKey: "secret",
+			},
+			require: func(b *blob.Bucket) {
+				var client *s3v2.Client
+				assert.Equal(t, b.As(&client), true)
+
+				opts := client.Options()
+				assert.Equal(t, opts.Region, "region")
+				assert.Equal(t, opts.UsePathStyle, false)
+
+				_, err := client.ListBuckets(context.Background(), &s3v2.ListBucketsInput{})
+				assert.ErrorContains(t, err, "http://foobar:12345/?x-id=ListBuckets")
+			},
+		},
+		"Appends http if scheme is undefined": {
+			config: &bucket.Config{
+				Endpoint:  "foobar:12345",
+				Bucket:    "name",
+				Region:    "region",
+				AccessKey: "access",
+				SecretKey: "secret",
+			},
+			require: func(b *blob.Bucket) {
+				var client *s3v2.Client
+				assert.Equal(t, b.As(&client), true)
+
+				opts := client.Options()
+				assert.Equal(t, opts.Region, "region")
+				assert.Equal(t, opts.UsePathStyle, false)
+
+				_, err := client.ListBuckets(context.Background(), &s3v2.ListBucketsInput{})
+				assert.ErrorContains(t, err, "http://foobar:12345/?x-id=ListBuckets")
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			b, err := bucket.Open(context.Background(), tc.config)
+
+			if tc.errMsg != "" {
+				assert.Assert(t, b == nil)
+				assert.Error(t, err, tc.errMsg)
+				return
+			}
+			assert.NilError(t, err)
+
+			if tc.require != nil {
+				tc.require(b)
+			}
+		})
+	}
+}

--- a/internal/storage/types/location_config.go
+++ b/internal/storage/types/location_config.go
@@ -7,12 +7,10 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/rukavina/sftpblob"
 	"gocloud.dev/blob"
-	"gocloud.dev/blob/s3blob"
 
+	"github.com/artefactual-sdps/enduro/internal/bucket"
 	"github.com/artefactual-sdps/enduro/internal/storage/ssblob"
 )
 
@@ -104,20 +102,16 @@ func (c S3Config) Valid() bool {
 }
 
 func (c S3Config) OpenBucket(ctx context.Context) (*blob.Bucket, error) {
-	sessOpts := session.Options{}
-	sessOpts.Config.WithRegion(c.Region)
-	sessOpts.Config.WithEndpoint(c.Endpoint)
-	sessOpts.Config.WithS3ForcePathStyle(c.PathStyle)
-	sessOpts.Config.WithCredentials(
-		credentials.NewStaticCredentials(
-			c.Key, c.Secret, c.Token,
-		),
-	)
-	sess, err := session.NewSessionWithOptions(sessOpts)
-	if err != nil {
-		return nil, err
-	}
-	return s3blob.OpenBucket(ctx, sess, c.Bucket, nil)
+	return bucket.Open(ctx, &bucket.Config{
+		Endpoint:  c.Endpoint,
+		Bucket:    c.Bucket,
+		AccessKey: c.Key,
+		SecretKey: c.Secret,
+		Token:     c.Token,
+		Profile:   c.Profile,
+		Region:    c.Region,
+		PathStyle: c.PathStyle,
+	})
 }
 
 type SFTPConfig struct {


### PR DESCRIPTION
This commit introduces a new package `bucket` aiming to consolidate the
different ways we configure and create buckets across the application.

It enables future work such as embedding the shared config in different
contexts as well as using memory-based or fs-based buckets for testing purposes
when setting up some components of the application.

Relates to https://github.com/artefactual-sdps/enduro/issues/858.
