### PR TITLE
Bump golangci-lint from 1.56.0 to 1.56.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,11 +17,24 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - name: Get date
+        id: get-date
+        shell: bash
+        run: |
+          echo "::set-output name=date::$(date -u "+%Y-%m")"
+      - name: Restore golangci-lint cache
+        uses: actions/cache@v4
+        timeout-minutes: 10
+        continue-on-error: true
         with:
-          version: v1.54.2
-          args: --timeout=5m ./...
+          path: ${{ runner.temp }}/golangci-lint-cache
+          key: ${{ runner.os }}-golangci-lint-cache-${{ steps.get-date.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-cache-
+      - name: Run golangci-lint
+        run: make lint
+        env:
+          GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-lint-cache
   shfmt:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,3 @@ linters-settings:
     exclude-generated: false
     severity: low
     confidence: low
-  govet:
-    disable:
-      - loopclosure

--- a/hack/make/dep_golangci_lint.mk
+++ b/hack/make/dep_golangci_lint.mk
@@ -5,7 +5,7 @@ $(call _assert_var,UNAME_ARCH)
 $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
-GOLANGCI_LINT_VERSION ?= 1.56.0
+GOLANGCI_LINT_VERSION ?= 1.56.1
 
 ARCH := $(UNAME_ARCH)
 ifeq ($(UNAME_ARCH),x86_64)


### PR DESCRIPTION
In 1.56.1 govet:loopclosure comes disabled by default for go1.22 so we don't have to manually disable it in the golangci-lint yaml config.

I've also updated the action so it uses `make lint` and basic caching.