### PR TITLE
Standardize watcher Download() interface

### DIFF
--- a/internal/filenotify/filenotify_test.go
+++ b/internal/filenotify/filenotify_test.go
@@ -1,4 +1,4 @@
-package filenotify
+package filenotify_test
 
 import (
 	"fmt"
@@ -8,10 +8,16 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/artefactual-sdps/enduro/internal/filenotify"
 )
 
+const pollInterval = time.Millisecond * 5
+
 func TestPollerEvent(t *testing.T) {
-	w, err := NewPollingWatcher()
+	w, err := filenotify.NewPollingWatcher(
+		filenotify.Config{PollInterval: pollInterval},
+	)
 	if err != nil {
 		t.Fatal("error creating poller")
 	}
@@ -44,7 +50,7 @@ func TestPollerEvent(t *testing.T) {
 	}
 }
 
-func assertEvent(w FileWatcher, eType fsnotify.Op) error {
+func assertEvent(w filenotify.FileWatcher, eType fsnotify.Op) error {
 	var err error
 	select {
 	case e := <-w.Events():
@@ -53,7 +59,7 @@ func assertEvent(w FileWatcher, eType fsnotify.Op) error {
 		}
 	case e := <-w.Errors():
 		err = fmt.Errorf("got unexpected error waiting for events %v: %v", eType, e)
-	case <-time.After(watchWaitTime * 3):
+	case <-time.After(pollInterval * 2):
 		err = fmt.Errorf("timeout waiting for event %v", eType)
 	}
 	return err

--- a/internal/filenotify/poller.go
+++ b/internal/filenotify/poller.go
@@ -1,14 +1,9 @@
 package filenotify
 
 import (
-	"time"
-
 	"github.com/fsnotify/fsnotify"
 	"github.com/radovskyb/watcher"
 )
-
-// watchWaitTime is the time to wait between file poll loops
-const watchWaitTime = 200 * time.Millisecond
 
 // filePoller is used to poll files for changes, especially in cases where fsnotify
 // can't be run (e.g. when inotify handles are exhausted)
@@ -33,9 +28,9 @@ func (w *filePoller) loop() {
 			switch event.Op {
 			case watcher.Create:
 				op = fsnotify.Create
-			case watcher.Rename:
-				fallthrough
 			case watcher.Move:
+				fallthrough
+			case watcher.Rename:
 				op = fsnotify.Rename
 			default:
 				continue

--- a/internal/watcher/config.go
+++ b/internal/watcher/config.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const defaultPollInterval = 200 * time.Millisecond
+
 type Config struct {
 	Filesystem []*FilesystemConfig
 	Minio      []*MinioConfig
@@ -29,14 +31,24 @@ func (c Config) CompletedDirs() []string {
 
 // See filesystem.go for more.
 type FilesystemConfig struct {
-	Name    string
-	Path    string
-	Inotify bool
-	Ignore  string
+	Name         string
+	Path         string
+	CompletedDir string
+	Ignore       string
+	Inotify      bool
 
 	RetentionPeriod  *time.Duration
-	CompletedDir     string
 	StripTopLevelDir bool
+
+	// PollInterval sets the length of time between filesystem polls (default:
+	// 200ms). If Inotify is true then PollInterval is ignored.
+	PollInterval time.Duration
+}
+
+func (cfg *FilesystemConfig) setDefaults() {
+	if cfg.PollInterval == 0 {
+		cfg.PollInterval = defaultPollInterval
+	}
 }
 
 // See minio.go for more.
@@ -53,6 +65,7 @@ type MinioConfig struct {
 	Secret          string
 	Token           string
 	Bucket          string
+	URL             string
 
 	RetentionPeriod  *time.Duration
 	StripTopLevelDir bool

--- a/internal/watcher/fake/mock_service.go
+++ b/internal/watcher/fake/mock_service.go
@@ -11,7 +11,6 @@ package fake
 
 import (
 	context "context"
-	io "io"
 	reflect "reflect"
 
 	watcher "github.com/artefactual-sdps/enduro/internal/watcher"
@@ -157,7 +156,7 @@ func (c *MockServiceDisposeCall) DoAndReturn(f func(context.Context, string, str
 }
 
 // Download mocks base method.
-func (m *MockService) Download(arg0 context.Context, arg1 io.Writer, arg2, arg3 string) error {
+func (m *MockService) Download(arg0 context.Context, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Download", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -183,13 +182,13 @@ func (c *MockServiceDownloadCall) Return(arg0 error) *MockServiceDownloadCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceDownloadCall) Do(f func(context.Context, io.Writer, string, string) error) *MockServiceDownloadCall {
+func (c *MockServiceDownloadCall) Do(f func(context.Context, string, string, string) error) *MockServiceDownloadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceDownloadCall) DoAndReturn(f func(context.Context, io.Writer, string, string) error) *MockServiceDownloadCall {
+func (c *MockServiceDownloadCall) DoAndReturn(f func(context.Context, string, string, string) error) *MockServiceDownloadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/watcher/fake/mock_watcher.go
+++ b/internal/watcher/fake/mock_watcher.go
@@ -80,6 +80,44 @@ func (c *MockWatcherCompletedDirCall) DoAndReturn(f func() string) *MockWatcherC
 	return c
 }
 
+// Download mocks base method.
+func (m *MockWatcher) Download(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Download", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Download indicates an expected call of Download.
+func (mr *MockWatcherMockRecorder) Download(arg0, arg1, arg2 any) *MockWatcherDownloadCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockWatcher)(nil).Download), arg0, arg1, arg2)
+	return &MockWatcherDownloadCall{Call: call}
+}
+
+// MockWatcherDownloadCall wrap *gomock.Call
+type MockWatcherDownloadCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockWatcherDownloadCall) Return(arg0 error) *MockWatcherDownloadCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockWatcherDownloadCall) Do(f func(context.Context, string, string) error) *MockWatcherDownloadCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockWatcherDownloadCall) DoAndReturn(f func(context.Context, string, string) error) *MockWatcherDownloadCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // OpenBucket mocks base method.
 func (m *MockWatcher) OpenBucket(arg0 context.Context) (*blob.Bucket, error) {
 	m.ctrl.T.Helper()

--- a/internal/watcher/filesystem_test.go
+++ b/internal/watcher/filesystem_test.go
@@ -1,0 +1,198 @@
+package watcher_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/poll"
+
+	"github.com/artefactual-sdps/enduro/internal/watcher"
+)
+
+type file struct {
+	name     string
+	contents []byte
+}
+
+func TestFileSystemWatcher(t *testing.T) {
+	td := fs.NewDir(t, "enduro-test-fs-watcher")
+	type test struct {
+		name   string
+		config *watcher.FilesystemConfig
+		file   file
+		want   *watcher.BlobEvent
+	}
+	for _, tt := range []test{
+		{
+			name: "Polling watcher returns a blob event",
+			config: &watcher.FilesystemConfig{
+				Name:         "filesystem",
+				Path:         t.TempDir(),
+				PollInterval: time.Millisecond * 5,
+			},
+			file: file{name: "test.txt"},
+			want: &watcher.BlobEvent{Key: "test.txt"},
+		},
+		{
+			name: "Inotify watcher returns a blob event",
+			config: &watcher.FilesystemConfig{
+				Name:    "filesystem",
+				Path:    t.TempDir(),
+				Inotify: true,
+			},
+			file: file{name: "test.txt"},
+			want: &watcher.BlobEvent{Key: "test.txt"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			w, err := watcher.NewFilesystemWatcher(ctx, tt.config)
+			assert.NilError(t, err)
+
+			check := func(t poll.LogT) poll.Result {
+				got, _, err := w.Watch(ctx)
+				if err != nil {
+					return poll.Error(fmt.Errorf("watcher error: %w", err))
+				}
+				if got.Key != tt.want.Key || got.IsDir != tt.want.IsDir {
+					return poll.Error(fmt.Errorf(
+						"expected: *watcher.BlobEvent(Key: %q, IsDir: %t); got: *watcher.BlobEvent(Key: %q, IsDir: %t)",
+						tt.want.Key, tt.want.IsDir, got.Key, got.IsDir,
+					))
+				}
+
+				return poll.Success()
+			}
+
+			if err = os.WriteFile(
+				filepath.Join(tt.config.Path, tt.file.name),
+				tt.file.contents,
+				0o600,
+			); err != nil {
+				t.Fatalf("Couldn't create text.txt in %q", td.Path())
+			}
+
+			poll.WaitOn(t, check, poll.WithTimeout(time.Millisecond*15))
+		})
+	}
+
+	t.Run("Path returns the watcher path", func(t *testing.T) {
+		t.Parallel()
+
+		td := t.TempDir()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		w, err := watcher.NewFilesystemWatcher(ctx, &watcher.FilesystemConfig{
+			Name: "filesystem",
+			Path: td,
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, w.Path(), td)
+	})
+
+	t.Run("OpenBucket returns a bucket", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		w, err := watcher.NewFilesystemWatcher(ctx, &watcher.FilesystemConfig{
+			Name: "filesystem",
+			Path: t.TempDir(),
+		})
+		assert.NilError(t, err)
+
+		b, err := w.OpenBucket(ctx)
+		assert.NilError(t, err)
+		assert.Equal(t, fmt.Sprintf("%T", b), "*blob.Bucket")
+		b.Close()
+	})
+
+	t.Run("RemoveAll deletes a directory", func(t *testing.T) {
+		t.Parallel()
+
+		td := fs.NewDir(t, "enduro-test-fswatcher",
+			fs.WithDir("transfer", fs.WithFile("test.txt", "A test file.")),
+		)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		w, err := watcher.NewFilesystemWatcher(ctx, &watcher.FilesystemConfig{
+			Name: "filesystem",
+			Path: td.Path(),
+		})
+		assert.NilError(t, err)
+
+		err = w.RemoveAll("transfer")
+		assert.NilError(t, err)
+		assert.Assert(t, fs.Equal(w.Path(), fs.Expected(t)))
+	})
+
+	t.Run("Dispose moves transfer to CompletedDir", func(t *testing.T) {
+		t.Parallel()
+
+		src := fs.NewDir(t, "enduro-test-fswatcher",
+			fs.WithDir("transfer", fs.WithFile("test.txt", "A test file.")),
+		)
+		dest := fs.NewDir(t, "enduro-test-fswatcher")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		w, err := watcher.NewFilesystemWatcher(ctx, &watcher.FilesystemConfig{
+			Name:         "filesystem",
+			Path:         src.Path(),
+			CompletedDir: dest.Path(),
+		})
+		assert.NilError(t, err)
+
+		err = w.Dispose("transfer")
+		assert.NilError(t, err)
+		assert.Assert(t, fs.Equal(dest.Path(), fs.Expected(t,
+			fs.WithDir("transfer", fs.WithFile("test.txt", "A test file.")),
+		)))
+	})
+
+	t.Run("Download copies a directory", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		src := fs.NewDir(t, "enduro-test-fswatcher",
+			fs.WithDir("transfer",
+				fs.WithFile("test.txt", "A test file."),
+				fs.WithFile("test2", "Another test file."),
+			),
+		)
+		dest := fs.NewDir(t, "enduro-test-fswatcher")
+
+		w, err := watcher.NewFilesystemWatcher(ctx, &watcher.FilesystemConfig{
+			Name:    "filesystem",
+			Path:    src.Path(),
+			Inotify: true,
+		})
+		assert.NilError(t, err)
+
+		err = w.Download(context.Background(), dest.Path(), "transfer")
+		assert.NilError(t, err)
+		assert.Assert(t, fs.Equal(dest.Path(), fs.Expected(t, fs.WithMode(0o700),
+			fs.WithDir("transfer", fs.WithMode(0o755),
+				fs.WithFile("test.txt", "A test file.", fs.WithMode(0o644)),
+				fs.WithFile("test2", "Another test file.", fs.WithMode(0o644)),
+			),
+		)))
+	})
+}


### PR DESCRIPTION
Refs #867

- Update existing watcher Download() method and interface signatures to take a destination filepath (string) instead of an io.Writer stream
- Add a `filewatcher.Download()` method
- Create a `minio.Download()` method and move implementation specific code from `serviceImpl.Download()` to it
- Update mocks