### PR TITLE
Bump Github actions/setup-go from v4 to v5

### DIFF
--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -14,7 +14,7 @@ jobs:
         id: go_version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
       - name: Check atlas.sum

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -18,7 +18,7 @@ jobs:
       id: go_version
       run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
     - name: Install Go (${{ steps.go_version.outputs.go_version }})
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ steps.go_version.outputs.go_version }}
         cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         id: go_version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
       - name: Get date
@@ -44,7 +44,7 @@ jobs:
         id: go_version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
       - name: Run shfmt

--- a/.github/workflows/mod.yml
+++ b/.github/workflows/mod.yml
@@ -14,7 +14,7 @@ jobs:
       id: go_version
       run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
     - name: Install Go (${{ steps.go_version.outputs.go_version }})
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ steps.go_version.outputs.go_version }}
     - name: Check go.mod

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
         id: go_version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
       - name: Install govulncheck

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -10,7 +10,7 @@ jobs:
         id: go_version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
       - name: Download Go dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       id: go_version
       run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
     - name: Install Go (${{ steps.go_version.outputs.go_version }})
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ steps.go_version.outputs.go_version }}
         cache: true

--- a/.github/workflows/workflowcheck.yml
+++ b/.github/workflows/workflowcheck.yml
@@ -14,7 +14,7 @@ jobs:
         id: go_version
         run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
       - name: Install Go (${{ steps.go_version.outputs.go_version }})
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go_version.outputs.go_version }}
       - name: Run workflowcheck


### PR DESCRIPTION
Fixes a Github actions error:

```
Node.js 16 actions are deprecated. Please update the following actions
to use Node.js 20: actions/setup-go@v4.
```