### PR TITLE
Fix skip-codecov check in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,21 +23,22 @@ jobs:
     - name: Test
       run: make test-ci
     - name: Determine skip-codecov
+      uses: actions/github-script@v7
       id: skip-codecov
       with:
         script: |
+          // Sets `ref` to the SHA of the current pull request's head commit,
+          // or, if not present, to the SHA of the commit that triggered the
+          // event.
+          const ref = '${{ github.event.pull_request.head.sha || github.event.after }}';
           const { repo, owner } = context.repo;
-          const { data: commit } = await github.rest.repos.getCommit({
-              owner,
-              repo,
-              ref: '${{ github.event.pull_request.head.sha || github.event.after }}'
-          });
-          const commitMesasge = commit.commit.message;
+          const { data: commit } = await github.rest.repos.getCommit({ owner, repo, ref });
+          const commitMessage = commit.commit.message;
           const skip = commitMessage.includes("[skip codecov]") || commitMessage.includes("[skip-codecov]");
           core.setOutput("skip", skip);
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
-      if: steps.skip-codecov.outputs.skip != "true"
+      if: ${{ steps.skip-codecov.outputs.skip != 'true' }}
       with:
         file: covreport
       env:


### PR DESCRIPTION
I added an extra step in test.yml to optionally disable Codecov in commit e5676993. I believed it was working, meaning that Codecov wasn't running, but that was a false positive; the entire job was actually broken. This commit fixes it.