### PR TITLE
Restore unparam linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters:
     - gofumpt
     - importas
     - gci
-#    - unparam  // https://github.com/golangci/golangci-lint/issues/3711
+    - unparam
     - gosec
 
 issues:

--- a/hack/make/dep_golangci_lint.mk
+++ b/hack/make/dep_golangci_lint.mk
@@ -5,7 +5,7 @@ $(call _assert_var,UNAME_ARCH)
 $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
-GOLANGCI_LINT_VERSION ?= 1.56.1
+GOLANGCI_LINT_VERSION ?= 1.56.2
 
 ARCH := $(UNAME_ARCH)
 ifeq ($(UNAME_ARCH),x86_64)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -122,6 +122,6 @@ func errorHandler(logger logr.Logger, msg string) func(context.Context, http.Res
 			_ = json.NewEncoder(w).Encode(&errorMessage{RequestID: reqID})
 		}
 
-		logger.Error(err, "Service error.", "reqID", reqID, "ws", ws)
+		logger.Error(err, "Service error.", "reqID", reqID, "ws", ws, "msg", msg)
 	}
 }

--- a/internal/sftp/goclient_test.go
+++ b/internal/sftp/goclient_test.go
@@ -27,7 +27,7 @@ import (
 
 // pubkeyHandler returns a handler that checks the client's public key against
 // the keys in the authorized_keys file.
-func pubKeyHandler(t *testing.T, ctx ssh.Context, key ssh.PublicKey) bool {
+func pubKeyHandler(t *testing.T, key ssh.PublicKey) bool {
 	file, err := os.Open("./testdata/authorized_keys")
 	if err != nil {
 		t.Fatalf("SFTP server: couldn't open authorized_keys file: %s", err)
@@ -108,7 +108,7 @@ func startSFTPServer(t *testing.T) (string, string) {
 			s.Write(authorizedKey)
 		},
 		PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
-			return pubKeyHandler(t, ctx, key)
+			return pubKeyHandler(t, key)
 		},
 		SubsystemHandlers: map[string]ssh.SubsystemHandler{
 			"sftp": sftpHandler,


### PR DESCRIPTION
Restore the [`unparam`](https://github.com/mvdan/unparam) linter in golangci-lint since it's working again with recent releases of Go and `golang.org/x/tools`.