### PR TITLE
Introduce coverage thresholds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,13 @@ coverage:
   precision: 2
   round: down
   range: "25...75"
+  status:
+    project:
+      default:
+        threshold: 0.1%
+    patch:
+      default:
+        threshold: 0.1%
 
 ignore:
 - "dashboard/"


### PR DESCRIPTION
A tentative solution for https://github.com/artefactual-sdps/enduro/issues/892 that updates the codecov config to allow a certain number of lines to transition from covered to uncovered without reporting a negative patch coverage result.