### PR TITLE
Fix long lines with golines

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,8 @@ linters-settings:
       - prefix(github.com/artefactual-sdps/enduro)
     section-separators:
       - newLine
+  gofumpt:
+    extra-rules: true
   importas:
     no-unaliased: true
     no-extra-aliases: false

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ include hack/make/bootstrap.mk
 include hack/make/dep_ent.mk
 include hack/make/dep_goa.mk
 include hack/make/dep_golangci_lint.mk
+include hack/make/dep_golines.mk
 include hack/make/dep_gomajor.mk
 include hack/make/dep_gosec.mk
 include hack/make/dep_gotestsum.mk
@@ -31,6 +32,7 @@ include hack/make/dep_workflowcheck.mk
 TOOLS = $(ENT) \
 	$(GOA) \
 	$(GOLANGCI_LINT) \
+	$(GOLINES) \
 	$(GOMAJOR) \
 	$(GOSEC) \
 	$(GOTESTSUM) \
@@ -72,6 +74,18 @@ env:
 deps: # @HELP List available module dependency updates.
 deps: $(GOMAJOR)
 	gomajor list
+
+golines: # @HELP Run the golines formatter to fix long lines.
+golines: $(GOLINES)
+	golines \
+		--base-formatter=goimports \
+		--chain-split-dots \
+		--ignored-dirs="$(TEST_IGNORED_PACKAGES)" \
+		--max-len=120 \
+		--reformat-tags \
+		--shorten-comments \
+		--write-output \
+		.
 
 tparse: # @HELP Run all tests and output a coverage report using tparse.
 tparse: $(TPARSE)

--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -184,14 +184,36 @@ func main() {
 			os.Exit(1)
 		}
 
-		w.RegisterActivityWithOptions(activities.NewDownloadActivity(logger, wsvc).Execute, temporalsdk_activity.RegisterOptions{Name: activities.DownloadActivityName})
-		w.RegisterActivityWithOptions(activities.NewUnarchiveActivity(logger).Execute, temporalsdk_activity.RegisterOptions{Name: activities.UnarchiveActivityName})
-		w.RegisterActivityWithOptions(activities.NewBundleActivity(logger).Execute, temporalsdk_activity.RegisterOptions{Name: activities.BundleActivityName})
-		w.RegisterActivityWithOptions(a3m.NewCreateAIPActivity(logger, &cfg.A3m, pkgsvc).Execute, temporalsdk_activity.RegisterOptions{Name: a3m.CreateAIPActivityName})
-		w.RegisterActivityWithOptions(activities.NewCleanUpActivity().Execute, temporalsdk_activity.RegisterOptions{Name: activities.CleanUpActivityName})
+		w.RegisterActivityWithOptions(
+			activities.NewDownloadActivity(logger, wsvc).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.DownloadActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			activities.NewUnarchiveActivity(logger).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.UnarchiveActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			activities.NewBundleActivity(logger).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.BundleActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			a3m.NewCreateAIPActivity(logger, &cfg.A3m, pkgsvc).Execute,
+			temporalsdk_activity.RegisterOptions{Name: a3m.CreateAIPActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			activities.NewCleanUpActivity().Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.CleanUpActivityName},
+		)
 
 		httpClient := cleanhttp.DefaultPooledClient()
-		storageHttpClient := goahttpstorage.NewClient("http", cfg.Storage.EnduroAddress, httpClient, goahttp.RequestEncoder, goahttp.ResponseDecoder, false)
+		storageHttpClient := goahttpstorage.NewClient(
+			"http",
+			cfg.Storage.EnduroAddress,
+			httpClient,
+			goahttp.RequestEncoder,
+			goahttp.ResponseDecoder,
+			false,
+		)
 		storageClient := goastorage.NewClient(
 			storageHttpClient.Submit(),
 			storageHttpClient.Update(),
@@ -205,11 +227,23 @@ func main() {
 			storageHttpClient.ShowLocation(),
 			storageHttpClient.LocationPackages(),
 		)
-		w.RegisterActivityWithOptions(activities.NewUploadActivity(storageClient).Execute, temporalsdk_activity.RegisterOptions{Name: activities.UploadActivityName})
+		w.RegisterActivityWithOptions(
+			activities.NewUploadActivity(storageClient).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.UploadActivityName},
+		)
 
-		w.RegisterActivityWithOptions(activities.NewMoveToPermanentStorageActivity(storageClient).Execute, temporalsdk_activity.RegisterOptions{Name: activities.MoveToPermanentStorageActivityName})
-		w.RegisterActivityWithOptions(activities.NewPollMoveToPermanentStorageActivity(storageClient).Execute, temporalsdk_activity.RegisterOptions{Name: activities.PollMoveToPermanentStorageActivityName})
-		w.RegisterActivityWithOptions(activities.NewRejectPackageActivity(storageClient).Execute, temporalsdk_activity.RegisterOptions{Name: activities.RejectPackageActivityName})
+		w.RegisterActivityWithOptions(
+			activities.NewMoveToPermanentStorageActivity(storageClient).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.MoveToPermanentStorageActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			activities.NewPollMoveToPermanentStorageActivity(storageClient).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.PollMoveToPermanentStorageActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			activities.NewRejectPackageActivity(storageClient).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.RejectPackageActivityName},
+		)
 
 		g.Add(
 			func() error {

--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -202,7 +202,10 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: activities.BundleActivityName},
 		)
 		w.RegisterActivityWithOptions(
-			activities.NewZipActivity(logger).Execute, temporalsdk_activity.RegisterOptions{Name: activities.ZipActivityName},
+			activities.NewZipActivity(
+				logger,
+			).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.ZipActivityName},
 		)
 		w.RegisterActivityWithOptions(
 			am.NewUploadTransferActivity(logger, sftpClient, cfg.AM.PollInterval).Execute,

--- a/hack/make/dep_golines.mk
+++ b/hack/make/dep_golines.mk
@@ -1,0 +1,16 @@
+$(call _assert_var,MAKEDIR)
+$(call _conditional_include,$(MAKEDIR)/base.mk)
+$(call _assert_var,CACHE_VERSIONS)
+$(call _assert_var,CACHE_BIN)
+
+GOLINES_VERSION ?= 0.12.2
+
+GOLINES := $(CACHE_VERSIONS)/golines/$(GOLINES_VERSION)
+$(GOLINES):
+	rm -f $(CACHE_BIN)/golines
+	mkdir -p $(CACHE_BIN)
+	env GOBIN=$(CACHE_BIN) go install github.com/segmentio/golines@v$(GOLINES_VERSION)
+	chmod +x $(CACHE_BIN)/golines
+	rm -rf $(dir $(GOLINES))
+	mkdir -p $(dir $(GOLINES))
+	touch $(GOLINES)

--- a/internal/a3m/a3m.go
+++ b/internal/a3m/a3m.go
@@ -42,7 +42,10 @@ func NewCreateAIPActivity(logger logr.Logger, cfg *Config, pkgsvc package_.Servi
 	}
 }
 
-func (a *CreateAIPActivity) Execute(ctx context.Context, opts *CreateAIPActivityParams) (*CreateAIPActivityResult, error) {
+func (a *CreateAIPActivity) Execute(
+	ctx context.Context,
+	opts *CreateAIPActivityParams,
+) (*CreateAIPActivityResult, error) {
 	result := &CreateAIPActivityResult{}
 
 	var g run.Group
@@ -129,7 +132,8 @@ func (a *CreateAIPActivity) Execute(ctx context.Context, opts *CreateAIPActivity
 						return err
 					}
 
-					if readResp.Status == transferservice.PackageStatus_PACKAGE_STATUS_FAILED || readResp.Status == transferservice.PackageStatus_PACKAGE_STATUS_REJECTED {
+					if readResp.Status == transferservice.PackageStatus_PACKAGE_STATUS_FAILED ||
+						readResp.Status == transferservice.PackageStatus_PACKAGE_STATUS_REJECTED {
 						return errors.New("package failed or rejected")
 					}
 

--- a/internal/am/delete_transfer.go
+++ b/internal/am/delete_transfer.go
@@ -26,7 +26,10 @@ func NewDeleteTransferActivity(logger logr.Logger, client sftp.Client) *DeleteTr
 	return &DeleteTransferActivity{client: client, logger: logger}
 }
 
-func (a *DeleteTransferActivity) Execute(ctx context.Context, params *DeleteTransferActivityParams) (*DeleteTransferActivityResult, error) {
+func (a *DeleteTransferActivity) Execute(
+	ctx context.Context,
+	params *DeleteTransferActivityParams,
+) (*DeleteTransferActivityResult, error) {
 	a.logger.V(1).Info("Execute DeleteTransferActivity",
 		"destination", params.Destination,
 	)

--- a/internal/am/job_tracker.go
+++ b/internal/am/job_tracker.go
@@ -32,7 +32,12 @@ type JobTracker struct {
 	savedIDs map[string]struct{}
 }
 
-func NewJobTracker(clock clockwork.Clock, jobSvc amclient.JobsService, pkgSvc package_.Service, presActionID uint) *JobTracker {
+func NewJobTracker(
+	clock clockwork.Clock,
+	jobSvc amclient.JobsService,
+	pkgSvc package_.Service,
+	presActionID uint,
+) *JobTracker {
 	return &JobTracker{
 		clock:  clock,
 		jobSvc: jobSvc,

--- a/internal/am/poll_ingest.go
+++ b/internal/am/poll_ingest.go
@@ -59,7 +59,10 @@ func NewPollIngestActivity(
 // A response status of "REJECTED", "FAILED", "USER_INPUT", or "BACKLOG" returns
 // a temporal.NonRetryableApplicationError to indicate that processing can not
 // continue.
-func (a *PollIngestActivity) Execute(ctx context.Context, params *PollIngestActivityParams) (*PollIngestActivityResult, error) {
+func (a *PollIngestActivity) Execute(
+	ctx context.Context,
+	params *PollIngestActivityParams,
+) (*PollIngestActivityResult, error) {
 	a.logger.V(1).Info("Executing PollIngestActivity",
 		"PresActionID", params.PresActionID,
 		"SIPID", params.SIPID,
@@ -101,7 +104,11 @@ func (a *PollIngestActivity) Execute(ctx context.Context, params *PollIngestActi
 // result if ingest processing is complete. An errWorkOngoing error indicates
 // work is ongoing and polling should continue. All other errors should
 // terminate polling.
-func (a *PollIngestActivity) poll(ctx context.Context, jobTracker *JobTracker, transferID string) (*amclient.IngestStatusResponse, int, error) {
+func (a *PollIngestActivity) poll(
+	ctx context.Context,
+	jobTracker *JobTracker,
+	transferID string,
+) (*amclient.IngestStatusResponse, int, error) {
 	var stillWorking bool
 
 	// Add a context timeout to prevent missing the heartbeat deadline.
@@ -142,7 +149,10 @@ func (a *PollIngestActivity) poll(ctx context.Context, jobTracker *JobTracker, t
 	return resp, count, nil
 }
 
-func (a *PollIngestActivity) ingestStatus(ctx context.Context, transferID string) (*amclient.IngestStatusResponse, error) {
+func (a *PollIngestActivity) ingestStatus(
+	ctx context.Context,
+	transferID string,
+) (*amclient.IngestStatusResponse, error) {
 	resp, httpResp, err := a.ingSvc.Status(ctx, transferID)
 	if err != nil {
 		return resp, convertAMClientError(httpResp, err)

--- a/internal/am/poll_transfer.go
+++ b/internal/am/poll_transfer.go
@@ -65,7 +65,10 @@ func NewPollTransferActivity(
 // A transfer status of "REJECTED", "FAILED", "USER_INPUT", or "BACKLOG" returns
 // a temporal.NonRetryableApplicationError to indicate that processing can not
 // continue.
-func (a *PollTransferActivity) Execute(ctx context.Context, params *PollTransferActivityParams) (*PollTransferActivityResult, error) {
+func (a *PollTransferActivity) Execute(
+	ctx context.Context,
+	params *PollTransferActivityParams,
+) (*PollTransferActivityResult, error) {
 	var taskCount int
 
 	a.logger.V(1).Info("Executing PollTransferActivity",
@@ -108,7 +111,11 @@ func (a *PollTransferActivity) Execute(ctx context.Context, params *PollTransfer
 //
 // If the transfer is still in progress or completed successfully, poll saves
 // the AM jobs progress as preservation tasks via JobTracker.
-func (a *PollTransferActivity) poll(ctx context.Context, jobTracker *JobTracker, transferID string) (*amclient.TransferStatusResponse, int, error) {
+func (a *PollTransferActivity) poll(
+	ctx context.Context,
+	jobTracker *JobTracker,
+	transferID string,
+) (*amclient.TransferStatusResponse, int, error) {
 	var stillWorking bool
 
 	// Add a context timeout to prevent missing the heartbeat deadline.
@@ -149,7 +156,10 @@ func (a *PollTransferActivity) poll(ctx context.Context, jobTracker *JobTracker,
 	return resp, count, nil
 }
 
-func (a *PollTransferActivity) transferStatus(ctx context.Context, transferID string) (*amclient.TransferStatusResponse, error) {
+func (a *PollTransferActivity) transferStatus(
+	ctx context.Context,
+	transferID string,
+) (*amclient.TransferStatusResponse, error) {
 	resp, httpResp, err := a.tfrSvc.Status(ctx, transferID)
 	if err != nil {
 		return resp, convertAMClientError(httpResp, err)

--- a/internal/am/start_transfer.go
+++ b/internal/am/start_transfer.go
@@ -36,7 +36,10 @@ func NewStartTransferActivity(logger logr.Logger, cfg *Config, amps amclient.Pac
 // "auto-approved" transfer. If the request is successful a transfer UUID is
 // returned.  An error response will return a retryable or non-retryable
 // temporal.ApplicationError, depending on the nature of the error.
-func (a *StartTransferActivity) Execute(ctx context.Context, opts *StartTransferActivityParams) (*StartTransferActivityResult, error) {
+func (a *StartTransferActivity) Execute(
+	ctx context.Context,
+	opts *StartTransferActivityParams,
+) (*StartTransferActivityResult, error) {
 	a.logger.V(1).Info("Executing StartTransferActivity", "Name", opts.Name, "Path", opts.Path)
 
 	processingConfig := a.cfg.ProcessingConfig

--- a/internal/am/status.go
+++ b/internal/am/status.go
@@ -20,8 +20,12 @@ func isComplete(status string) (bool, error) {
 	case "PROCESSING", "":
 		return false, nil
 	case "REJECTED", "FAILED", "USER_INPUT":
-		return false, temporal_tools.NewNonRetryableError(fmt.Errorf("Invalid Archivematica response status: %s", status))
+		return false, temporal_tools.NewNonRetryableError(
+			fmt.Errorf("Invalid Archivematica response status: %s", status),
+		)
 	default:
-		return false, temporal_tools.NewNonRetryableError(fmt.Errorf("Unknown Archivematica response status: %s", status))
+		return false, temporal_tools.NewNonRetryableError(
+			fmt.Errorf("Unknown Archivematica response status: %s", status),
+		)
 	}
 }

--- a/internal/am/upload_transfer.go
+++ b/internal/am/upload_transfer.go
@@ -53,7 +53,10 @@ func NewUploadTransferActivity(
 }
 
 // Execute copies the source transfer to the destination via SFTP.
-func (a *UploadTransferActivity) Execute(ctx context.Context, params *UploadTransferActivityParams) (*UploadTransferActivityResult, error) {
+func (a *UploadTransferActivity) Execute(
+	ctx context.Context,
+	params *UploadTransferActivityParams,
+) (*UploadTransferActivityResult, error) {
 	a.logger.V(1).Info("Execute UploadTransferActivity", "SourcePath", params.SourcePath)
 
 	src, err := os.Open(params.SourcePath)

--- a/internal/api/design/upload.go
+++ b/internal/api/design/upload.go
@@ -21,8 +21,16 @@ var _ = Service("upload", func() {
 			AccessToken("oauth_token", String)
 		})
 
-		Error("invalid_media_type", ErrorResult, "Error returned when the Content-Type header does not define a multipart request.")
-		Error("invalid_multipart_request", ErrorResult, "Error returned when the request body is not a valid multipart content.")
+		Error(
+			"invalid_media_type",
+			ErrorResult,
+			"Error returned when the Content-Type header does not define a multipart request.",
+		)
+		Error(
+			"invalid_multipart_request",
+			ErrorResult,
+			"Error returned when the request body is not a valid multipart content.",
+		)
 		Error("internal_error", ErrorResult, "Fault while processing upload.")
 
 		HTTP(func() {

--- a/internal/api/origin.go
+++ b/internal/api/origin.go
@@ -21,7 +21,8 @@ func sameOriginChecker(logger logr.Logger) func(r *http.Request) bool {
 		}
 		eq := equalASCIIFold(u.Host, r.Host)
 		if !eq {
-			logger.V(1).Info("WebSocket client rejected (origin and host not equal)", "origin-host", u.Host, "request-host", r.Host)
+			logger.V(1).
+				Info("WebSocket client rejected (origin and host not equal)", "origin-host", u.Host, "request-host", r.Host)
 		}
 		return eq
 	}

--- a/internal/bagit/bagit_test.go
+++ b/internal/bagit/bagit_test.go
@@ -10,8 +10,24 @@ import (
 
 func TestBagit(t *testing.T) {
 	assert.NilError(t, bagit.Complete("./tests/test-bagged-transfer"))
-	assert.ErrorContains(t, bagit.Complete("./tests/test-bagged-transfer-with-invalid-oxum"), "Payload-Oxum validation failed. Expected 1 files and 7 bytes but found 2 files and 7 bytes")
-	assert.ErrorContains(t, bagit.Complete("./tests/test-bagged-transfer-with-missing-manifest"), "Bag validation failed: tests/test-bagged-transfer-with-missing-manifest/manifest-sha256.txt does not exist")
-	assert.ErrorContains(t, bagit.Complete("./tests/test-bagged-transfer-with-unexpected-files"), "Bag validation failed: data/dos.txt exists on filesystem but is not in the manifest")
-	assert.ErrorContains(t, bagit.Complete("./tests/test-bagged-transfer-with-invalid-checksums"), "Bag validation failed: data/adios.txt sha256 validation failed")
+	assert.ErrorContains(
+		t,
+		bagit.Complete("./tests/test-bagged-transfer-with-invalid-oxum"),
+		"Payload-Oxum validation failed. Expected 1 files and 7 bytes but found 2 files and 7 bytes",
+	)
+	assert.ErrorContains(
+		t,
+		bagit.Complete("./tests/test-bagged-transfer-with-missing-manifest"),
+		"Bag validation failed: tests/test-bagged-transfer-with-missing-manifest/manifest-sha256.txt does not exist",
+	)
+	assert.ErrorContains(
+		t,
+		bagit.Complete("./tests/test-bagged-transfer-with-unexpected-files"),
+		"Bag validation failed: data/dos.txt exists on filesystem but is not in the manifest",
+	)
+	assert.ErrorContains(
+		t,
+		bagit.Complete("./tests/test-bagged-transfer-with-invalid-checksums"),
+		"Bag validation failed: data/adios.txt sha256 validation failed",
+	)
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -61,6 +61,10 @@ func TestMigrateEnduroDatabase(t *testing.T) {
 		}()
 
 		err = MigrateEnduroDatabase(db)
-		assert.Error(t, err, "error creating golang-migrate object: error creating migrate driver: no such function: DATABASE in line 0: SELECT DATABASE()")
+		assert.Error(
+			t,
+			err,
+			"error creating golang-migrate object: error creating migrate driver: no such function: DATABASE in line 0: SELECT DATABASE()",
+		)
 	})
 }

--- a/internal/event/redis.go
+++ b/internal/event/redis.go
@@ -76,7 +76,12 @@ type SubscriptionRedisImpl struct {
 
 var _ Subscription = (*SubscriptionRedisImpl)(nil)
 
-func NewSubscriptionRedis(ctx context.Context, logger logr.Logger, c redis.UniversalClient, channel string) Subscription {
+func NewSubscriptionRedis(
+	ctx context.Context,
+	logger logr.Logger,
+	c redis.UniversalClient,
+	channel string,
+) Subscription {
 	pubsub := c.Subscribe(ctx, channel)
 	// Call Receive to force the connection to wait a response from
 	// Redis so the subscription is active immediately.

--- a/internal/package_/goa.go
+++ b/internal/package_/goa.go
@@ -35,7 +35,11 @@ var patternMatchingCharReplacer = strings.NewReplacer(
 
 var ErrInvalidToken error = goapackage.Unauthorized("invalid token")
 
-func (w *goaWrapper) OAuth2Auth(ctx context.Context, token string, scheme *security.OAuth2Scheme) (context.Context, error) {
+func (w *goaWrapper) OAuth2Auth(
+	ctx context.Context,
+	token string,
+	scheme *security.OAuth2Scheme,
+) (context.Context, error) {
 	ok, err := w.tokenVerifier.Verify(ctx, token)
 	if err != nil {
 		w.logger.V(1).Info("failed to verify token", "err", err)
@@ -48,7 +52,10 @@ func (w *goaWrapper) OAuth2Auth(ctx context.Context, token string, scheme *secur
 	return ctx, nil
 }
 
-func (w *goaWrapper) MonitorRequest(ctx context.Context, payload *goapackage.MonitorRequestPayload) (*goapackage.MonitorRequestResult, error) {
+func (w *goaWrapper) MonitorRequest(
+	ctx context.Context,
+	payload *goapackage.MonitorRequestPayload,
+) (*goapackage.MonitorRequestResult, error) {
 	res := &goapackage.MonitorRequestResult{}
 
 	ticket, err := w.ticketProvider.Request(ctx)
@@ -65,7 +72,11 @@ func (w *goaWrapper) MonitorRequest(ctx context.Context, payload *goapackage.Mon
 }
 
 // Monitor package activity. It implements goapackage.Service.
-func (w *goaWrapper) Monitor(ctx context.Context, payload *goapackage.MonitorPayload, stream goapackage.MonitorServerStream) error {
+func (w *goaWrapper) Monitor(
+	ctx context.Context,
+	payload *goapackage.MonitorPayload,
+	stream goapackage.MonitorServerStream,
+) error {
 	defer stream.Close()
 
 	// Verify the ticket.
@@ -200,7 +211,10 @@ func (w *goaWrapper) List(ctx context.Context, payload *goapackage.ListPayload) 
 }
 
 // Show package by ID. It implements goapackage.Service.
-func (w *goaWrapper) Show(ctx context.Context, payload *goapackage.ShowPayload) (*goapackage.EnduroStoredPackage, error) {
+func (w *goaWrapper) Show(
+	ctx context.Context,
+	payload *goapackage.ShowPayload,
+) (*goapackage.EnduroStoredPackage, error) {
 	c, err := w.read(ctx, payload.ID)
 	if err == sql.ErrNoRows {
 		return nil, &goapackage.PackageNotFound{ID: payload.ID, Message: "package not found"}
@@ -266,7 +280,10 @@ func (w *goaWrapper) Move(ctx context.Context, payload *goapackage.MovePayload) 
 	return nil
 }
 
-func (w *goaWrapper) MoveStatus(ctx context.Context, payload *goapackage.MoveStatusPayload) (*goapackage.MoveStatusResult, error) {
+func (w *goaWrapper) MoveStatus(
+	ctx context.Context,
+	payload *goapackage.MoveStatusPayload,
+) (*goapackage.MoveStatusResult, error) {
 	goapkg, err := w.Show(ctx, &goapackage.ShowPayload{ID: payload.ID})
 	if err != nil {
 		return nil, goapackage.MakeFailedDependency(errors.New("cannot perform operation"))

--- a/internal/package_/package_.go
+++ b/internal/package_/package_.go
@@ -23,16 +23,33 @@ type Service interface {
 	// Goa returns an implementation of the goapackage Service.
 	Goa() goapackage.Service
 	Create(context.Context, *datatypes.Package) error
-	UpdateWorkflowStatus(ctx context.Context, ID uint, name, workflowID, runID, aipID string, status enums.PackageStatus, storedAt time.Time) error
+	UpdateWorkflowStatus(
+		ctx context.Context,
+		ID uint,
+		name, workflowID, runID, aipID string,
+		status enums.PackageStatus,
+		storedAt time.Time,
+	) error
 	SetStatus(ctx context.Context, ID uint, status enums.PackageStatus) error
 	SetStatusInProgress(ctx context.Context, ID uint, startedAt time.Time) error
 	SetStatusPending(ctx context.Context, ID uint) error
 	SetLocationID(ctx context.Context, ID uint, locationID uuid.UUID) error
 	CreatePreservationAction(ctx context.Context, pa *PreservationAction) error
 	SetPreservationActionStatus(ctx context.Context, ID uint, status PreservationActionStatus) error
-	CompletePreservationAction(ctx context.Context, ID uint, status PreservationActionStatus, completedAt time.Time) error
+	CompletePreservationAction(
+		ctx context.Context,
+		ID uint,
+		status PreservationActionStatus,
+		completedAt time.Time,
+	) error
 	CreatePreservationTask(ctx context.Context, pt *PreservationTask) error
-	CompletePreservationTask(ctx context.Context, ID uint, status PreservationTaskStatus, completedAt time.Time, note *string) error
+	CompletePreservationTask(
+		ctx context.Context,
+		ID uint,
+		status PreservationTaskStatus,
+		completedAt time.Time,
+		note *string,
+	) error
 }
 
 type packageImpl struct {
@@ -93,7 +110,13 @@ func (svc *packageImpl) Create(ctx context.Context, pkg *datatypes.Package) erro
 	return nil
 }
 
-func (svc *packageImpl) UpdateWorkflowStatus(ctx context.Context, ID uint, name, workflowID, runID, aipID string, status enums.PackageStatus, storedAt time.Time) error {
+func (svc *packageImpl) UpdateWorkflowStatus(
+	ctx context.Context,
+	ID uint,
+	name, workflowID, runID, aipID string,
+	status enums.PackageStatus,
+	storedAt time.Time,
+) error {
 	// Ensure that storedAt is reset during retries.
 	completedAt := &storedAt
 	if status == enums.PackageStatusInProgress {

--- a/internal/package_/package_.go
+++ b/internal/package_/package_.go
@@ -23,7 +23,7 @@ type Service interface {
 	// Goa returns an implementation of the goapackage Service.
 	Goa() goapackage.Service
 	Create(context.Context, *datatypes.Package) error
-	UpdateWorkflowStatus(ctx context.Context, ID uint, name string, workflowID, runID, aipID string, status enums.PackageStatus, storedAt time.Time) error
+	UpdateWorkflowStatus(ctx context.Context, ID uint, name, workflowID, runID, aipID string, status enums.PackageStatus, storedAt time.Time) error
 	SetStatus(ctx context.Context, ID uint, status enums.PackageStatus) error
 	SetStatusInProgress(ctx context.Context, ID uint, startedAt time.Time) error
 	SetStatusPending(ctx context.Context, ID uint) error
@@ -93,7 +93,7 @@ func (svc *packageImpl) Create(ctx context.Context, pkg *datatypes.Package) erro
 	return nil
 }
 
-func (svc *packageImpl) UpdateWorkflowStatus(ctx context.Context, ID uint, name string, workflowID, runID, aipID string, status enums.PackageStatus, storedAt time.Time) error {
+func (svc *packageImpl) UpdateWorkflowStatus(ctx context.Context, ID uint, name, workflowID, runID, aipID string, status enums.PackageStatus, storedAt time.Time) error {
 	// Ensure that storedAt is reset during retries.
 	completedAt := &storedAt
 	if status == enums.PackageStatusInProgress {

--- a/internal/package_/preservation_action.go
+++ b/internal/package_/preservation_action.go
@@ -220,7 +220,10 @@ type PreservationTask struct {
 	PreservationActionID uint `db:"preservation_action_id"`
 }
 
-func (w *goaWrapper) PreservationActions(ctx context.Context, payload *goapackage.PreservationActionsPayload) (*goapackage.EnduroPackagePreservationActions, error) {
+func (w *goaWrapper) PreservationActions(
+	ctx context.Context,
+	payload *goapackage.PreservationActionsPayload,
+) (*goapackage.EnduroPackagePreservationActions, error) {
 	goapkg, err := w.Show(ctx, &goapackage.ShowPayload{ID: payload.ID})
 	if err != nil {
 		return nil, err
@@ -328,7 +331,11 @@ func (svc *packageImpl) CreatePreservationAction(ctx context.Context, pa *Preser
 	return nil
 }
 
-func (svc *packageImpl) SetPreservationActionStatus(ctx context.Context, ID uint, status PreservationActionStatus) error {
+func (svc *packageImpl) SetPreservationActionStatus(
+	ctx context.Context,
+	ID uint,
+	status PreservationActionStatus,
+) error {
 	query := `UPDATE preservation_action SET status = ? WHERE id = ?`
 	args := []interface{}{
 		status,
@@ -348,7 +355,12 @@ func (svc *packageImpl) SetPreservationActionStatus(ctx context.Context, ID uint
 	return nil
 }
 
-func (svc *packageImpl) CompletePreservationAction(ctx context.Context, ID uint, status PreservationActionStatus, completedAt time.Time) error {
+func (svc *packageImpl) CompletePreservationAction(
+	ctx context.Context,
+	ID uint,
+	status PreservationActionStatus,
+	completedAt time.Time,
+) error {
 	query := `UPDATE preservation_action SET status = ?, completed_at = ? WHERE id = ?`
 	args := []interface{}{
 		status,
@@ -410,7 +422,13 @@ func (svc *packageImpl) CreatePreservationTask(ctx context.Context, pt *Preserva
 	return nil
 }
 
-func (svc *packageImpl) CompletePreservationTask(ctx context.Context, ID uint, status PreservationTaskStatus, completedAt time.Time, note *string) error {
+func (svc *packageImpl) CompletePreservationTask(
+	ctx context.Context,
+	ID uint,
+	status PreservationTaskStatus,
+	completedAt time.Time,
+	note *string,
+) error {
 	var query string
 	args := []interface{}{}
 
@@ -435,7 +453,10 @@ func (svc *packageImpl) CompletePreservationTask(ctx context.Context, ID uint, s
 	return nil
 }
 
-func (svc *packageImpl) readPreservationAction(ctx context.Context, ID uint) (*goapackage.EnduroPackagePreservationAction, error) {
+func (svc *packageImpl) readPreservationAction(
+	ctx context.Context,
+	ID uint,
+) (*goapackage.EnduroPackagePreservationAction, error) {
 	query := `
 		SELECT
 			preservation_action.id,
@@ -469,7 +490,10 @@ func (svc *packageImpl) readPreservationAction(ctx context.Context, ID uint) (*g
 	return &item, nil
 }
 
-func (svc *packageImpl) readPreservationTask(ctx context.Context, ID uint) (*goapackage.EnduroPackagePreservationTask, error) {
+func (svc *packageImpl) readPreservationTask(
+	ctx context.Context,
+	ID uint,
+) (*goapackage.EnduroPackagePreservationTask, error) {
 	query := `
 		SELECT
 			preservation_task.id,

--- a/internal/package_/workflow.go
+++ b/internal/package_/workflow.go
@@ -96,7 +96,11 @@ type MoveWorkflowRequest struct {
 	TaskQueue  string
 }
 
-func InitMoveWorkflow(ctx context.Context, tc temporalsdk_client.Client, req *MoveWorkflowRequest) (temporalsdk_client.WorkflowRun, error) {
+func InitMoveWorkflow(
+	ctx context.Context,
+	tc temporalsdk_client.Client,
+	req *MoveWorkflowRequest,
+) (temporalsdk_client.WorkflowRun, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 

--- a/internal/persistence/ent/client/client.go
+++ b/internal/persistence/ent/client/client.go
@@ -87,7 +87,11 @@ func (c *client) CreatePackage(ctx context.Context, pkg *datatypes.Package) erro
 //
 // The package "ID" and "CreatedAt" field values can not be updated with this
 // method.
-func (c *client) UpdatePackage(ctx context.Context, id uint, updater persistence.PackageUpdater) (*datatypes.Package, error) {
+func (c *client) UpdatePackage(
+	ctx context.Context,
+	id uint,
+	updater persistence.PackageUpdater,
+) (*datatypes.Package, error) {
 	tx, err := c.ent.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, newDBError(err)

--- a/internal/sftp/ssh.go
+++ b/internal/sftp/ssh.go
@@ -68,7 +68,8 @@ func sshConnect(ctx context.Context, logger logr.Logger, cfg Config) (*ssh.Clien
 
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, address, sshConfig)
 	if err != nil {
-		if strings.Contains(err.Error(), "ssh: unable to authenticate") || strings.Contains(err.Error(), "knownhosts: key is unknown") {
+		if strings.Contains(err.Error(), "ssh: unable to authenticate") ||
+			strings.Contains(err.Error(), "knownhosts: key is unknown") {
 			logger.V(2).Info("ssh: authentication failed", "address", address, "user", cfg.User)
 			return nil, NewAuthError(err)
 		}

--- a/internal/storage/activities/copy.go
+++ b/internal/storage/activities/copy.go
@@ -17,7 +17,10 @@ func NewCopyToPermanentLocationActivity(storagesvc storage.Service) *CopyToPerma
 	return &CopyToPermanentLocationActivity{storagesvc: storagesvc}
 }
 
-func (a *CopyToPermanentLocationActivity) Execute(ctx context.Context, params *storage.CopyToPermanentLocationActivityParams) (*CopyToPermanentLocationActivityResult, error) {
+func (a *CopyToPermanentLocationActivity) Execute(
+	ctx context.Context,
+	params *storage.CopyToPermanentLocationActivityParams,
+) (*CopyToPermanentLocationActivityResult, error) {
 	p, err := a.storagesvc.ReadPackage(ctx, params.AIPID)
 	if err != nil {
 		return &CopyToPermanentLocationActivityResult{}, err

--- a/internal/storage/local_activities.go
+++ b/internal/storage/local_activities.go
@@ -13,7 +13,11 @@ type UpdatePackageLocationLocalActivityParams struct {
 	LocationID uuid.UUID
 }
 
-func UpdatePackageLocationLocalActivity(ctx context.Context, storagesvc Service, params *UpdatePackageLocationLocalActivityParams) error {
+func UpdatePackageLocationLocalActivity(
+	ctx context.Context,
+	storagesvc Service,
+	params *UpdatePackageLocationLocalActivityParams,
+) error {
 	return storagesvc.UpdatePackageLocationID(ctx, params.AIPID, params.LocationID)
 }
 
@@ -22,7 +26,11 @@ type UpdatePackageStatusLocalActivityParams struct {
 	Status types.PackageStatus
 }
 
-func UpdatePackageStatusLocalActivity(ctx context.Context, storagesvc Service, params *UpdatePackageStatusLocalActivityParams) error {
+func UpdatePackageStatusLocalActivity(
+	ctx context.Context,
+	storagesvc Service,
+	params *UpdatePackageStatusLocalActivityParams,
+) error {
 	return storagesvc.UpdatePackageStatus(ctx, params.AIPID, params.Status)
 }
 
@@ -30,6 +38,10 @@ type DeleteFromLocationLocalActivityParams struct {
 	AIPID uuid.UUID
 }
 
-func DeleteFromLocationLocalActivity(ctx context.Context, storagesvc Service, params *DeleteFromLocationLocalActivityParams) error {
+func DeleteFromLocationLocalActivity(
+	ctx context.Context,
+	storagesvc Service,
+	params *DeleteFromLocationLocalActivityParams,
+) error {
 	return storagesvc.Delete(ctx, params.AIPID)
 }

--- a/internal/storage/persistence/ent/client/client.go
+++ b/internal/storage/persistence/ent/client/client.go
@@ -135,7 +135,11 @@ func pkgAsGoa(ctx context.Context, pkg *db.Pkg) *goastorage.Package {
 	return p
 }
 
-func (c *Client) CreateLocation(ctx context.Context, location *goastorage.Location, config *types.LocationConfig) (*goastorage.Location, error) {
+func (c *Client) CreateLocation(
+	ctx context.Context,
+	location *goastorage.Location,
+	config *types.LocationConfig,
+) (*goastorage.Location, error) {
 	q := c.c.Location.Create()
 
 	q.SetName(location.Name)

--- a/internal/storage/persistence/persistence.go
+++ b/internal/storage/persistence/persistence.go
@@ -18,7 +18,11 @@ type Storage interface {
 	UpdatePackageLocationID(ctx context.Context, aipID, locationID uuid.UUID) error
 
 	// Location.
-	CreateLocation(ctx context.Context, location *goastorage.Location, config *types.LocationConfig) (*goastorage.Location, error)
+	CreateLocation(
+		ctx context.Context,
+		location *goastorage.Location,
+		config *types.LocationConfig,
+	) (*goastorage.Location, error)
 	ListLocations(ctx context.Context) (goastorage.LocationCollection, error)
 	ReadLocation(ctx context.Context, locationID uuid.UUID) (*goastorage.Location, error)
 	LocationPackages(ctx context.Context, locationID uuid.UUID) (goastorage.PackageCollection, error)

--- a/internal/storage/service.go
+++ b/internal/storage/service.go
@@ -197,7 +197,10 @@ func (s *serviceImpl) Download(ctx context.Context, payload *goastorage.Download
 	return []byte{}, nil
 }
 
-func (s *serviceImpl) Locations(ctx context.Context, payload *goastorage.LocationsPayload) (goastorage.LocationCollection, error) {
+func (s *serviceImpl) Locations(
+	ctx context.Context,
+	payload *goastorage.LocationsPayload,
+) (goastorage.LocationCollection, error) {
 	return s.storagePersistence.ListLocations(ctx)
 }
 
@@ -225,7 +228,10 @@ func (s *serviceImpl) Move(ctx context.Context, payload *goastorage.MovePayload)
 	return nil
 }
 
-func (s *serviceImpl) MoveStatus(ctx context.Context, payload *goastorage.MoveStatusPayload) (*goastorage.MoveStatusResult, error) {
+func (s *serviceImpl) MoveStatus(
+	ctx context.Context,
+	payload *goastorage.MoveStatusPayload,
+) (*goastorage.MoveStatusResult, error) {
 	aipID, err := uuid.Parse(payload.AipID)
 	if err != nil {
 		return nil, goastorage.MakeNotValid(errors.New("cannot perform operation"))
@@ -342,7 +348,10 @@ func (s *serviceImpl) PackageReader(ctx context.Context, pkg *goastorage.Package
 	return reader, nil
 }
 
-func (s *serviceImpl) AddLocation(ctx context.Context, payload *goastorage.AddLocationPayload) (res *goastorage.AddLocationResult, err error) {
+func (s *serviceImpl) AddLocation(
+	ctx context.Context,
+	payload *goastorage.AddLocationPayload,
+) (res *goastorage.AddLocationResult, err error) {
 	source := types.NewLocationSource(payload.Source)
 	purpose := types.NewLocationPurpose(payload.Purpose)
 	UUID := uuid.Must(uuid.NewRandomFromReader(s.rander))
@@ -385,7 +394,10 @@ func (s *serviceImpl) ReadLocation(ctx context.Context, UUID uuid.UUID) (*goasto
 	return s.storagePersistence.ReadLocation(ctx, UUID)
 }
 
-func (s *serviceImpl) ShowLocation(ctx context.Context, payload *goastorage.ShowLocationPayload) (*goastorage.Location, error) {
+func (s *serviceImpl) ShowLocation(
+	ctx context.Context,
+	payload *goastorage.ShowLocationPayload,
+) (*goastorage.Location, error) {
 	locationID, err := uuid.Parse(payload.UUID)
 	if err != nil {
 		return nil, goastorage.MakeNotValid(errors.New("cannot perform operation"))
@@ -394,7 +406,10 @@ func (s *serviceImpl) ShowLocation(ctx context.Context, payload *goastorage.Show
 	return s.ReadLocation(ctx, locationID)
 }
 
-func (s *serviceImpl) LocationPackages(ctx context.Context, payload *goastorage.LocationPackagesPayload) (goastorage.PackageCollection, error) {
+func (s *serviceImpl) LocationPackages(
+	ctx context.Context,
+	payload *goastorage.LocationPackagesPayload,
+) (goastorage.PackageCollection, error) {
 	locationID, err := uuid.Parse(payload.UUID)
 	if err != nil {
 		return nil, goastorage.MakeNotValid(errors.New("cannot perform operation"))

--- a/internal/storage/ssblob/ssblob.go
+++ b/internal/storage/ssblob/ssblob.go
@@ -112,7 +112,12 @@ func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driv
 	return nil, errNotImplemented
 }
 
-func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length int64, opts *driver.ReaderOptions) (driver.Reader, error) {
+func (b *bucket) NewRangeReader(
+	ctx context.Context,
+	key string,
+	offset, length int64,
+	opts *driver.ReaderOptions,
+) (driver.Reader, error) {
 	url := b.baseURL.JoinPath("api/v2/file", key, "download")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
@@ -137,7 +142,11 @@ func (b *bucket) NewRangeReader(ctx context.Context, key string, offset, length 
 	}, nil
 }
 
-func (b *bucket) NewTypedWriter(ctx context.Context, key, contentType string, opts *driver.WriterOptions) (driver.Writer, error) {
+func (b *bucket) NewTypedWriter(
+	ctx context.Context,
+	key, contentType string,
+	opts *driver.WriterOptions,
+) (driver.Writer, error) {
 	return nil, errNotImplemented
 }
 

--- a/internal/storage/workflow.go
+++ b/internal/storage/workflow.go
@@ -36,7 +36,11 @@ type CopyToPermanentLocationActivityParams struct {
 
 type UploadDoneSignal struct{}
 
-func InitStorageUploadWorkflow(ctx context.Context, tc temporalsdk_client.Client, req *StorageUploadWorkflowRequest) (temporalsdk_client.WorkflowRun, error) {
+func InitStorageUploadWorkflow(
+	ctx context.Context,
+	tc temporalsdk_client.Client,
+	req *StorageUploadWorkflowRequest,
+) (temporalsdk_client.WorkflowRun, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 
@@ -48,7 +52,11 @@ func InitStorageUploadWorkflow(ctx context.Context, tc temporalsdk_client.Client
 	return tc.ExecuteWorkflow(ctx, opts, StorageUploadWorkflowName, req)
 }
 
-func InitStorageMoveWorkflow(ctx context.Context, tc temporalsdk_client.Client, req *StorageMoveWorkflowRequest) (temporalsdk_client.WorkflowRun, error) {
+func InitStorageMoveWorkflow(
+	ctx context.Context,
+	tc temporalsdk_client.Client,
+	req *StorageMoveWorkflowRequest,
+) (temporalsdk_client.WorkflowRun, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 

--- a/internal/storage/workflows/move.go
+++ b/internal/storage/workflows/move.go
@@ -46,7 +46,8 @@ func (w *StorageMoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req stor
 		err := temporalsdk_workflow.ExecuteActivity(activityOpts, storage.CopyToPermanentLocationActivityName, &storage.CopyToPermanentLocationActivityParams{
 			AIPID:      req.AIPID,
 			LocationID: req.LocationID,
-		}).Get(activityOpts, nil)
+		}).
+			Get(activityOpts, nil)
 		if err != nil {
 			return err
 		}
@@ -66,7 +67,8 @@ func (w *StorageMoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req stor
 		})
 		err := temporalsdk_workflow.ExecuteLocalActivity(activityOpts, storage.DeleteFromLocationLocalActivity, w.storagesvc, &storage.DeleteFromLocationLocalActivityParams{
 			AIPID: req.AIPID,
-		}).Get(activityOpts, nil)
+		}).
+			Get(activityOpts, nil)
 		if err != nil {
 			return err
 		}
@@ -86,7 +88,8 @@ func (w *StorageMoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req stor
 		err := temporalsdk_workflow.ExecuteLocalActivity(activityOpts, storage.UpdatePackageLocationLocalActivity, w.storagesvc, &storage.UpdatePackageLocationLocalActivityParams{
 			AIPID:      req.AIPID,
 			LocationID: req.LocationID,
-		}).Get(activityOpts, nil)
+		}).
+			Get(activityOpts, nil)
 		if err != nil {
 			return err
 		}
@@ -102,7 +105,11 @@ func (w *StorageMoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req stor
 	return nil
 }
 
-func (w *StorageMoveWorkflow) updatePackageStatus(ctx temporalsdk_workflow.Context, st types.PackageStatus, aipID uuid.UUID) error {
+func (w *StorageMoveWorkflow) updatePackageStatus(
+	ctx temporalsdk_workflow.Context,
+	st types.PackageStatus,
+	aipID uuid.UUID,
+) error {
 	activityOpts := temporalsdk_workflow.WithLocalActivityOptions(ctx, temporalsdk_workflow.LocalActivityOptions{
 		ScheduleToCloseTimeout: 5 * time.Second,
 		RetryPolicy: &temporalsdk_temporal.RetryPolicy{
@@ -118,5 +125,6 @@ func (w *StorageMoveWorkflow) updatePackageStatus(ctx temporalsdk_workflow.Conte
 		Status: st,
 	}
 
-	return temporalsdk_workflow.ExecuteLocalActivity(activityOpts, storage.UpdatePackageStatusLocalActivity, w.storagesvc, params).Get(activityOpts, nil)
+	return temporalsdk_workflow.ExecuteLocalActivity(activityOpts, storage.UpdatePackageStatusLocalActivity, w.storagesvc, params).
+		Get(activityOpts, nil)
 }

--- a/internal/storage/workflows/move_test.go
+++ b/internal/storage/workflows/move_test.go
@@ -32,7 +32,10 @@ func TestStorageMoveWorkflow(t *testing.T) {
 	storagesvc.EXPECT().UpdatePackageStatus(gomock.Any(), aipID, types.StatusStored)
 
 	// Worker activities
-	env.RegisterActivityWithOptions(activities.NewCopyToPermanentLocationActivity(storagesvc).Execute, temporalsdk_activity.RegisterOptions{Name: storage.CopyToPermanentLocationActivityName})
+	env.RegisterActivityWithOptions(
+		activities.NewCopyToPermanentLocationActivity(storagesvc).Execute,
+		temporalsdk_activity.RegisterOptions{Name: storage.CopyToPermanentLocationActivityName},
+	)
 	env.OnActivity(storage.CopyToPermanentLocationActivityName, mock.Anything, mock.Anything).Return(nil, nil)
 
 	env.ExecuteWorkflow(

--- a/internal/storage/workflows/upload.go
+++ b/internal/storage/workflows/upload.go
@@ -12,7 +12,10 @@ func NewStorageUploadWorkflow() *StorageUploadWorkflow {
 	return &StorageUploadWorkflow{}
 }
 
-func (w *StorageUploadWorkflow) Execute(ctx temporalsdk_workflow.Context, req storage.StorageUploadWorkflowRequest) error {
+func (w *StorageUploadWorkflow) Execute(
+	ctx temporalsdk_workflow.Context,
+	req storage.StorageUploadWorkflowRequest,
+) error {
 	var signal storage.UploadDoneSignal
 	timerFuture := temporalsdk_workflow.NewTimer(ctx, storage.SubmitURLExpirationTime)
 	signalChan := temporalsdk_workflow.GetSignalChannel(ctx, storage.UploadDoneSignalName)

--- a/internal/telemetry/traces.go
+++ b/internal/telemetry/traces.go
@@ -17,9 +17,15 @@ import (
 
 // TracerProvider provides Tracers that are used by instrumentation code to
 // trace computational workflows.
-func TracerProvider(ctx context.Context, logger logr.Logger, cfg Config, appName, appVersion string) (trace.TracerProvider, ShutdownProvider, error) {
+func TracerProvider(
+	ctx context.Context,
+	logger logr.Logger,
+	cfg Config,
+	appName, appVersion string,
+) (trace.TracerProvider, ShutdownProvider, error) {
 	if !cfg.Traces.Enabled || cfg.Traces.Address == "" {
-		logger.V(1).Info("Tracing system is disabled.", "enabled", cfg.Traces.Enabled, "addr", cfg.Traces.Address, "sampling-ration", cfg.Traces.SamplingRatio)
+		logger.V(1).
+			Info("Tracing system is disabled.", "enabled", cfg.Traces.Enabled, "addr", cfg.Traces.Address, "sampling-ration", cfg.Traces.SamplingRatio)
 		shutdown := func(context.Context) error { return nil }
 		return noop.NewTracerProvider(), shutdown, nil
 	}

--- a/internal/upload/service.go
+++ b/internal/upload/service.go
@@ -39,7 +39,12 @@ var _ Service = (*serviceImpl)(nil)
 
 var ErrInvalidToken error = goastorage.Unauthorized("invalid token")
 
-func NewService(logger logr.Logger, config Config, uploadMaxSize int, tokenVerifier auth.TokenVerifier) (s *serviceImpl, err error) {
+func NewService(
+	logger logr.Logger,
+	config Config,
+	uploadMaxSize int,
+	tokenVerifier auth.TokenVerifier,
+) (s *serviceImpl, err error) {
 	s = &serviceImpl{
 		logger:        logger,
 		config:        config,
@@ -78,7 +83,11 @@ func (s *serviceImpl) openBucket(ctx context.Context, config Config) error {
 	return nil
 }
 
-func (s *serviceImpl) OAuth2Auth(ctx context.Context, token string, scheme *security.OAuth2Scheme) (context.Context, error) {
+func (s *serviceImpl) OAuth2Auth(
+	ctx context.Context,
+	token string,
+	scheme *security.OAuth2Scheme,
+) (context.Context, error) {
 	ok, err := s.tokenVerifier.Verify(ctx, token)
 	if err != nil {
 		s.logger.V(1).Info("failed to verify token", "err", err)

--- a/internal/watcher/minio.go
+++ b/internal/watcher/minio.go
@@ -37,7 +37,12 @@ type MinioEventSet struct {
 
 var _ Watcher = (*minioWatcher)(nil)
 
-func NewMinioWatcher(ctx context.Context, tp trace.TracerProvider, logger logr.Logger, config *MinioConfig) (*minioWatcher, error) {
+func NewMinioWatcher(
+	ctx context.Context,
+	tp trace.TracerProvider,
+	logger logr.Logger,
+	config *MinioConfig,
+) (*minioWatcher, error) {
 	opts, err := redis.ParseURL(config.RedisAddress)
 	if err != nil {
 		return nil, err

--- a/internal/watcher/minio_test.go
+++ b/internal/watcher/minio_test.go
@@ -252,7 +252,9 @@ func TestWatcherReturnsOnValidMessage(t *testing.T) {
 			return poll.Error(fmt.Errorf("watcher return an error unexpectedly: %w", err))
 		}
 		if event.Bucket != "bucket" || event.Key != "list-email-draft.txt" {
-			return poll.Error(fmt.Errorf("received unexpected event attributes (bucket %s, key %s)", event.Bucket, event.Key))
+			return poll.Error(
+				fmt.Errorf("received unexpected event attributes (bucket %s, key %s)", event.Bucket, event.Key),
+			)
 		}
 
 		return poll.Success()

--- a/internal/workflow/activities/bundle.go
+++ b/internal/workflow/activities/bundle.go
@@ -231,7 +231,9 @@ func unbag(path string) error {
 		{"manifest-md5.txt", "checksum.md5"},
 	} {
 		securePath, _ := securejoin.SecureJoin(path, item[0])
-		file, err := os.Open(securePath) //#nosec G304 -- Potential file inclusion not possible. item[0] is coming from controlled list.
+		file, err := os.Open(
+			securePath,
+		) //#nosec G304 -- Potential file inclusion not possible. item[0] is coming from controlled list.
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				continue
@@ -241,7 +243,9 @@ func unbag(path string) error {
 		defer file.Close()
 
 		securePath, _ = securejoin.SecureJoin(metadataPath, item[1])
-		newFile, err := os.Create(securePath) //#nosec G304 -- Potential file inclusion not possible. item[1] is coming from controlled list.
+		newFile, err := os.Create(
+			securePath,
+		) //#nosec G304 -- Potential file inclusion not possible. item[1] is coming from controlled list.
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				continue

--- a/internal/workflow/activities/delete_original.go
+++ b/internal/workflow/activities/delete_original.go
@@ -16,6 +16,9 @@ func NewDeleteOriginalActivity(wsvc watcher.Service) *DeleteOriginalActivity {
 	return &DeleteOriginalActivity{wsvc: wsvc}
 }
 
-func (a *DeleteOriginalActivity) Execute(ctx context.Context, watcherName, key string) (*DeleteOriginalActivityResult, error) {
+func (a *DeleteOriginalActivity) Execute(
+	ctx context.Context,
+	watcherName, key string,
+) (*DeleteOriginalActivityResult, error) {
 	return &DeleteOriginalActivityResult{}, a.wsvc.Delete(ctx, watcherName, key)
 }

--- a/internal/workflow/activities/dispose_original.go
+++ b/internal/workflow/activities/dispose_original.go
@@ -16,6 +16,9 @@ func NewDisposeOriginalActivity(wsvc watcher.Service) *DisposeOriginalActivity {
 	return &DisposeOriginalActivity{wsvc: wsvc}
 }
 
-func (a *DisposeOriginalActivity) Execute(ctx context.Context, watcherName, completedDir, key string) (*DisposeOriginalActivityResult, error) {
+func (a *DisposeOriginalActivity) Execute(
+	ctx context.Context,
+	watcherName, completedDir, key string,
+) (*DisposeOriginalActivityResult, error) {
 	return &DisposeOriginalActivityResult{}, a.wsvc.Dispose(ctx, watcherName, key)
 }

--- a/internal/workflow/activities/download.go
+++ b/internal/workflow/activities/download.go
@@ -35,7 +35,10 @@ func NewDownloadActivity(logger logr.Logger, wsvc watcher.Service) *DownloadActi
 	}
 }
 
-func (a *DownloadActivity) Execute(ctx context.Context, params *DownloadActivityParams) (*DownloadActivityResult, error) {
+func (a *DownloadActivity) Execute(
+	ctx context.Context,
+	params *DownloadActivityParams,
+) (*DownloadActivityResult, error) {
 	a.logger.V(1).Info("Executing DownloadActivity",
 		"Key", params.Key,
 		"WatcherName", params.WatcherName,

--- a/internal/workflow/activities/storage.go
+++ b/internal/workflow/activities/storage.go
@@ -28,7 +28,10 @@ func NewMoveToPermanentStorageActivity(storageClient *goastorage.Client) *MoveTo
 	}
 }
 
-func (a *MoveToPermanentStorageActivity) Execute(ctx context.Context, params *MoveToPermanentStorageActivityParams) (*MoveToPermanentStorageActivityResult, error) {
+func (a *MoveToPermanentStorageActivity) Execute(
+	ctx context.Context,
+	params *MoveToPermanentStorageActivityParams,
+) (*MoveToPermanentStorageActivityResult, error) {
 	childCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 
@@ -56,7 +59,10 @@ func NewPollMoveToPermanentStorageActivity(storageClient *goastorage.Client) *Po
 	}
 }
 
-func (a *PollMoveToPermanentStorageActivity) Execute(ctx context.Context, params *PollMoveToPermanentStorageActivityParams) (*PollMoveToPermanentStorageActivityResult, error) {
+func (a *PollMoveToPermanentStorageActivity) Execute(
+	ctx context.Context,
+	params *PollMoveToPermanentStorageActivityParams,
+) (*PollMoveToPermanentStorageActivityResult, error) {
 	var g run.Group
 
 	{
@@ -128,7 +134,10 @@ func NewRejectPackageActivity(storageClient *goastorage.Client) *RejectPackageAc
 	}
 }
 
-func (a *RejectPackageActivity) Execute(ctx context.Context, params *RejectPackageActivityParams) (*RejectPackageActivityResult, error) {
+func (a *RejectPackageActivity) Execute(
+	ctx context.Context,
+	params *RejectPackageActivityParams,
+) (*RejectPackageActivityResult, error) {
 	childCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 

--- a/internal/workflow/activities/unarchive.go
+++ b/internal/workflow/activities/unarchive.go
@@ -44,7 +44,10 @@ func NewUnarchiveActivity(logger logr.Logger) *UnarchiveActivity {
 // Execute attempts to unarchive the archive file at SourcePath to a temporary
 // directory to DestPath. If SourcePath points to a non-archive file then the
 // returned DestPath will be equal to SourcePath.
-func (a *UnarchiveActivity) Execute(ctx context.Context, params *UnarchiveActivityParams) (*UnarchiveActivityResult, error) {
+func (a *UnarchiveActivity) Execute(
+	ctx context.Context,
+	params *UnarchiveActivityParams,
+) (*UnarchiveActivityResult, error) {
 	a.logger.V(1).Info("Executing UnarchiveActivity",
 		"SourcePath", params.SourcePath,
 		"StripTopLevelDir", params.StripTopLevelDir,

--- a/internal/workflow/activities/upload_test.go
+++ b/internal/workflow/activities/upload_test.go
@@ -32,11 +32,18 @@ type StorageService struct {
 	LocationPackagesHandler func(ctx context.Context, req *goastorage.LocationPackagesPayload) (res goastorage.PackageCollection, err error)
 }
 
-func (s StorageService) OAuth2Auth(ctx context.Context, token string, scheme *security.OAuth2Scheme) (ctx2 context.Context, err error) {
+func (s StorageService) OAuth2Auth(
+	ctx context.Context,
+	token string,
+	scheme *security.OAuth2Scheme,
+) (ctx2 context.Context, err error) {
 	return s.OAuth2AuthHandler(ctx, token, scheme)
 }
 
-func (s StorageService) Submit(ctx context.Context, req *goastorage.SubmitPayload) (res *goastorage.SubmitResult, err error) {
+func (s StorageService) Submit(
+	ctx context.Context,
+	req *goastorage.SubmitPayload,
+) (res *goastorage.SubmitResult, err error) {
 	return s.SubmitHandler(ctx, req)
 }
 
@@ -48,7 +55,10 @@ func (s StorageService) Download(ctx context.Context, req *goastorage.DownloadPa
 	return s.DownloadHandler(ctx, req)
 }
 
-func (s StorageService) Locations(ctx context.Context, req *goastorage.LocationsPayload) (res goastorage.LocationCollection, err error) {
+func (s StorageService) Locations(
+	ctx context.Context,
+	req *goastorage.LocationsPayload,
+) (res goastorage.LocationCollection, err error) {
 	return s.LocationsHandler(ctx, req)
 }
 
@@ -56,7 +66,10 @@ func (s StorageService) Move(ctx context.Context, req *goastorage.MovePayload) (
 	return s.MoveHandler(ctx, req)
 }
 
-func (s StorageService) MoveStatus(ctx context.Context, req *goastorage.MoveStatusPayload) (res *goastorage.MoveStatusResult, err error) {
+func (s StorageService) MoveStatus(
+	ctx context.Context,
+	req *goastorage.MoveStatusPayload,
+) (res *goastorage.MoveStatusResult, err error) {
 	return s.MoveStatusHandler(ctx, req)
 }
 
@@ -68,15 +81,24 @@ func (s StorageService) Show(ctx context.Context, req *goastorage.ShowPayload) (
 	return s.ShowHandler(ctx, req)
 }
 
-func (s StorageService) AddLocation(ctx context.Context, req *goastorage.AddLocationPayload) (res *goastorage.AddLocationResult, err error) {
+func (s StorageService) AddLocation(
+	ctx context.Context,
+	req *goastorage.AddLocationPayload,
+) (res *goastorage.AddLocationResult, err error) {
 	return s.AddLocationHandler(ctx, req)
 }
 
-func (s StorageService) ShowLocation(ctx context.Context, req *goastorage.ShowLocationPayload) (res *goastorage.Location, err error) {
+func (s StorageService) ShowLocation(
+	ctx context.Context,
+	req *goastorage.ShowLocationPayload,
+) (res *goastorage.Location, err error) {
 	return s.ShowLocationHandler(ctx, req)
 }
 
-func (s StorageService) LocationPackages(ctx context.Context, req *goastorage.LocationPackagesPayload) (res goastorage.PackageCollection, err error) {
+func (s StorageService) LocationPackages(
+	ctx context.Context,
+	req *goastorage.LocationPackagesPayload,
+) (res goastorage.PackageCollection, err error) {
 	return s.LocationPackagesHandler(ctx, req)
 }
 

--- a/internal/workflow/local_activities.go
+++ b/internal/workflow/local_activities.go
@@ -19,7 +19,12 @@ type createPackageLocalActivityParams struct {
 	Status enums.PackageStatus
 }
 
-func createPackageLocalActivity(ctx context.Context, logger logr.Logger, pkgsvc package_.Service, params *createPackageLocalActivityParams) (uint, error) {
+func createPackageLocalActivity(
+	ctx context.Context,
+	logger logr.Logger,
+	pkgsvc package_.Service,
+	params *createPackageLocalActivityParams,
+) (uint, error) {
 	info := temporalsdk_activity.GetInfo(ctx)
 
 	col := &datatypes.Package{
@@ -47,7 +52,12 @@ type updatePackageLocalActivityParams struct {
 
 type updatePackageLocalActivityResult struct{}
 
-func updatePackageLocalActivity(ctx context.Context, logger logr.Logger, pkgsvc package_.Service, params *updatePackageLocalActivityParams) (*updatePackageLocalActivityResult, error) {
+func updatePackageLocalActivity(
+	ctx context.Context,
+	logger logr.Logger,
+	pkgsvc package_.Service,
+	params *updatePackageLocalActivityParams,
+) (*updatePackageLocalActivityResult, error) {
 	info := temporalsdk_activity.GetInfo(ctx)
 
 	err := pkgsvc.UpdateWorkflowStatus(
@@ -70,19 +80,34 @@ func updatePackageLocalActivity(ctx context.Context, logger logr.Logger, pkgsvc 
 
 type setStatusInProgressLocalActivityResult struct{}
 
-func setStatusInProgressLocalActivity(ctx context.Context, pkgsvc package_.Service, pkgID uint, startedAt time.Time) (*setStatusInProgressLocalActivityResult, error) {
+func setStatusInProgressLocalActivity(
+	ctx context.Context,
+	pkgsvc package_.Service,
+	pkgID uint,
+	startedAt time.Time,
+) (*setStatusInProgressLocalActivityResult, error) {
 	return &setStatusInProgressLocalActivityResult{}, pkgsvc.SetStatusInProgress(ctx, pkgID, startedAt)
 }
 
 type setStatusLocalActivityResult struct{}
 
-func setStatusLocalActivity(ctx context.Context, pkgsvc package_.Service, pkgID uint, status enums.PackageStatus) (*setStatusLocalActivityResult, error) {
+func setStatusLocalActivity(
+	ctx context.Context,
+	pkgsvc package_.Service,
+	pkgID uint,
+	status enums.PackageStatus,
+) (*setStatusLocalActivityResult, error) {
 	return &setStatusLocalActivityResult{}, pkgsvc.SetStatus(ctx, pkgID, status)
 }
 
 type setLocationIDLocalActivityResult struct{}
 
-func setLocationIDLocalActivity(ctx context.Context, pkgsvc package_.Service, pkgID uint, locationID uuid.UUID) (*setLocationIDLocalActivityResult, error) {
+func setLocationIDLocalActivity(
+	ctx context.Context,
+	pkgsvc package_.Service,
+	pkgID uint,
+	locationID uuid.UUID,
+) (*setLocationIDLocalActivityResult, error) {
 	return &setLocationIDLocalActivityResult{}, pkgsvc.SetLocationID(ctx, pkgID, locationID)
 }
 
@@ -98,7 +123,11 @@ type saveLocationMovePreservationActionLocalActivityParams struct {
 
 type saveLocationMovePreservationActionLocalActivityResult struct{}
 
-func saveLocationMovePreservationActionLocalActivity(ctx context.Context, pkgsvc package_.Service, params *saveLocationMovePreservationActionLocalActivityParams) (*saveLocationMovePreservationActionLocalActivityResult, error) {
+func saveLocationMovePreservationActionLocalActivity(
+	ctx context.Context,
+	pkgsvc package_.Service,
+	params *saveLocationMovePreservationActionLocalActivityParams,
+) (*saveLocationMovePreservationActionLocalActivityResult, error) {
 	paID, err := createPreservationActionLocalActivity(ctx, pkgsvc, &createPreservationActionLocalActivityParams{
 		WorkflowID:  params.WorkflowID,
 		Type:        params.Type,
@@ -140,7 +169,11 @@ type createPreservationActionLocalActivityParams struct {
 	PackageID   uint
 }
 
-func createPreservationActionLocalActivity(ctx context.Context, pkgsvc package_.Service, params *createPreservationActionLocalActivityParams) (uint, error) {
+func createPreservationActionLocalActivity(
+	ctx context.Context,
+	pkgsvc package_.Service,
+	params *createPreservationActionLocalActivityParams,
+) (uint, error) {
 	pa := package_.PreservationAction{
 		WorkflowID: params.WorkflowID,
 		Type:       params.Type,
@@ -159,7 +192,12 @@ func createPreservationActionLocalActivity(ctx context.Context, pkgsvc package_.
 
 type setPreservationActionStatusLocalActivityResult struct{}
 
-func setPreservationActionStatusLocalActivity(ctx context.Context, pkgsvc package_.Service, ID uint, status package_.PreservationActionStatus) (*setPreservationActionStatusLocalActivityResult, error) {
+func setPreservationActionStatusLocalActivity(
+	ctx context.Context,
+	pkgsvc package_.Service,
+	ID uint,
+	status package_.PreservationActionStatus,
+) (*setPreservationActionStatusLocalActivityResult, error) {
 	return &setPreservationActionStatusLocalActivityResult{}, pkgsvc.SetPreservationActionStatus(ctx, ID, status)
 }
 
@@ -171,8 +209,17 @@ type completePreservationActionLocalActivityParams struct {
 
 type completePreservationActionLocalActivityResult struct{}
 
-func completePreservationActionLocalActivity(ctx context.Context, pkgsvc package_.Service, params *completePreservationActionLocalActivityParams) (*completePreservationActionLocalActivityResult, error) {
-	return &completePreservationActionLocalActivityResult{}, pkgsvc.CompletePreservationAction(ctx, params.PreservationActionID, params.Status, params.CompletedAt)
+func completePreservationActionLocalActivity(
+	ctx context.Context,
+	pkgsvc package_.Service,
+	params *completePreservationActionLocalActivityParams,
+) (*completePreservationActionLocalActivityResult, error) {
+	return &completePreservationActionLocalActivityResult{}, pkgsvc.CompletePreservationAction(
+		ctx,
+		params.PreservationActionID,
+		params.Status,
+		params.CompletedAt,
+	)
 }
 
 type createPreservationTaskLocalActivityParams struct {
@@ -185,7 +232,11 @@ type createPreservationTaskLocalActivityParams struct {
 	PreservationActionID uint
 }
 
-func createPreservationTaskLocalActivity(ctx context.Context, pkgsvc package_.Service, params *createPreservationTaskLocalActivityParams) (uint, error) {
+func createPreservationTaskLocalActivity(
+	ctx context.Context,
+	pkgsvc package_.Service,
+	params *createPreservationTaskLocalActivityParams,
+) (uint, error) {
 	pt := package_.PreservationTask{
 		TaskID:               params.TaskID,
 		Name:                 params.Name,
@@ -212,6 +263,16 @@ type completePreservationTaskLocalActivityParams struct {
 
 type completePreservationTaskLocalActivityResult struct{}
 
-func completePreservationTaskLocalActivity(ctx context.Context, pkgsvc package_.Service, params *completePreservationTaskLocalActivityParams) (*completePreservationTaskLocalActivityResult, error) {
-	return &completePreservationTaskLocalActivityResult{}, pkgsvc.CompletePreservationTask(ctx, params.ID, params.Status, params.CompletedAt, params.Note)
+func completePreservationTaskLocalActivity(
+	ctx context.Context,
+	pkgsvc package_.Service,
+	params *completePreservationTaskLocalActivityParams,
+) (*completePreservationTaskLocalActivityResult, error) {
+	return &completePreservationTaskLocalActivityResult{}, pkgsvc.CompletePreservationTask(
+		ctx,
+		params.ID,
+		params.Status,
+		params.CompletedAt,
+		params.Note,
+	)
 }

--- a/internal/workflow/move.go
+++ b/internal/workflow/move.go
@@ -31,7 +31,8 @@ func (w *MoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req *package_.M
 	// Set package to in progress status.
 	{
 		ctx := withLocalActivityOpts(ctx)
-		err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setStatusLocalActivity, w.pkgsvc, req.ID, enums.PackageStatusInProgress).Get(ctx, nil)
+		err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setStatusLocalActivity, w.pkgsvc, req.ID, enums.PackageStatusInProgress).
+			Get(ctx, nil)
 		if err != nil {
 			return err
 		}
@@ -43,7 +44,8 @@ func (w *MoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req *package_.M
 		err := temporalsdk_workflow.ExecuteActivity(activityOpts, activities.MoveToPermanentStorageActivityName, &activities.MoveToPermanentStorageActivityParams{
 			AIPID:      req.AIPID,
 			LocationID: req.LocationID,
-		}).Get(activityOpts, nil)
+		}).
+			Get(activityOpts, nil)
 		if err != nil {
 			status = package_.ActionStatusError
 		}
@@ -55,7 +57,8 @@ func (w *MoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req *package_.M
 			activityOpts := withActivityOptsForLongLivedRequest(ctx)
 			err := temporalsdk_workflow.ExecuteActivity(activityOpts, activities.PollMoveToPermanentStorageActivityName, &activities.PollMoveToPermanentStorageActivityParams{
 				AIPID: req.AIPID,
-			}).Get(activityOpts, nil)
+			}).
+				Get(activityOpts, nil)
 			if err != nil {
 				status = package_.ActionStatusError
 			}
@@ -67,7 +70,8 @@ func (w *MoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req *package_.M
 	// Set package to done status.
 	{
 		ctx := withLocalActivityOpts(ctx)
-		err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setStatusLocalActivity, w.pkgsvc, req.ID, enums.PackageStatusDone).Get(ctx, nil)
+		err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setStatusLocalActivity, w.pkgsvc, req.ID, enums.PackageStatusDone).
+			Get(ctx, nil)
 		if err != nil {
 			return err
 		}
@@ -77,7 +81,8 @@ func (w *MoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req *package_.M
 	{
 		if status != package_.ActionStatusError {
 			ctx := withLocalActivityOpts(ctx)
-			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setLocationIDLocalActivity, w.pkgsvc, req.ID, req.LocationID).Get(ctx, nil)
+			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setLocationIDLocalActivity, w.pkgsvc, req.ID, req.LocationID).
+				Get(ctx, nil)
 			if err != nil {
 				return err
 			}
@@ -96,7 +101,8 @@ func (w *MoveWorkflow) Execute(ctx temporalsdk_workflow.Context, req *package_.M
 			Status:      status,
 			StartedAt:   startedAt,
 			CompletedAt: completedAt,
-		}).Get(ctx, nil)
+		}).
+			Get(ctx, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/workflow/move_test.go
+++ b/internal/workflow/move_test.go
@@ -64,7 +64,8 @@ func (s *MoveWorkflowTestSuite) TestSuccessfulMove() {
 	locationID := uuid.MustParse("51328c02-2b63-47be-958e-e8088aa1a61f")
 
 	// Package is set to in progress status.
-	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, pkgID, enums.PackageStatusInProgress).Return(nil, nil)
+	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, pkgID, enums.PackageStatusInProgress).
+		Return(nil, nil)
 
 	// Move operation succeeds.
 	s.env.OnActivity(
@@ -86,7 +87,8 @@ func (s *MoveWorkflowTestSuite) TestSuccessfulMove() {
 	).Return(nil, nil)
 
 	// Package is set back to done status.
-	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, pkgID, enums.PackageStatusDone).Return(nil, nil)
+	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, pkgID, enums.PackageStatusDone).
+		Return(nil, nil)
 
 	// Package location is set.
 	s.env.OnActivity(setLocationIDLocalActivity, mock.Anything, mock.Anything, pkgID, locationID).Return(nil, nil)
@@ -119,7 +121,8 @@ func (s *MoveWorkflowTestSuite) TestFailedMove() {
 	locationID := uuid.MustParse("51328c02-2b63-47be-958e-e8088aa1a61f")
 
 	// Package is set to in progress status.
-	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, pkgID, enums.PackageStatusInProgress).Return(nil, nil)
+	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, pkgID, enums.PackageStatusInProgress).
+		Return(nil, nil)
 
 	// Move operation fails.
 	s.env.OnActivity(
@@ -132,7 +135,8 @@ func (s *MoveWorkflowTestSuite) TestFailedMove() {
 	).Return(nil, errors.New("error moving package"))
 
 	// Package is set back to done status.
-	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, pkgID, enums.PackageStatusDone).Return(nil, nil)
+	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, pkgID, enums.PackageStatusDone).
+		Return(nil, nil)
 
 	// Preservation action is created with failed status.
 	s.env.OnActivity(

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -73,16 +73,46 @@ func (s *ProcessingWorkflowTestSuite) SetupWorkflowTest(taskQueue string) {
 	wsvc := watcherfake.NewMockService(ctrl)
 	sftpc := sftp_fake.NewMockClient(ctrl)
 
-	s.env.RegisterActivityWithOptions(activities.NewDownloadActivity(logger, wsvc).Execute, temporalsdk_activity.RegisterOptions{Name: activities.DownloadActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewUnarchiveActivity(logger).Execute, temporalsdk_activity.RegisterOptions{Name: activities.UnarchiveActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewBundleActivity(logger).Execute, temporalsdk_activity.RegisterOptions{Name: activities.BundleActivityName})
-	s.env.RegisterActivityWithOptions(a3m.NewCreateAIPActivity(logger, &a3m.Config{}, pkgsvc).Execute, temporalsdk_activity.RegisterOptions{Name: a3m.CreateAIPActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewUploadActivity(nil).Execute, temporalsdk_activity.RegisterOptions{Name: activities.UploadActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewMoveToPermanentStorageActivity(nil).Execute, temporalsdk_activity.RegisterOptions{Name: activities.MoveToPermanentStorageActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewPollMoveToPermanentStorageActivity(nil).Execute, temporalsdk_activity.RegisterOptions{Name: activities.PollMoveToPermanentStorageActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewRejectPackageActivity(nil).Execute, temporalsdk_activity.RegisterOptions{Name: activities.RejectPackageActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewCleanUpActivity().Execute, temporalsdk_activity.RegisterOptions{Name: activities.CleanUpActivityName})
-	s.env.RegisterActivityWithOptions(activities.NewDeleteOriginalActivity(wsvc).Execute, temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalActivityName})
+	s.env.RegisterActivityWithOptions(
+		activities.NewDownloadActivity(logger, wsvc).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.DownloadActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewUnarchiveActivity(logger).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.UnarchiveActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewBundleActivity(logger).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.BundleActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		a3m.NewCreateAIPActivity(logger, &a3m.Config{}, pkgsvc).Execute,
+		temporalsdk_activity.RegisterOptions{Name: a3m.CreateAIPActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewUploadActivity(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.UploadActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewMoveToPermanentStorageActivity(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.MoveToPermanentStorageActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewPollMoveToPermanentStorageActivity(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.PollMoveToPermanentStorageActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewRejectPackageActivity(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.RejectPackageActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewCleanUpActivity().Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.CleanUpActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewDeleteOriginalActivity(wsvc).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalActivityName},
+	)
 
 	// Archivematica activities
 	s.env.RegisterActivityWithOptions(
@@ -160,9 +190,12 @@ func (s *ProcessingWorkflowTestSuite) TestPackageConfirmation() {
 	)
 
 	// Activity mocks/assertions sequence
-	s.env.OnActivity(createPackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(pkgID, nil)
-	s.env.OnActivity(setStatusInProgressLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(createPreservationActionLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(uint(0), nil)
+	s.env.OnActivity(createPackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(pkgID, nil)
+	s.env.OnActivity(setStatusInProgressLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	s.env.OnActivity(createPreservationActionLocalActivity, mock.Anything, mock.Anything, mock.Anything).
+		Return(uint(0), nil)
 
 	s.env.OnActivity(activities.DownloadActivityName, sessionCtx,
 		&activities.DownloadActivityParams{Key: key, WatcherName: watcherName},
@@ -187,20 +220,32 @@ func (s *ProcessingWorkflowTestSuite) TestPackageConfirmation() {
 	)
 
 	s.env.OnActivity(a3m.CreateAIPActivityName, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(createPreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(uint(0), nil)
+	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	s.env.OnActivity(createPreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).
+		Return(uint(0), nil)
 	s.env.OnActivity(activities.UploadActivityName, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(completePreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	s.env.OnActivity(completePreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	s.env.OnActivity(activities.MoveToPermanentStorageActivityName, mock.Anything, mock.Anything).Return(nil, nil)
 	s.env.OnActivity(activities.PollMoveToPermanentStorageActivityName, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(setLocationIDLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(completePreservationActionLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.completePreservationActionLocalActivityParams")).Return(nil, nil).Once()
-	s.env.OnActivity(activities.CleanUpActivityName, sessionCtx, mock.AnythingOfType("*activities.CleanUpActivityParams")).Return(nil, nil).Once()
+	s.env.OnActivity(setLocationIDLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	s.env.OnActivity(completePreservationActionLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.completePreservationActionLocalActivityParams")).
+		Return(nil, nil).
+		Once()
+	s.env.OnActivity(activities.CleanUpActivityName, sessionCtx, mock.AnythingOfType("*activities.CleanUpActivityParams")).
+		Return(nil, nil).
+		Once()
 	s.env.OnActivity(activities.DeleteOriginalActivityName, sessionCtx, watcherName, key).Return(nil, nil).Once()
-	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(completePreservationActionLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	s.env.OnActivity(completePreservationActionLocalActivity, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 
 	s.env.ExecuteWorkflow(
 		s.workflow.Execute,
@@ -236,8 +281,12 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 		pkgsvc,
 		&createPackageLocalActivityParams{Key: key, Status: enums.PackageStatusQueued},
 	).Return(pkgID, nil).Once()
-	s.env.OnActivity(setStatusInProgressLocalActivity, ctx, pkgsvc, pkgID, mock.AnythingOfType("time.Time")).Return(nil, nil).Once()
-	s.env.OnActivity(createPreservationActionLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.createPreservationActionLocalActivityParams")).Return(uint(0), nil).Once()
+	s.env.OnActivity(setStatusInProgressLocalActivity, ctx, pkgsvc, pkgID, mock.AnythingOfType("time.Time")).
+		Return(nil, nil).
+		Once()
+	s.env.OnActivity(createPreservationActionLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.createPreservationActionLocalActivityParams")).
+		Return(uint(0), nil).
+		Once()
 
 	s.env.OnActivity(activities.DownloadActivityName, sessionCtx,
 		&activities.DownloadActivityParams{Key: key, WatcherName: watcherName},
@@ -261,18 +310,40 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 		nil,
 	)
 
-	s.env.OnActivity(a3m.CreateAIPActivityName, sessionCtx, mock.AnythingOfType("*a3m.CreateAIPActivityParams")).Return(nil, nil).Once()
-	s.env.OnActivity(updatePackageLocalActivity, ctx, logger, pkgsvc, mock.AnythingOfType("*workflow.updatePackageLocalActivityParams")).Return(nil, nil).Times(2)
-	s.env.OnActivity(createPreservationTaskLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.createPreservationTaskLocalActivityParams")).Return(uint(0), nil).Once()
-	s.env.OnActivity(activities.UploadActivityName, sessionCtx, mock.AnythingOfType("*activities.UploadActivityParams")).Return(nil, nil).Once()
-	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Never()
-	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Never()
-	s.env.OnActivity(completePreservationTaskLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.completePreservationTaskLocalActivityParams")).Return(nil, nil).Once()
-	s.env.OnActivity(activities.MoveToPermanentStorageActivityName, sessionCtx, mock.AnythingOfType("*activities.MoveToPermanentStorageActivityParams")).Return(nil, nil).Once()
-	s.env.OnActivity(activities.PollMoveToPermanentStorageActivityName, sessionCtx, mock.AnythingOfType("*activities.PollMoveToPermanentStorageActivityParams")).Return(nil, nil).Once()
+	s.env.OnActivity(a3m.CreateAIPActivityName, sessionCtx, mock.AnythingOfType("*a3m.CreateAIPActivityParams")).
+		Return(nil, nil).
+		Once()
+	s.env.OnActivity(updatePackageLocalActivity, ctx, logger, pkgsvc, mock.AnythingOfType("*workflow.updatePackageLocalActivityParams")).
+		Return(nil, nil).
+		Times(2)
+	s.env.OnActivity(createPreservationTaskLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.createPreservationTaskLocalActivityParams")).
+		Return(uint(0), nil).
+		Once()
+	s.env.OnActivity(activities.UploadActivityName, sessionCtx, mock.AnythingOfType("*activities.UploadActivityParams")).
+		Return(nil, nil).
+		Once()
+	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil).
+		Never()
+	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil).
+		Never()
+	s.env.OnActivity(completePreservationTaskLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.completePreservationTaskLocalActivityParams")).
+		Return(nil, nil).
+		Once()
+	s.env.OnActivity(activities.MoveToPermanentStorageActivityName, sessionCtx, mock.AnythingOfType("*activities.MoveToPermanentStorageActivityParams")).
+		Return(nil, nil).
+		Once()
+	s.env.OnActivity(activities.PollMoveToPermanentStorageActivityName, sessionCtx, mock.AnythingOfType("*activities.PollMoveToPermanentStorageActivityParams")).
+		Return(nil, nil).
+		Once()
 	s.env.OnActivity(setLocationIDLocalActivity, ctx, pkgsvc, pkgID, locationID).Return(nil, nil).Once()
-	s.env.OnActivity(completePreservationActionLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.completePreservationActionLocalActivityParams")).Return(nil, nil).Once()
-	s.env.OnActivity(activities.CleanUpActivityName, sessionCtx, mock.AnythingOfType("*activities.CleanUpActivityParams")).Return(nil, nil).Once()
+	s.env.OnActivity(completePreservationActionLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.completePreservationActionLocalActivityParams")).
+		Return(nil, nil).
+		Once()
+	s.env.OnActivity(activities.CleanUpActivityName, sessionCtx, mock.AnythingOfType("*activities.CleanUpActivityParams")).
+		Return(nil, nil).
+		Once()
 	s.env.OnActivity(activities.DeleteOriginalActivityName, sessionCtx, watcherName, key).Return(nil, nil).Once()
 
 	s.env.ExecuteWorkflow(
@@ -313,7 +384,8 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 		&createPackageLocalActivityParams{Key: key, Status: enums.PackageStatusQueued},
 	).Return(pkgID, nil)
 
-	s.env.OnActivity(setStatusInProgressLocalActivity, ctx, pkgsvc, pkgID, mock.AnythingOfType("time.Time")).Return(nil, nil)
+	s.env.OnActivity(setStatusInProgressLocalActivity, ctx, pkgsvc, pkgID, mock.AnythingOfType("time.Time")).
+		Return(nil, nil)
 
 	s.env.OnActivity(createPreservationActionLocalActivity, ctx,
 		pkgsvc, mock.AnythingOfType("*workflow.createPreservationActionLocalActivityParams"),
@@ -379,10 +451,18 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 	).Return(nil, nil)
 
 	// Post-preservation activities.
-	s.env.OnActivity(updatePackageLocalActivity, ctx, logger, pkgsvc, mock.AnythingOfType("*workflow.updatePackageLocalActivityParams")).Return(nil, nil).Once()
-	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Never()
-	s.env.OnActivity(completePreservationActionLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.completePreservationActionLocalActivityParams")).Return(nil, nil).Once()
-	s.env.OnActivity(activities.CleanUpActivityName, sessionCtx, mock.AnythingOfType("*activities.CleanUpActivityParams")).Return(nil, nil).Once()
+	s.env.OnActivity(updatePackageLocalActivity, ctx, logger, pkgsvc, mock.AnythingOfType("*workflow.updatePackageLocalActivityParams")).
+		Return(nil, nil).
+		Once()
+	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil).
+		Never()
+	s.env.OnActivity(completePreservationActionLocalActivity, ctx, pkgsvc, mock.AnythingOfType("*workflow.completePreservationActionLocalActivityParams")).
+		Return(nil, nil).
+		Once()
+	s.env.OnActivity(activities.CleanUpActivityName, sessionCtx, mock.AnythingOfType("*activities.CleanUpActivityParams")).
+		Return(nil, nil).
+		Once()
 	s.env.OnActivity(activities.DeleteOriginalActivityName, sessionCtx, watcherName, key).Return(nil, nil).Once()
 
 	s.env.ExecuteWorkflow(
@@ -421,9 +501,12 @@ func (s *ProcessingWorkflowTestSuite) TestPackageRejection() {
 	)
 
 	// Activity mocks/assertions sequence
-	s.env.OnActivity(createPackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(pkgID, nil)
-	s.env.OnActivity(setStatusInProgressLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(createPreservationActionLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(uint(0), nil)
+	s.env.OnActivity(createPackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(pkgID, nil)
+	s.env.OnActivity(setStatusInProgressLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	s.env.OnActivity(createPreservationActionLocalActivity, mock.Anything, mock.Anything, mock.Anything).
+		Return(uint(0), nil)
 
 	s.env.OnActivity(activities.DownloadActivityName, sessionCtx,
 		&activities.DownloadActivityParams{Key: key, WatcherName: watcherName},
@@ -448,17 +531,27 @@ func (s *ProcessingWorkflowTestSuite) TestPackageRejection() {
 	)
 
 	s.env.OnActivity(a3m.CreateAIPActivityName, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(completePreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	s.env.OnActivity(completePreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 	s.env.OnActivity(activities.UploadActivityName, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(createPreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(uint(0), nil)
-	s.env.OnActivity(activities.RejectPackageActivityName, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(activities.CleanUpActivityName, sessionCtx, mock.AnythingOfType("*activities.CleanUpActivityParams")).Return(nil, nil).Once()
+	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	s.env.OnActivity(createPreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).
+		Return(uint(0), nil)
+	s.env.OnActivity(activities.RejectPackageActivityName, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	s.env.OnActivity(activities.CleanUpActivityName, sessionCtx, mock.AnythingOfType("*activities.CleanUpActivityParams")).
+		Return(nil, nil).
+		Once()
 	s.env.OnActivity(activities.DeleteOriginalActivityName, sessionCtx, watcherName, key).Return(nil, nil).Once()
-	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-	s.env.OnActivity(completePreservationActionLocalActivity, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	s.env.OnActivity(completePreservationActionLocalActivity, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 
 	s.env.ExecuteWorkflow(
 		s.workflow.Execute,

--- a/internal/workflow/timer.go
+++ b/internal/workflow/timer.go
@@ -17,7 +17,10 @@ func NewTimer() *Timer {
 	return &Timer{}
 }
 
-func (t *Timer) WithTimeout(ctx temporalsdk_workflow.Context, d time.Duration) (temporalsdk_workflow.Context, temporalsdk_workflow.CancelFunc) {
+func (t *Timer) WithTimeout(
+	ctx temporalsdk_workflow.Context,
+	d time.Duration,
+) (temporalsdk_workflow.Context, temporalsdk_workflow.CancelFunc) {
 	logger := temporalsdk_workflow.GetLogger(ctx)
 
 	timedCtx, cancelHandler := temporalsdk_workflow.WithCancel(ctx)


### PR DESCRIPTION
Here's another attempt to fix long lines, this time using [golines]. This tool does not integrate with golangci-lint but it's also not incompatible either, i.e. golangci-lint is not raising issues with code formatted by golines. The result isn't perfect, but seems good enough. While not integrated with the linter/formatter, I'm considering keeping it installed so we can run it manually for now, or perhaps in CI in the future. Thoughts?

Alternatives:
* [golangci-lint/lll](https://golangci-lint.run/usage/linters/#lll) - part of golangci-lint but it doesn't have autofix.
* [gofumpt](https://github.com/mvdan/gofumpt) - the line splitter is an experimental feature not compatible with golangci-lint and it doesn't seem to identify issues in our project.

[golines]: https://github.com/segmentio/golines