### PR TITLE
Fix user hydration when authenticated

### DIFF
--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -1,10 +1,24 @@
 <script setup lang="ts">
+import { watch } from "vue";
+import { client } from "@/client";
 import { useLayoutStore } from "./stores/layout";
 import Header from "@/components/Header.vue";
 import Sidebar from "@/components/Sidebar.vue";
 import { DialogWrapper } from "vue3-promise-dialog";
 
 const layoutStore = useLayoutStore();
+
+// Connect to the package monitor API when the user is loaded successfully.
+watch(
+  () => layoutStore.isUserValid,
+  (valid) => {
+    if (valid) {
+      client.package.packageMonitorRequest().then(() => {
+        client.connectPackageMonitor();
+      });
+    }
+  },
+);
 </script>
 
 <template>

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1,8 +1,6 @@
 import App from "./App.vue";
-import auth from "./auth";
-import { client, api } from "./client";
+import { api } from "./client";
 import router from "./router";
-import { useLayoutStore } from "./stores/layout";
 import "./styles/main.scss";
 import { PiniaDebounce } from "@pinia/plugin-debounce";
 import humanizeDuration from "humanize-duration";
@@ -24,15 +22,6 @@ app.use({
   },
 });
 app.mount("#app");
-
-auth.getUser().then((user) => {
-  useLayoutStore().setUser(user);
-  if (user) {
-    client.package.packageMonitorRequest().then(() => {
-      client.connectPackageMonitor();
-    });
-  }
-});
 
 interface Filters {
   [key: string]: (...value: any[]) => string;

--- a/dashboard/src/pages/user/signin-callback.vue
+++ b/dashboard/src/pages/user/signin-callback.vue
@@ -7,11 +7,6 @@ import { useRouter } from "vue-router/auto";
 const router = useRouter();
 auth.signinCallback().then((user) => {
   useLayoutStore().setUser(user || null);
-  if (user) {
-    client.package.packageMonitorRequest().then(() => {
-      client.connectPackageMonitor();
-    });
-  }
   router.push({ name: "/" });
 });
 </script>

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -6,9 +6,12 @@ const router = createRouter({
   strict: false,
 });
 
-router.beforeEach((to, _, next) => {
+const publicRoutes: Array<string> = ["/user/signin", "/user/signin-callback"];
+
+// Send unauthenticated users to the sign-in page.
+router.beforeEach(async (to, _, next) => {
   const layoutStore = useLayoutStore();
-  const publicRoutes: Array<string> = ["/user/signin", "/user/signin-callback"];
+  await layoutStore.loadUser();
   const routeName = to.name?.toString() || "";
   if (!layoutStore.isUserValid && !publicRoutes.includes(routeName)) {
     next({ name: "/user/signin" });

--- a/dashboard/src/stores/layout.ts
+++ b/dashboard/src/stores/layout.ts
@@ -34,6 +34,13 @@ export const useLayoutStore = defineStore("layout", {
     updateBreadcrumb(breadcrumb: Array<BreadcrumbItem>) {
       this.breadcrumb = breadcrumb;
     },
+    // Load the currently authenticated user.
+    async loadUser() {
+      if (this.user === null) {
+        const user = await auth.getUser();
+        this.setUser(user);
+      }
+    },
     setUser(user: User | null) {
       this.user = user;
     },


### PR DESCRIPTION
After updating to Vue 3.4, the global navigation guard in the router stopped
being able to validate authenticated users during the initial loading of the
application, e.g. after a page refresh. The root issue lies in the `getUser`
success callback in `main.ts` executing too late, i.e. not having run by the
time when the navigation guard was evaluating `isUserValid`. I'm not sure what
is the exact change in Vue that caused this issue, but I suspect it's related
to the updates in the reactivity system.

To reproduce the issue:
1. Open http://localhost:8080 and sign in.
2. Open http://localhost:8080 again from a new tab,
3. You'll be redirected (unexpectedly) to the sign-in page.

The fix proposed consists in loading the user from the layout store using a new
action that is triggered by the navigation guard.

The `App` component now uses `watch` to observe `layoutStore.isUserValid` and
react by establishing the package monitor connection when it's set to true,
effectively decoupling the connection process from the authentication workflow.