### PR TITLE
add mysql to devbox

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -9,7 +9,8 @@
     "python3@latest",
     "markdownlint-cli@latest",
     "python311Packages.pip-tools@latest",
-    "go_1_22@latest"
+    "go_1_22@latest",
+    "mysql@latest"
   ],
   "shell": {
     "init_hook": [

--- a/devbox.lock
+++ b/devbox.lock
@@ -149,6 +149,13 @@
         }
       }
     },
+    "mysql@latest": {
+      "last_modified": "2023-02-24T09:01:09Z",
+      "plugin_version": "0.0.3",
+      "resolved": "github:NixOS/nixpkgs/7d0ed7f2e5aea07ab22ccb338d27fbe347ed2f11#mysql",
+      "source": "devbox-search",
+      "version": "10.6.12"
+    },
     "nodejs_20@latest": {
       "last_modified": "2023-12-13T22:54:10Z",
       "plugin_version": "0.0.2",


### PR DESCRIPTION
Previously, dev dependencies that run via make db would not work. Adding mysql allows devs to launch a mysql database connection to enduro.  
