### PR TITLE
Add `make pre-commit` to run all code checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,7 @@ shfmt: $(SHFMT) # @HELP Run shfmt to format shell programs in the hack directory
 gosec: # @HELP Run gosec security scanner.
 gosec: $(GOSEC)
 	gosec \
+		-terse \
 		-exclude-dir=dashboard \
 		-exclude-dir=hack \
 		-exclude-dir=internal/api/gen \
@@ -210,6 +211,15 @@ workflowcheck: $(WORKFLOWCHECK)
 db: # @HELP Opens the MySQL shell connected to the enduro development database.
 db:
 	mysql -h127.0.0.1 -P3306 -uroot -proot123 enduro
+
+pre-commit: # @HELP Check that code is ready to commit.
+pre-commit:
+	$(MAKE) -j lint \
+	golines \
+	gosec \
+	shfmt \
+	test-race \
+	workflowcheck \
 
 help: # @HELP Print this message.
 help:

--- a/hack/make/dep_workflowcheck.mk
+++ b/hack/make/dep_workflowcheck.mk
@@ -3,14 +3,13 @@ $(call _conditional_include,$(MAKEDIR)/base.mk)
 $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
-# Tag contrib/tools/workflowcheck/v0.1.0 isn't compatible with go1.22.
-WORKFLOWCHECK_VERSION ?= 72a5b6f
+WORKFLOWCHECK_VERSION ?= 0.2.0
 
 WORKFLOWCHECK := $(CACHE_VERSIONS)/workflowcheck/$(WORKFLOWCHECK_VERSION)
 $(WORKFLOWCHECK):
 	rm -f $(CACHE_BIN)/workflowcheck
 	mkdir -p $(CACHE_BIN)
-	env GOBIN=$(CACHE_BIN) go install go.temporal.io/sdk/contrib/tools/workflowcheck@$(WORKFLOWCHECK_VERSION)
+	env GOBIN=$(CACHE_BIN) go install go.temporal.io/sdk/contrib/tools/workflowcheck@v$(WORKFLOWCHECK_VERSION)
 	chmod +x $(CACHE_BIN)/workflowcheck
 	rm -rf $(dir $(WORKFLOWCHECK))
 	mkdir -p $(dir $(WORKFLOWCHECK))


### PR DESCRIPTION
Run `make pre-commit` before pushing your code to check that it passes all CI checks.

Also reduce the verbosity of `make gosec`.