### PR TITLE
Use tparallel linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - gci
     - unparam
     - gosec
+    - tparallel
 
 issues:
   exclude-rules:

--- a/internal/am/poll_ingest_test.go
+++ b/internal/am/poll_ingest_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestPollIngestActivity(t *testing.T) {
+	t.Parallel()
+
 	clock := clockwork.NewFakeClock()
 	path := "/var/archivematica/fake/sip"
 	presActionID := uint(2)

--- a/internal/am/start_transfer_test.go
+++ b/internal/am/start_transfer_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestStartTransferActivity(t *testing.T) {
+	t.Parallel()
+
 	transferID := uuid.New().String()
 	opts := am.StartTransferActivityParams{
 		Name: "Testing",

--- a/internal/am/upload_transfer_test.go
+++ b/internal/am/upload_transfer_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestUploadTransferActivity(t *testing.T) {
+	t.Parallel()
+
 	filename := "transfer.zip"
 	td := tfs.NewDir(t, "enduro-upload-transfer-test",
 		tfs.WithFile(filename, "Testing 1-2-3!"),

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestRescoverMiddleware(t *testing.T) {
+	t.Parallel()
+
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
 	w := httptest.NewRecorder()
 
@@ -32,6 +34,8 @@ func TestRescoverMiddleware(t *testing.T) {
 }
 
 func TestVersionHeaderMiddleware(t *testing.T) {
+	t.Parallel()
+
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
 	w := httptest.NewRecorder()
 
@@ -55,6 +59,8 @@ func TestWriteTimeout(t *testing.T) {
 	})
 
 	t.Run("Sets a write timeout", func(t *testing.T) {
+		t.Parallel()
+
 		ts := httptest.NewServer(writeTimeout(h, time.Microsecond))
 		defer ts.Close()
 
@@ -63,6 +69,8 @@ func TestWriteTimeout(t *testing.T) {
 	})
 
 	t.Run("Sets an unlimited write timeout", func(t *testing.T) {
+		t.Parallel()
+
 		ts := httptest.NewServer(writeTimeout(h, 0))
 		defer ts.Close()
 

--- a/internal/db/convert_test.go
+++ b/internal/db/convert_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestFormatOptionalString(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Returns nil pointer for an empty string", func(t *testing.T) {
 		t.Parallel()
 		got := db.FormatOptionalString("")
@@ -25,6 +27,8 @@ func TestFormatOptionalString(t *testing.T) {
 }
 
 func TestFormatOptionalTime(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Returns nil pointer for null time", func(t *testing.T) {
 		t.Parallel()
 		got := db.FormatOptionalTime(sql.NullTime{})

--- a/internal/enums/pkg_status_test.go
+++ b/internal/enums/pkg_status_test.go
@@ -48,6 +48,8 @@ func TestStatus(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("Status_%s", tc.str), func(t *testing.T) {
+			t.Parallel()
+
 			s := enums.NewPackageStatus(tc.str)
 			assert.Assert(t, s != enums.PackageStatusUnknown)
 			assert.Equal(t, s, tc.val)
@@ -66,6 +68,8 @@ func TestStatus(t *testing.T) {
 }
 
 func TestStatusUnknown(t *testing.T) {
+	t.Parallel()
+
 	s := enums.NewPackageStatus("?")
 
 	assert.Equal(t, s, enums.PackageStatusUnknown)

--- a/internal/package_/package__test.go
+++ b/internal/package_/package__test.go
@@ -40,6 +40,8 @@ func testSvc(t *testing.T) (package_.Service, *persistence_fake.MockService) {
 }
 
 func TestCreatePackage(t *testing.T) {
+	t.Parallel()
+
 	type test struct {
 		name    string
 		pkg     datatypes.Package

--- a/internal/package_/preservation_task_test.go
+++ b/internal/package_/preservation_task_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestCreatePreservationTask(t *testing.T) {
+	t.Parallel()
+
 	taskID := "a499e8fc-7309-4e26-b39d-d8ab68466c27"
 
 	type test struct {
@@ -138,6 +140,8 @@ func TestCreatePreservationTask(t *testing.T) {
 }
 
 func TestCompletePreservationTask(t *testing.T) {
+	t.Parallel()
+
 	completedAt := time.Date(2024, 4, 2, 10, 35, 32, 0, time.UTC)
 
 	type args struct {

--- a/internal/persistence/ent/client/client_test.go
+++ b/internal/persistence/ent/client/client_test.go
@@ -60,6 +60,8 @@ func createPreservationAction(
 }
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Returns a working ent DB client", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/persistence/ent/client/package_test.go
+++ b/internal/persistence/ent/client/package_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestCreatePackage(t *testing.T) {
+	t.Parallel()
+
 	runID := uuid.New()
 	aipID := uuid.NullUUID{UUID: uuid.New(), Valid: true}
 	locID := uuid.NullUUID{UUID: uuid.New(), Valid: true}
@@ -142,6 +144,8 @@ func TestCreatePackage(t *testing.T) {
 }
 
 func TestUpdatePackage(t *testing.T) {
+	t.Parallel()
+
 	runID := uuid.MustParse("c5f7c35a-d5a6-4e00-b4da-b036ce5b40bc")
 	runID2 := uuid.MustParse("c04d0191-d7ce-46dd-beff-92d6830082ff")
 

--- a/internal/persistence/ent/client/preservation_task_test.go
+++ b/internal/persistence/ent/client/preservation_task_test.go
@@ -43,6 +43,8 @@ func addDBFixtures(
 }
 
 func TestCreatePreservationTask(t *testing.T) {
+	t.Parallel()
+
 	taskID := "ef0193bf-a622-4a8b-b860-cda605a426b5"
 	started := sql.NullTime{Time: time.Now(), Valid: true}
 	completed := sql.NullTime{Time: started.Time.Add(time.Second), Valid: true}
@@ -153,6 +155,8 @@ func TestCreatePreservationTask(t *testing.T) {
 }
 
 func TestUpdatePreservationTask(t *testing.T) {
+	t.Parallel()
+
 	taskID := uuid.MustParse("c5f7c35a-d5a6-4e00-b4da-b036ce5b40bc")
 	taskID2 := uuid.MustParse("c04d0191-d7ce-46dd-beff-92d6830082ff")
 

--- a/internal/storage/service_test.go
+++ b/internal/storage/service_test.go
@@ -123,6 +123,8 @@ func TestNewService(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Errors on invalid configuration", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := storage.NewService(
 			logr.Discard(),
 			storage.Config{},

--- a/internal/watcher/filesystem_test.go
+++ b/internal/watcher/filesystem_test.go
@@ -21,6 +21,8 @@ type file struct {
 }
 
 func TestFileSystemWatcher(t *testing.T) {
+	t.Parallel()
+
 	td := fs.NewDir(t, "enduro-test-fs-watcher")
 	type test struct {
 		name   string

--- a/internal/watcher/minio_test.go
+++ b/internal/watcher/minio_test.go
@@ -340,6 +340,8 @@ func TestWatcherReturnsErrOnInvalidObjectKey(t *testing.T) {
 }
 
 func TestMinioWatcherDownload(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Downloads a file", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/workflow/activities/bundle_test.go
+++ b/internal/workflow/activities/bundle_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestBundleActivity(t *testing.T) {
+	t.Parallel()
+
 	sourceDir := fs.NewDir(t, "enduro-bundle-test",
 		fs.FromDir("../../testdata"),
 	)

--- a/internal/workflow/activities/download_test.go
+++ b/internal/workflow/activities/download_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestDownloadActivity(t *testing.T) {
+	t.Parallel()
+
 	key := "jabber.txt"
 	watcherName := "watcher"
 

--- a/internal/workflow/activities/zip_test.go
+++ b/internal/workflow/activities/zip_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestZipActivity(t *testing.T) {
+	t.Parallel()
+
 	transferName := "my_transfer"
 	contents := tfs.WithDir(transferName,
 		tfs.WithDir("subdir",


### PR DESCRIPTION
This PR configures the `tparallel` linter which detects a couple of common mistakes when using `t.Parallel()`.

Context:
- https://github.com/moricho/tparallel
- https://brandur.org/fragments/go-prefer-t-cleanup-with-parallel-subtests