### PR TITLE
Add failed SIPs/PIPs buckets

### DIFF
--- a/enduro.toml
+++ b/enduro.toml
@@ -229,3 +229,19 @@ sharedPath = "/home/enduro/preprocessing"
 namespace = "default"
 taskQueue = "preprocessing"
 workflowName = "preprocessing"
+
+[failedSips]
+endpoint = "http://minio.enduro-sdps:9000"
+pathStyle = true
+accessKey = "minio"
+secretKey = "minio123"
+region = "us-west-1"
+bucket = "failed-sips"
+
+[failedPips]
+endpoint = "http://minio.enduro-sdps:9000"
+pathStyle = true
+accessKey = "minio"
+secretKey = "minio123"
+region = "us-west-1"
+bucket = "failed-pips"

--- a/hack/kube/base/minio-setup-buckets-job.yaml
+++ b/hack/kube/base/minio-setup-buckets-job.yaml
@@ -31,5 +31,7 @@ spec:
               mc mb enduro/aips --ignore-existing;
               mc mb enduro/perma-aips-1 --ignore-existing;
               mc mb enduro/perma-aips-2 --ignore-existing;
+              mc mb enduro/failed-sips --ignore-existing;
+              mc mb enduro/failed-pips --ignore-existing;
               mc event add enduro/sips arn:minio:sqs::PRIMARY:redis --event put --ignore-existing",
             ]

--- a/hack/kube/tools/minio-recreate-buckets-job.yaml
+++ b/hack/kube/tools/minio-recreate-buckets-job.yaml
@@ -31,5 +31,7 @@ spec:
               mc mb enduro/aips --ignore-existing;
               mc mb enduro/perma-aips-1 --ignore-existing;
               mc mb enduro/perma-aips-2 --ignore-existing;
+              mc mb enduro/failed-sips --ignore-existing;
+              mc mb enduro/failed-pips --ignore-existing;
               mc event add enduro/sips arn:minio:sqs::PRIMARY:redis --event put --ignore-existing",
             ]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
+	"go.artefactual.dev/tools/bucket"
 
 	"github.com/artefactual-sdps/enduro/internal/a3m"
 	"github.com/artefactual-sdps/enduro/internal/am"
@@ -53,6 +54,9 @@ type Configuration struct {
 	Upload          package_.UploadConfig
 	Watcher         watcher.Config
 	Telemetry       telemetry.Config
+
+	FailedSIPs bucket.Config
+	FailedPIPs bucket.Config
 }
 
 func (c *Configuration) Validate() error {

--- a/internal/workflow/activities/activities.go
+++ b/internal/workflow/activities/activities.go
@@ -12,4 +12,6 @@ const (
 	PollMoveToPermanentStorageActivityName = "poll-move-to-permanent-storage-activity"
 	RejectPackageActivityName              = "reject-package-activity"
 	UploadActivityName                     = "upload-activity"
+	SendToFailedSIPsName                   = "send-to-failed-sips"
+	SendToFailedPIPsName                   = "send-to-failed-pips"
 )


### PR DESCRIPTION
If there is an error before the SIP is sent to preservation, copy the
downloaded SIP file to a failed SIPs bucket. If there is an error on
preservation, send a copy of the PIP to a failed PIPs bucket, with all
the transformations made before it was sent to preservation.

- Add failed buckets configuration.
- Use temporal-activities/bucketupload registered with two different
  names for each failed bucket.
- Modify Kubernetes jobs to set up and re-create buckets.

Refs #929.