### PR TITLE
Integrate Static Code Analysis Tools for IaC files

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,26 @@
+name: Trivy
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  trivy:
+    name: Run Trivy for IaC Security Analysis
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "config"
+          exit-code: "1"
+          severity: "CRITICAL,HIGH,MEDIUM"
+        env:
+          TRIVY_MISCONFIG_SCANNERS: dockerfile

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -12,6 +12,14 @@ CMD npm run dev
 FROM nginx:alpine
 RUN apk add --no-cache bash
 
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN addgroup -g ${GROUP_ID} -S nginx
+RUN adduser -u ${USER_ID} -S -D nginx nginx
+USER nginx
+
+RUN chown -R nginx:nginx /var/cache/nginx /var/run /usr/share/nginx/html
+
 ARG VERSION_PATH
 ARG VERSION_LONG
 ARG VERSION_SHORT


### PR DESCRIPTION
This pull request enhances build security by integrating the Trivy static code analysis tool configured to scan IaC files.

This new GitHub action is currently configured to scan Dockerfiles only, but this will be expanded in future pull requests.

This PR also addresses a security enhancement identified by Trivy.