### PR TITLE
Add timestamps to package task display (fixes #832)

### DIFF
--- a/dashboard/src/components/PreservationActionCollapse.vue
+++ b/dashboard/src/components/PreservationActionCollapse.vue
@@ -114,6 +114,8 @@ watch($$(expandCounter), () => show());
           <tr>
             <th scope="col">Task #</th>
             <th scope="col">Name</th>
+            <th scope="col">Start</th>
+            <th scope="col">End</th>
             <th scope="col">Outcome</th>
             <th scope="col">Notes</th>
           </tr>
@@ -125,6 +127,8 @@ watch($$(expandCounter), () => show());
           >
             <td>{{ action.tasks.length - index }}</td>
             <td>{{ task.name }}</td>
+            <td>{{ $filters.formatDateTime(task.startedAt) }}</td>
+            <td>{{ $filters.formatDateTime(task.completedAt) }}</td>
             <td>
               <StatusBadge :status="task.status" />
             </td>

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -36,13 +36,13 @@ declare module "@vue/runtime-core" {
 app.config.globalProperties.$filters = {
   formatDateTimeString(value: string) {
     const date = new Date(value);
-    return moment(String(date)).format("YYYY-MM-DD HH:mm:ss");
+    return moment(date).format("YYYY-MM-DD HH:mm:ss");
   },
   formatDateTime(value: Date | undefined) {
-    if (!value) {
+    if (!value || Number.isNaN(value.getTime())) {
       return "";
     }
-    return moment(String(value)).format("YYYY-MM-DD HH:mm:ss");
+    return moment(value).format("YYYY-MM-DD HH:mm:ss");
   },
   formatDuration(from: Date, to: Date) {
     const diff = moment(to).diff(from);


### PR DESCRIPTION
Added display of package task start and completion date/time when displaying package activity tasks in the dashboard.

Fixed warnings during date conversion to ISO 8601 format.