### PR TITLE
Bump golangci-lint from 1.56.2 to 1.58.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,8 @@ linters:
     - unparam
     - gosec
     - tparallel
+    - contextcheck
+    - intrange
 
 issues:
   exclude-dirs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,5 @@
 run:
   deadline: 60s
-  skip-dirs:
-    - dashboard
-    - hack
-    - internal/storage/persistence/ent/schema
 
 linters:
   enable:
@@ -16,6 +12,10 @@ linters:
     - tparallel
 
 issues:
+  exclude-dirs:
+    - dashboard
+    - hack
+    - internal/storage/persistence/ent/schema
   exclude-rules:
     - path: _test\.go
       linters:

--- a/hack/make/dep_golangci_lint.mk
+++ b/hack/make/dep_golangci_lint.mk
@@ -5,7 +5,7 @@ $(call _assert_var,UNAME_ARCH)
 $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
-GOLANGCI_LINT_VERSION ?= 1.56.2
+GOLANGCI_LINT_VERSION ?= 1.58.1
 
 ARCH := $(UNAME_ARCH)
 ifeq ($(UNAME_ARCH),x86_64)

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -12,10 +12,8 @@ import (
 
 const fileMode = os.FileMode(0o755)
 
-// Bundler helps create Archivematica transfers in the filesystem.
-//
-// It is a simpler alternative to amclient.TransferSession that does not concern
-// with the submission of the transfer.
+// The Bundler simplifies the creation of Archivematica transfers ready for
+// submission, complete with checksums and metadata files.
 type Bundler struct {
 	fs afero.Fs
 
@@ -52,7 +50,8 @@ func NewBundler(fs afero.Fs) (*Bundler, error) {
 }
 
 // NewBundlerWithTempDir returns a bundler based on a temporary directory
-// created under the path given.
+// created under the path given, e.g. the path to a transfer source location in
+// the filesystem.
 func NewBundlerWithTempDir(path string) (*Bundler, error) {
 	mode := os.FileMode(0o755)
 	osFs := afero.NewOsFs()

--- a/internal/bundler/bundler_test.go
+++ b/internal/bundler/bundler_test.go
@@ -1,42 +1,102 @@
-/*
-Package bundler provides a transfer package creator for Archivematica.
-
-It is an alternative to TransferSession that addresses some of its major pain
-points. For example, this version does not concern with submitting the package
-to Archivematica and makes the package filesystem available to the user for
-more flexibility to alter its contents manually.
-
-It could eventually be included in the amclient module as its own package.
-*/
-package bundler
+package bundler_test
 
 import (
 	"bytes"
 	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 
-	"github.com/spf13/afero"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+
+	"github.com/artefactual-sdps/enduro/internal/bundler"
 )
 
 func TestNewBundlerWithTempDir(t *testing.T) {
-	transferDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Parallel()
 
-	b, err := NewBundlerWithTempDir(transferDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tmpDir := fs.NewDir(t, "enduro-bundler")
+	b, err := bundler.NewBundlerWithTempDir(tmpDir.Path())
+	assert.NilError(t, err)
 
-	ok, err := afero.DirExists(b.fs, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
-		t.Fatal("dir not exists")
-	}
+	// Describe the transfer.
+	b.Describe("dc.title", "Transfer")
 
-	_ = b.Write("foobar.txt", bytes.NewReader([]byte("foooooo")))
-	_ = b.Bundle()
+	// Describe and write foobar.txt and notes.txt into the transfer.
+	err = b.Write("foobar.txt", bytes.NewReader([]byte("some text")))
+	assert.NilError(t, err)
+	b.DescribeFile("foobar.txt", "dc.title", "Foobar")
+	b.ChecksumMD5("foobar.txt", "552e21cd4cd9918678e3c1a0df491bc3")
+	b.ChecksumSHA1("foobar.txt", "37aa63c77398d954473262e1a0057c1e632eda77")
+	b.ChecksumSHA256("foobar.txt", "b94f6f125c79e3a5ffaa826f584c10d52ada669e6762051b826b55776d05aed2")
+	err = b.Write("notes.txt", bytes.NewReader([]byte("some notes")))
+	assert.NilError(t, err)
+	b.DescribeFile("notes.txt", "dc.title", "Notes")
+	b.DescribeFile("notes.txt", "dc.description", "Some notes")
+
+	err = b.Bundle()
+	assert.NilError(t, err)
+
+	// The actual transfer directory being bundled is created two levels deep,
+	// using a root container ("c") and a temporary directory, for example:
+	// `/tmp/enduro-bundler-2161969315/c/304672139`.
+	dir := transferDir(t, tmpDir.Path())
+	assert.Equal(t, b.FullBaseFsPath(), dir)
+
+	umask := os.FileMode(syscall.Umask(0))
+	dirMode := fs.WithMode(0o755 &^ umask)
+	fileMode := fs.WithMode(0o664 &^ umask)
+
+	assert.Assert(t, fs.Equal(
+		dir,
+		fs.Expected(t,
+			// By default, the bundler uses less restrictive permissions to
+			// allow other local users (e.g., the default Archivematica user) to
+			// access the contents. This might not be the best approach.
+			dirMode,
+			fs.WithDir("metadata",
+				fs.WithFile("checksum.md5", "552e21cd4cd9918678e3c1a0df491bc3 foobar.txt\n", fileMode),
+				fs.WithFile("checksum.sha1", "37aa63c77398d954473262e1a0057c1e632eda77 foobar.txt\n", fileMode),
+				fs.WithFile("checksum.sha256", "b94f6f125c79e3a5ffaa826f584c10d52ada669e6762051b826b55776d05aed2 foobar.txt\n", fileMode),
+				fs.WithFile("metadata.csv", `filename,dc.description,dc.title
+foobar.txt,,Foobar
+notes.txt,Some notes,Notes
+objects/,,Transfer
+`,
+					fileMode),
+			),
+			// The `objects`` directory is empty because the bundler opts to
+			// place the files in the root directory, which is also supported.
+			fs.WithDir("objects"),
+			fs.WithFile("foobar.txt", "some text", fileMode),
+			fs.WithFile("notes.txt", "some notes", fileMode),
+		),
+	))
+
+	// We can remove the transfer but it should not remove the root container
+	// since it is the common ancestor to other transfers
+	err = b.Destroy()
+	assert.NilError(t, err)
+	assert.Assert(t, fs.Equal(
+		tmpDir.Path(),
+		fs.Expected(t,
+			fs.WithDir("c"),
+		),
+	))
+}
+
+func transferDir(t *testing.T, dir string) string {
+	t.Helper()
+
+	// bundler uses an additional "c" parent directory to avoid polluting the
+	// Archivematica transfer source location, which is arguably unnecessary
+	// or should maybe be optional.
+	rootContainer := filepath.Join(dir, "c")
+
+	// Inside it, it creates a temporary directory named randomly.
+	entries, err := os.ReadDir(rootContainer)
+	assert.NilError(t, err)
+
+	return filepath.Join(rootContainer, entries[0].Name())
 }

--- a/internal/bundler/metadata.go
+++ b/internal/bundler/metadata.go
@@ -76,7 +76,7 @@ func (m *MetadataSet) Write() error {
 	// Build a list of fields
 	fields := []string{}
 	for field, o := range occurrences {
-		for i := 0; i < o; i++ {
+		for range o {
 			fields = append(fields, field)
 		}
 	}

--- a/internal/package_/goa.go
+++ b/internal/package_/goa.go
@@ -252,7 +252,7 @@ func (w *goaWrapper) Reject(ctx context.Context, payload *goapackage.RejectPaylo
 	signal := ReviewPerformedSignal{
 		Accepted: false,
 	}
-	err = w.tc.SignalWorkflow(context.Background(), *goapkg.WorkflowID, "", ReviewPerformedSignalName, signal)
+	err = w.tc.SignalWorkflow(ctx, *goapkg.WorkflowID, "", ReviewPerformedSignalName, signal)
 	if err != nil {
 		return goapackage.MakeNotAvailable(errors.New("cannot perform operation"))
 	}

--- a/internal/storage/download.go
+++ b/internal/storage/download.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -35,7 +34,7 @@ func Download(svc Service, mux goahttp.Muxer, dec func(r *http.Request) goahttp.
 		}
 
 		// Read storage package.
-		ctx := context.Background()
+		ctx := req.Context()
 		pkg, err := svc.ReadPackage(ctx, aipID)
 		if err != nil {
 			rw.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
This pull request also:
- Enables a couple of extra linters that I've found useful: [`intrange`](https://github.com/ckaznocha/intrange) and [`contextcheck`](https://github.com/kkHAIKE/contextcheck), and
- Add tests to the bundler package.