### PR TITLE
Fix name of AMSSConfig.ConvertToAMSSConfig()

### DIFF
--- a/internal/api/gen/storage/convert.go
+++ b/internal/api/gen/storage/convert.go
@@ -12,8 +12,8 @@ import (
 	types "github.com/artefactual-sdps/enduro/internal/storage/types"
 )
 
-// ConvertToSSConfig creates an instance of SSConfig initialized from t.
-func (t *AMSSConfig) ConvertToSSConfig() *types.AMSSConfig {
+// ConvertToAMSSConfig creates an instance of AMSSConfig initialized from t.
+func (t *AMSSConfig) ConvertToAMSSConfig() *types.AMSSConfig {
 	v := &types.AMSSConfig{
 		APIKey:   t.APIKey,
 		URL:      t.URL,

--- a/internal/storage/location.go
+++ b/internal/storage/location.go
@@ -64,7 +64,7 @@ func NewLocation(location *goastorage.Location) (Location, error) {
 	case *goastorage.SFTPConfig:
 		config.Value = c.ConvertToSFTPConfig()
 	case *goastorage.AMSSConfig:
-		config.Value = c.ConvertToSSConfig()
+		config.Value = c.ConvertToAMSSConfig()
 	default:
 		return nil, fmt.Errorf("unsupported config type: %T", c)
 	}


### PR DESCRIPTION
Regenerating the goa assets updated the name of the method.