### PR TITLE
Add tilt-am-knownhosts rule to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,16 @@ test-race: # @HELP Run all tests with the race detector.
 test-race:
 	$(MAKE) test GOTEST_FLAGS="-race"
 
+tilt-am-knownhosts:  # @HELP Update Archivematica Storage Service known_hosts.
+tilt-am-knownhosts: HOST ?= host.k3d.internal
+tilt-am-knownhosts: PORT ?= 12322
+tilt-am-knownhosts:
+	ssh-keyscan -H -p $(PORT) $(HOST) > hack/kube/overlays/dev-am/.known_hosts.secret
+	tilt trigger "(Tiltfile)"
+	tilt wait --for=condition=Ready "uiresource/(Tiltfile)"
+	tilt trigger enduro-am
+	tilt wait --for=condition=Ready uiresource/enduro-am
+
 tools: # @HELP Install tools.
 tools: $(TOOLS)
 


### PR DESCRIPTION
Allows to update the `.known_hosts.secret` file for Archivematica's SFTP connection using `ssh-keyscan` and restarting the required Tilt services after.