### PR TITLE
Switch to a Ubuntu docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 	-o /out/enduro-am-worker \
 	./cmd/enduro-am-worker
 
-FROM gcr.io/distroless/base-debian12:latest AS base
-USER 1000
+FROM ubuntu:22.04 AS base
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN addgroup --gid ${GROUP_ID} enduro
+RUN adduser --uid ${USER_ID} --gid ${GROUP_ID} --disabled-password --gecos "" enduro
+USER enduro
 
 FROM base AS enduro
 COPY --from=build-enduro --link /out/enduro /home/enduro/bin/enduro


### PR DESCRIPTION
The Ubuntu base image allows shell access to a running continer for debugging purposes, unlike the Google distroless image.