### PR TITLE
Disable MinIO web console login animation

### DIFF
--- a/hack/kube/base/minio.yaml
+++ b/hack/kube/base/minio.yaml
@@ -82,6 +82,8 @@ spec:
               value: "/tmp/events"
             - name: MINIO_NOTIFY_REDIS_QUEUE_LIMIT_PRIMARY
               value: "10000"
+            - name: MINIO_BROWSER_LOGIN_ANIMATION
+              value: "off"
           ports:
             - containerPort: 9000
             - containerPort: 9001


### PR DESCRIPTION
Fixes #998

Disable the MinIO web UI login animation to avoid a web socket port forwarding bug: https://github.com/minio/console/issues/2539.