### PR TITLE
Open localhost:9002 in Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -99,7 +99,7 @@ if os.environ.get('TRIGGER_MODE_AUTO', '').lower() in true:
   trigger_mode = TRIGGER_MODE_AUTO
 
 # Enduro resources
-k8s_resource("enduro", labels=["Enduro"], trigger_mode=trigger_mode)
+k8s_resource("enduro", labels=["Enduro"], port_forwards="9002:9002", trigger_mode=trigger_mode)
 k8s_resource("enduro-dashboard", port_forwards="8080:80", labels=["Enduro"], trigger_mode=trigger_mode)
 
 if PRES_SYS == 'am':


### PR DESCRIPTION
Open the internal API port (localhost:9002) in the Tilt dev deployment to allow access to the localhost:9002/swagger/swagger.json resource.