### PR TITLE
Check integer values before conversion

### DIFF
--- a/internal/a3m/a3m.go
+++ b/internal/a3m/a3m.go
@@ -33,7 +33,7 @@ type CreateAIPActivity struct {
 type CreateAIPActivityParams struct {
 	Name                 string
 	Path                 string
-	PreservationActionID uint
+	PreservationActionID int
 }
 
 type CreateAIPActivityResult struct {
@@ -111,7 +111,7 @@ func (a *CreateAIPActivity) Execute(
 							TranscribeFiles:                              a.cfg.TranscribeFiles,
 							PerformPolicyChecksOnOriginals:               a.cfg.PerformPolicyChecksOnOriginals,
 							PerformPolicyChecksOnPreservationDerivatives: a.cfg.PerformPolicyChecksOnPreservationDerivatives,
-							AipCompressionLevel:                          int32(a.cfg.AipCompressionLevel),
+							AipCompressionLevel:                          a.cfg.AipCompressionLevel,
 							AipCompressionAlgorithm:                      a.cfg.AipCompressionAlgorithm,
 						},
 					},
@@ -169,7 +169,7 @@ func savePreservationTasks(
 	tracer trace.Tracer,
 	jobs []*transferservice.Job,
 	pkgsvc package_.Service,
-	paID uint,
+	paID int,
 ) error {
 	ctx, span := tracer.Start(ctx, "savePreservationTasks")
 	defer span.End()

--- a/internal/a3m/config.go
+++ b/internal/a3m/config.go
@@ -1,6 +1,15 @@
 package a3m
 
-import transferservice "buf.build/gen/go/artefactual/a3m/protocolbuffers/go/a3m/api/transferservice/v1beta1"
+import (
+	"fmt"
+
+	transferservice "buf.build/gen/go/artefactual/a3m/protocolbuffers/go/a3m/api/transferservice/v1beta1"
+)
+
+const (
+	minCompressionLevel = 0
+	maxCompressionLevel = 9
+)
 
 type Config struct {
 	Name     string
@@ -14,8 +23,22 @@ type Config struct {
 	Processing
 }
 
-// The `Processing` struct represents a configuration for processing various tasks in the transferservice.
-// It mirrors the processing configuration fields in transferservice.ProcessingConfig.
+func (c *Config) Validate() error {
+	if c.AipCompressionAlgorithm < minCompressionLevel || c.AipCompressionLevel > maxCompressionLevel {
+		return fmt.Errorf(
+			"AipCompressionLevel: %d is outside valid range (%d to %d)",
+			c.AipCompressionLevel,
+			minCompressionLevel,
+			maxCompressionLevel,
+		)
+	}
+
+	return nil
+}
+
+// The `Processing` struct represents a configuration for processing various
+// tasks in the transferservice. It mirrors the processing configuration fields
+// in transferservice.ProcessingConfig.
 type Processing struct {
 	AssignUuidsToDirectories                     bool
 	ExamineContents                              bool
@@ -30,7 +53,7 @@ type Processing struct {
 	TranscribeFiles                              bool
 	PerformPolicyChecksOnOriginals               bool
 	PerformPolicyChecksOnPreservationDerivatives bool
-	AipCompressionLevel                          int
+	AipCompressionLevel                          int32
 	AipCompressionAlgorithm                      transferservice.ProcessingConfig_AIPCompressionAlgorithm
 }
 

--- a/internal/am/job_tracker.go
+++ b/internal/am/job_tracker.go
@@ -27,7 +27,7 @@ type JobTracker struct {
 
 	// presActionID is the PreservationAction ID that will be the parent ID for
 	// all saved preservation tasks.
-	presActionID uint
+	presActionID int
 
 	// savedIDs caches the ID of jobs that have already been saved so we don't
 	// create duplicates.
@@ -38,7 +38,7 @@ func NewJobTracker(
 	clock clockwork.Clock,
 	jobSvc amclient.JobsService,
 	pkgSvc package_.Service,
-	presActionID uint,
+	presActionID int,
 ) *JobTracker {
 	return &JobTracker{
 		clock:  clock,

--- a/internal/am/job_tracker_test.go
+++ b/internal/am/job_tracker_test.go
@@ -25,7 +25,7 @@ import (
 func TestJobTracker(t *testing.T) {
 	t.Parallel()
 
-	paID := uint(1)
+	paID := 1
 	unitID := uuid.New().String()
 
 	clock := clockwork.NewFakeClock()

--- a/internal/am/poll_ingest.go
+++ b/internal/am/poll_ingest.go
@@ -16,7 +16,7 @@ import (
 const PollIngestActivityName = "poll-ingest-activity"
 
 type PollIngestActivityParams struct {
-	PresActionID uint
+	PresActionID int
 	SIPID        string
 }
 

--- a/internal/am/poll_ingest_test.go
+++ b/internal/am/poll_ingest_test.go
@@ -26,7 +26,7 @@ func TestPollIngestActivity(t *testing.T) {
 
 	clock := clockwork.NewFakeClock()
 	path := "/var/archivematica/fake/sip"
-	presActionID := uint(2)
+	presActionID := 2
 	sipID := uuid.New().String()
 
 	httpError := func(m *amclienttest.MockIngestServiceMockRecorder, statusCode int) {

--- a/internal/am/poll_transfer.go
+++ b/internal/am/poll_transfer.go
@@ -17,7 +17,7 @@ import (
 const PollTransferActivityName = "poll-transfer-activity"
 
 type PollTransferActivityParams struct {
-	PresActionID uint
+	PresActionID int
 	TransferID   string
 }
 

--- a/internal/am/poll_transfer_test.go
+++ b/internal/am/poll_transfer_test.go
@@ -28,7 +28,7 @@ var (
 func TestPollTransferActivity(t *testing.T) {
 	t.Parallel()
 	transferID := uuid.New().String()
-	presActionID := uint(1)
+	presActionID := 1
 	sipID := uuid.New().String()
 	path := "/var/archivematica/fake/sip"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,7 @@ type Configuration struct {
 func (c *Configuration) Validate() error {
 	// TODO: should this validate all the fields in Configuration?
 	return errors.Join(
+		c.A3m.Validate(),
 		c.API.Auth.Validate(),
 		c.BagIt.Validate(),
 		c.Preprocessing.Validate(),

--- a/internal/datatypes/package_.go
+++ b/internal/datatypes/package_.go
@@ -14,7 +14,7 @@ import (
 
 // Package represents a package in the package table.
 type Package struct {
-	ID         uint                `db:"id"`
+	ID         int                 `db:"id"`
 	Name       string              `db:"name"`
 	WorkflowID string              `db:"workflow_id"`
 	RunID      string              `db:"run_id"`
@@ -34,8 +34,13 @@ type Package struct {
 
 // Goa returns the API representation of the package.
 func (p Package) Goa() *goapackage.EnduroStoredPackage {
+	var id uint
+	if p.ID > 0 {
+		id = uint(p.ID) // #nosec G115 -- range validated.
+	}
+
 	col := goapackage.EnduroStoredPackage{
-		ID:          p.ID,
+		ID:          id,
 		Name:        db.FormatOptionalString(p.Name),
 		WorkflowID:  db.FormatOptionalString(p.WorkflowID),
 		RunID:       db.FormatOptionalString(p.RunID),

--- a/internal/datatypes/preservation_action.go
+++ b/internal/datatypes/preservation_action.go
@@ -8,11 +8,11 @@ import (
 
 // PreservationAction represents a preservation action in the preservation_action table.
 type PreservationAction struct {
-	ID          uint                           `db:"id"`
+	ID          int                            `db:"id"`
 	WorkflowID  string                         `db:"workflow_id"`
 	Type        enums.PreservationActionType   `db:"type"`
 	Status      enums.PreservationActionStatus `db:"status"`
 	StartedAt   sql.NullTime                   `db:"started_at"`
 	CompletedAt sql.NullTime                   `db:"completed_at"`
-	PackageID   uint                           `db:"package_id"`
+	PackageID   int                            `db:"package_id"`
 }

--- a/internal/datatypes/preservation_task.go
+++ b/internal/datatypes/preservation_task.go
@@ -9,12 +9,12 @@ import (
 // PreservationTask represents a preservation action task in the
 // preservation_task table.
 type PreservationTask struct {
-	ID                   uint                         `db:"id"`
+	ID                   int                          `db:"id"`
 	TaskID               string                       `db:"task_id"`
 	Name                 string                       `db:"name"`
 	Status               enums.PreservationTaskStatus `db:"status"`
 	StartedAt            sql.NullTime                 `db:"started_at"`
 	CompletedAt          sql.NullTime                 `db:"completed_at"`
-	Note                 string
-	PreservationActionID uint `db:"preservation_action_id"`
+	Note                 string                       `db:"note"`
+	PreservationActionID int                          `db:"preservation_action_id"`
 }

--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -52,7 +52,7 @@ func Move(src, dst string) error {
 }
 
 // SetFileModes recursively sets the file mode of root and its contents.
-func SetFileModes(root string, dirMode, fileMode int) error {
+func SetFileModes(root string, dirMode, fileMode fs.FileMode) error {
 	return filepath.WalkDir(root,
 		func(path string, d os.DirEntry, err error) error {
 			if err != nil {

--- a/internal/package_/convert.go
+++ b/internal/package_/convert.go
@@ -10,28 +10,60 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/db"
 )
 
+func packageToGoaPackageCreatedEvent(p *datatypes.Package) *goapackage.PackageCreatedEvent {
+	var id uint
+	if p.ID > 0 {
+		id = uint(p.ID) // #nosec G115 -- range validated.
+	}
+
+	return &goapackage.PackageCreatedEvent{
+		ID:   id,
+		Item: p.Goa(),
+	}
+}
+
 // preservationActionToGoa returns the API representation of a preservation task.
-func preservationActionToGoa(pt *datatypes.PreservationAction) *goapackage.EnduroPackagePreservationAction {
+func preservationActionToGoa(pa *datatypes.PreservationAction) *goapackage.EnduroPackagePreservationAction {
 	var startedAt string
-	if pt.StartedAt.Valid {
-		startedAt = pt.StartedAt.Time.Format(time.RFC3339)
+	if pa.StartedAt.Valid {
+		startedAt = pa.StartedAt.Time.Format(time.RFC3339)
+	}
+
+	var id uint
+	if pa.ID > 0 {
+		id = uint(pa.ID) // #nosec G115 -- range validated.
+	}
+
+	var packageID uint
+	if pa.PackageID > 0 {
+		packageID = uint(pa.PackageID) // #nosec G115 -- range validated.
 	}
 
 	return &goapackage.EnduroPackagePreservationAction{
-		ID:          pt.ID,
-		WorkflowID:  pt.WorkflowID,
-		Type:        pt.Type.String(),
-		Status:      pt.Status.String(),
+		ID:          uint(id),
+		WorkflowID:  pa.WorkflowID,
+		Type:        pa.Type.String(),
+		Status:      pa.Status.String(),
 		StartedAt:   startedAt,
-		CompletedAt: db.FormatOptionalTime(pt.CompletedAt),
-		PackageID:   &pt.PackageID,
+		CompletedAt: db.FormatOptionalTime(pa.CompletedAt),
+		PackageID:   ref.New(packageID),
 	}
 }
 
 // preservationTaskToGoa returns the API representation of a preservation task.
 func preservationTaskToGoa(pt *datatypes.PreservationTask) *goapackage.EnduroPackagePreservationTask {
+	var id uint
+	if pt.ID > 0 {
+		id = uint(pt.ID) // #nosec G115 -- range validated.
+	}
+
+	var paID uint
+	if pt.PreservationActionID > 0 {
+		paID = uint(pt.PreservationActionID) // #nosec G115 -- range validated.
+	}
+
 	return &goapackage.EnduroPackagePreservationTask{
-		ID:     pt.ID,
+		ID:     id,
 		TaskID: pt.TaskID,
 		Name:   pt.Name,
 		Status: pt.Status.String(),
@@ -42,6 +74,6 @@ func preservationTaskToGoa(pt *datatypes.PreservationTask) *goapackage.EnduroPac
 
 		CompletedAt:          db.FormatOptionalTime(pt.CompletedAt),
 		Note:                 &pt.Note,
-		PreservationActionID: &pt.PreservationActionID,
+		PreservationActionID: ref.New(paID),
 	}
 }

--- a/internal/package_/fake/mock_package_.go
+++ b/internal/package_/fake/mock_package_.go
@@ -45,7 +45,7 @@ func (m *MockService) EXPECT() *MockServiceMockRecorder {
 }
 
 // CompletePreservationAction mocks base method.
-func (m *MockService) CompletePreservationAction(arg0 context.Context, arg1 uint, arg2 enums.PreservationActionStatus, arg3 time.Time) error {
+func (m *MockService) CompletePreservationAction(arg0 context.Context, arg1 int, arg2 enums.PreservationActionStatus, arg3 time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CompletePreservationAction", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -71,19 +71,19 @@ func (c *MockServiceCompletePreservationActionCall) Return(arg0 error) *MockServ
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceCompletePreservationActionCall) Do(f func(context.Context, uint, enums.PreservationActionStatus, time.Time) error) *MockServiceCompletePreservationActionCall {
+func (c *MockServiceCompletePreservationActionCall) Do(f func(context.Context, int, enums.PreservationActionStatus, time.Time) error) *MockServiceCompletePreservationActionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceCompletePreservationActionCall) DoAndReturn(f func(context.Context, uint, enums.PreservationActionStatus, time.Time) error) *MockServiceCompletePreservationActionCall {
+func (c *MockServiceCompletePreservationActionCall) DoAndReturn(f func(context.Context, int, enums.PreservationActionStatus, time.Time) error) *MockServiceCompletePreservationActionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CompletePreservationTask mocks base method.
-func (m *MockService) CompletePreservationTask(arg0 context.Context, arg1 uint, arg2 enums.PreservationTaskStatus, arg3 time.Time, arg4 *string) error {
+func (m *MockService) CompletePreservationTask(arg0 context.Context, arg1 int, arg2 enums.PreservationTaskStatus, arg3 time.Time, arg4 *string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CompletePreservationTask", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -109,13 +109,13 @@ func (c *MockServiceCompletePreservationTaskCall) Return(arg0 error) *MockServic
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceCompletePreservationTaskCall) Do(f func(context.Context, uint, enums.PreservationTaskStatus, time.Time, *string) error) *MockServiceCompletePreservationTaskCall {
+func (c *MockServiceCompletePreservationTaskCall) Do(f func(context.Context, int, enums.PreservationTaskStatus, time.Time, *string) error) *MockServiceCompletePreservationTaskCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceCompletePreservationTaskCall) DoAndReturn(f func(context.Context, uint, enums.PreservationTaskStatus, time.Time, *string) error) *MockServiceCompletePreservationTaskCall {
+func (c *MockServiceCompletePreservationTaskCall) DoAndReturn(f func(context.Context, int, enums.PreservationTaskStatus, time.Time, *string) error) *MockServiceCompletePreservationTaskCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -273,7 +273,7 @@ func (c *MockServiceGoaCall) DoAndReturn(f func() package_.Service) *MockService
 }
 
 // SetLocationID mocks base method.
-func (m *MockService) SetLocationID(arg0 context.Context, arg1 uint, arg2 uuid.UUID) error {
+func (m *MockService) SetLocationID(arg0 context.Context, arg1 int, arg2 uuid.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetLocationID", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -299,19 +299,19 @@ func (c *MockServiceSetLocationIDCall) Return(arg0 error) *MockServiceSetLocatio
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceSetLocationIDCall) Do(f func(context.Context, uint, uuid.UUID) error) *MockServiceSetLocationIDCall {
+func (c *MockServiceSetLocationIDCall) Do(f func(context.Context, int, uuid.UUID) error) *MockServiceSetLocationIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceSetLocationIDCall) DoAndReturn(f func(context.Context, uint, uuid.UUID) error) *MockServiceSetLocationIDCall {
+func (c *MockServiceSetLocationIDCall) DoAndReturn(f func(context.Context, int, uuid.UUID) error) *MockServiceSetLocationIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetPreservationActionStatus mocks base method.
-func (m *MockService) SetPreservationActionStatus(arg0 context.Context, arg1 uint, arg2 enums.PreservationActionStatus) error {
+func (m *MockService) SetPreservationActionStatus(arg0 context.Context, arg1 int, arg2 enums.PreservationActionStatus) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPreservationActionStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -337,19 +337,19 @@ func (c *MockServiceSetPreservationActionStatusCall) Return(arg0 error) *MockSer
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceSetPreservationActionStatusCall) Do(f func(context.Context, uint, enums.PreservationActionStatus) error) *MockServiceSetPreservationActionStatusCall {
+func (c *MockServiceSetPreservationActionStatusCall) Do(f func(context.Context, int, enums.PreservationActionStatus) error) *MockServiceSetPreservationActionStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceSetPreservationActionStatusCall) DoAndReturn(f func(context.Context, uint, enums.PreservationActionStatus) error) *MockServiceSetPreservationActionStatusCall {
+func (c *MockServiceSetPreservationActionStatusCall) DoAndReturn(f func(context.Context, int, enums.PreservationActionStatus) error) *MockServiceSetPreservationActionStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetStatus mocks base method.
-func (m *MockService) SetStatus(arg0 context.Context, arg1 uint, arg2 enums.PackageStatus) error {
+func (m *MockService) SetStatus(arg0 context.Context, arg1 int, arg2 enums.PackageStatus) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -375,19 +375,19 @@ func (c *MockServiceSetStatusCall) Return(arg0 error) *MockServiceSetStatusCall 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceSetStatusCall) Do(f func(context.Context, uint, enums.PackageStatus) error) *MockServiceSetStatusCall {
+func (c *MockServiceSetStatusCall) Do(f func(context.Context, int, enums.PackageStatus) error) *MockServiceSetStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceSetStatusCall) DoAndReturn(f func(context.Context, uint, enums.PackageStatus) error) *MockServiceSetStatusCall {
+func (c *MockServiceSetStatusCall) DoAndReturn(f func(context.Context, int, enums.PackageStatus) error) *MockServiceSetStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetStatusInProgress mocks base method.
-func (m *MockService) SetStatusInProgress(arg0 context.Context, arg1 uint, arg2 time.Time) error {
+func (m *MockService) SetStatusInProgress(arg0 context.Context, arg1 int, arg2 time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatusInProgress", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -413,19 +413,19 @@ func (c *MockServiceSetStatusInProgressCall) Return(arg0 error) *MockServiceSetS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceSetStatusInProgressCall) Do(f func(context.Context, uint, time.Time) error) *MockServiceSetStatusInProgressCall {
+func (c *MockServiceSetStatusInProgressCall) Do(f func(context.Context, int, time.Time) error) *MockServiceSetStatusInProgressCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceSetStatusInProgressCall) DoAndReturn(f func(context.Context, uint, time.Time) error) *MockServiceSetStatusInProgressCall {
+func (c *MockServiceSetStatusInProgressCall) DoAndReturn(f func(context.Context, int, time.Time) error) *MockServiceSetStatusInProgressCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetStatusPending mocks base method.
-func (m *MockService) SetStatusPending(arg0 context.Context, arg1 uint) error {
+func (m *MockService) SetStatusPending(arg0 context.Context, arg1 int) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatusPending", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -451,19 +451,19 @@ func (c *MockServiceSetStatusPendingCall) Return(arg0 error) *MockServiceSetStat
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceSetStatusPendingCall) Do(f func(context.Context, uint) error) *MockServiceSetStatusPendingCall {
+func (c *MockServiceSetStatusPendingCall) Do(f func(context.Context, int) error) *MockServiceSetStatusPendingCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceSetStatusPendingCall) DoAndReturn(f func(context.Context, uint) error) *MockServiceSetStatusPendingCall {
+func (c *MockServiceSetStatusPendingCall) DoAndReturn(f func(context.Context, int) error) *MockServiceSetStatusPendingCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // UpdateWorkflowStatus mocks base method.
-func (m *MockService) UpdateWorkflowStatus(arg0 context.Context, arg1 uint, arg2, arg3, arg4, arg5 string, arg6 enums.PackageStatus, arg7 time.Time) error {
+func (m *MockService) UpdateWorkflowStatus(arg0 context.Context, arg1 int, arg2, arg3, arg4, arg5 string, arg6 enums.PackageStatus, arg7 time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateWorkflowStatus", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
@@ -489,13 +489,13 @@ func (c *MockServiceUpdateWorkflowStatusCall) Return(arg0 error) *MockServiceUpd
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceUpdateWorkflowStatusCall) Do(f func(context.Context, uint, string, string, string, string, enums.PackageStatus, time.Time) error) *MockServiceUpdateWorkflowStatusCall {
+func (c *MockServiceUpdateWorkflowStatusCall) Do(f func(context.Context, int, string, string, string, string, enums.PackageStatus, time.Time) error) *MockServiceUpdateWorkflowStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceUpdateWorkflowStatusCall) DoAndReturn(f func(context.Context, uint, string, string, string, string, enums.PackageStatus, time.Time) error) *MockServiceUpdateWorkflowStatusCall {
+func (c *MockServiceUpdateWorkflowStatusCall) DoAndReturn(f func(context.Context, int, string, string, string, string, enums.PackageStatus, time.Time) error) *MockServiceUpdateWorkflowStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/package_/preservation_task_test.go
+++ b/internal/package_/preservation_task_test.go
@@ -145,7 +145,7 @@ func TestCompletePreservationTask(t *testing.T) {
 	completedAt := time.Date(2024, 4, 2, 10, 35, 32, 0, time.UTC)
 
 	type args struct {
-		id          uint
+		id          int
 		status      enums.PreservationTaskStatus
 		completedAt time.Time
 		note        *string
@@ -176,7 +176,7 @@ func TestCompletePreservationTask(t *testing.T) {
 				svc.EXPECT().
 					UpdatePreservationTask(
 						mockutil.Context(),
-						uint(1),
+						1,
 						mockutil.Func(
 							"should update preservation task",
 							func(updater persistence.PresTaskUpdater) error {
@@ -188,7 +188,7 @@ func TestCompletePreservationTask(t *testing.T) {
 					DoAndReturn(
 						func(
 							ctx context.Context,
-							id uint,
+							id int,
 							updater persistence.PresTaskUpdater,
 						) (*datatypes.PreservationTask, error) {
 							pt, err := updater(pt)
@@ -221,7 +221,7 @@ func TestCompletePreservationTask(t *testing.T) {
 				svc.EXPECT().
 					UpdatePreservationTask(
 						mockutil.Context(),
-						uint(1),
+						1,
 						mockutil.Func(
 							"should update preservation task",
 							func(updater persistence.PresTaskUpdater) error {
@@ -233,7 +233,7 @@ func TestCompletePreservationTask(t *testing.T) {
 					DoAndReturn(
 						func(
 							ctx context.Context,
-							id uint,
+							id int,
 							updater persistence.PresTaskUpdater,
 						) (*datatypes.PreservationTask, error) {
 							pt, err := updater(pt)
@@ -261,7 +261,7 @@ func TestCompletePreservationTask(t *testing.T) {
 				svc.EXPECT().
 					UpdatePreservationTask(
 						mockutil.Context(),
-						uint(2),
+						2,
 						mockutil.Func(
 							"should update preservation task",
 							func(updater persistence.PresTaskUpdater) error {

--- a/internal/package_/workflow.go
+++ b/internal/package_/workflow.go
@@ -31,7 +31,7 @@ type ProcessingWorkflowRequest struct {
 
 	// The zero value represents a new package. It can be used to indicate
 	// an existing package in retries.
-	PackageID uint
+	PackageID int
 
 	// Name of the watcher that received this blob.
 	WatcherName string
@@ -90,7 +90,7 @@ func InitProcessingWorkflow(ctx context.Context, tc temporalsdk_client.Client, r
 }
 
 type MoveWorkflowRequest struct {
-	ID         uint
+	ID         int
 	AIPID      string
 	LocationID uuid.UUID
 	TaskQueue  string

--- a/internal/persistence/ent/client/convert.go
+++ b/internal/persistence/ent/client/convert.go
@@ -31,14 +31,19 @@ func convertPkgToPackage(pkg *db.Pkg) *datatypes.Package {
 		locID = uuid.NullUUID{UUID: pkg.LocationID, Valid: true}
 	}
 
+	var status uint
+	if pkg.Status > 0 {
+		status = uint(pkg.Status) // #nosec G115 -- range validated.
+	}
+
 	return &datatypes.Package{
-		ID:          uint(pkg.ID),
+		ID:          pkg.ID,
 		Name:        pkg.Name,
 		WorkflowID:  pkg.WorkflowID,
 		RunID:       pkg.RunID.String(),
 		AIPID:       aipID,
 		LocationID:  locID,
-		Status:      enums.PackageStatus(pkg.Status),
+		Status:      enums.PackageStatus(status),
 		CreatedAt:   pkg.CreatedAt,
 		StartedAt:   started,
 		CompletedAt: completed,
@@ -59,13 +64,13 @@ func convertPreservationAction(pa *db.PreservationAction) *datatypes.Preservatio
 	}
 
 	return &datatypes.PreservationAction{
-		ID:          uint(pa.ID),
+		ID:          pa.ID,
 		WorkflowID:  pa.WorkflowID,
-		Type:        enums.PreservationActionType(pa.Type),
-		Status:      enums.PreservationActionStatus(pa.Status),
+		Type:        enums.PreservationActionType(pa.Type),     // #nosec G115 -- constrained value.
+		Status:      enums.PreservationActionStatus(pa.Status), // #nosec G115 -- constrained value.
 		StartedAt:   started,
 		CompletedAt: completed,
-		PackageID:   uint(pa.PackageID),
+		PackageID:   pa.PackageID,
 	}
 }
 
@@ -82,14 +87,19 @@ func convertPreservationTask(pt *db.PreservationTask) *datatypes.PreservationTas
 		completed = sql.NullTime{Time: pt.CompletedAt, Valid: true}
 	}
 
+	var status uint
+	if pt.Status > 0 {
+		status = uint(pt.Status) // #nosec G115 -- range validated.
+	}
+
 	return &datatypes.PreservationTask{
-		ID:                   uint(pt.ID),
+		ID:                   pt.ID,
 		TaskID:               pt.TaskID.String(),
 		Name:                 pt.Name,
-		Status:               enums.PreservationTaskStatus(pt.Status),
+		Status:               enums.PreservationTaskStatus(status),
 		StartedAt:            started,
 		CompletedAt:          completed,
 		Note:                 pt.Note,
-		PreservationActionID: uint(pt.PreservationActionID),
+		PreservationActionID: pt.PreservationActionID,
 	}
 }

--- a/internal/persistence/ent/client/package.go
+++ b/internal/persistence/ent/client/package.go
@@ -37,7 +37,7 @@ func (c *client) CreatePackage(ctx context.Context, pkg *datatypes.Package) erro
 		SetName(pkg.Name).
 		SetWorkflowID(pkg.WorkflowID).
 		SetRunID(runID).
-		SetStatus(int8(pkg.Status))
+		SetStatus(int8(pkg.Status)) // #nosec G115 -- constrained value.
 
 	// Add optional fields.
 	if pkg.AIPID.Valid {
@@ -75,7 +75,7 @@ func (c *client) CreatePackage(ctx context.Context, pkg *datatypes.Package) erro
 // method.
 func (c *client) UpdatePackage(
 	ctx context.Context,
-	id uint,
+	id int,
 	updater persistence.PackageUpdater,
 ) (*datatypes.Package, error) {
 	tx, err := c.ent.BeginTx(ctx, nil)
@@ -83,7 +83,7 @@ func (c *client) UpdatePackage(
 		return nil, newDBError(err)
 	}
 
-	p, err := tx.Pkg.Get(ctx, int(id))
+	p, err := tx.Pkg.Get(ctx, id)
 	if err != nil {
 		return nil, rollback(tx, newDBError(err))
 	}
@@ -99,11 +99,11 @@ func (c *client) UpdatePackage(
 	}
 
 	// Set required column values.
-	q := tx.Pkg.UpdateOneID(int(id)).
+	q := tx.Pkg.UpdateOneID(id).
 		SetName(up.Name).
 		SetWorkflowID(up.WorkflowID).
 		SetRunID(runID).
-		SetStatus(int8(up.Status))
+		SetStatus(int8(up.Status)) // #nosec G115 -- constrained value.
 
 	// Set nullable column values.
 	if up.AIPID.Valid {

--- a/internal/persistence/ent/client/package_test.go
+++ b/internal/persistence/ent/client/package_test.go
@@ -306,7 +306,7 @@ func TestUpdatePackage(t *testing.T) {
 			_, svc := setUpClient(t, logr.Discard())
 			ctx := context.Background()
 
-			var id uint
+			var id int
 			if tt.args.pkg != nil {
 				pkg := *tt.args.pkg // Make a local copy of pkg.
 				err := svc.CreatePackage(ctx, &pkg)

--- a/internal/persistence/ent/client/preservation_action.go
+++ b/internal/persistence/ent/client/preservation_action.go
@@ -31,11 +31,11 @@ func (c *client) CreatePreservationAction(ctx context.Context, pa *datatypes.Pre
 
 	q := c.ent.PreservationAction.Create().
 		SetWorkflowID(pa.WorkflowID).
-		SetType(int8(pa.Type)).
-		SetStatus(int8(pa.Status)).
+		SetType(int8(pa.Type)).     // #nosec G115 -- constrained value.
+		SetStatus(int8(pa.Status)). // #nosec G115 -- constrained value.
 		SetNillableStartedAt(startedAt).
 		SetNillableCompletedAt(completedAt).
-		SetPackageID(int(pa.PackageID))
+		SetPackageID(pa.PackageID)
 
 	r, err := q.Save(ctx)
 	if err != nil {

--- a/internal/persistence/ent/client/preservation_action_test.go
+++ b/internal/persistence/ent/client/preservation_action_test.go
@@ -100,7 +100,7 @@ func TestCreatePreservationAction(t *testing.T) {
 
 			pa := *tt.args.pa // Make a local copy.
 			if tt.args.setPackageID {
-				pa.PackageID = uint(pkg.ID)
+				pa.PackageID = pkg.ID
 			}
 
 			err := svc.CreatePreservationAction(ctx, &pa)

--- a/internal/persistence/ent/client/preservation_task.go
+++ b/internal/persistence/ent/client/preservation_task.go
@@ -38,7 +38,7 @@ func (c *client) CreatePreservationTask(ctx context.Context, pt *datatypes.Prese
 	q := c.ent.PreservationTask.Create().
 		SetTaskID(taskID).
 		SetName(pt.Name).
-		SetStatus(int8(pt.Status)).
+		SetStatus(int8(pt.Status)). // #nosec G115 -- constrained value.
 		SetNillableStartedAt(startedAt).
 		SetNillableCompletedAt(completedAt).
 		SetNote(pt.Note).
@@ -57,7 +57,7 @@ func (c *client) CreatePreservationTask(ctx context.Context, pt *datatypes.Prese
 
 func (c *client) UpdatePreservationTask(
 	ctx context.Context,
-	id uint,
+	id int,
 	updater persistence.PresTaskUpdater,
 ) (*datatypes.PreservationTask, error) {
 	tx, err := c.ent.BeginTx(ctx, nil)
@@ -65,7 +65,7 @@ func (c *client) UpdatePreservationTask(
 		return nil, newDBErrorWithDetails(err, "update preservation task")
 	}
 
-	pt, err := tx.PreservationTask.Get(ctx, int(id))
+	pt, err := tx.PreservationTask.Get(ctx, id)
 	if err != nil {
 		return nil, rollback(tx, newDBError(err))
 	}
@@ -81,10 +81,10 @@ func (c *client) UpdatePreservationTask(
 		return nil, rollback(tx, newParseError(err, "TaskID"))
 	}
 
-	q := tx.PreservationTask.UpdateOneID(int(id)).
+	q := tx.PreservationTask.UpdateOneID(id).
 		SetTaskID(taskID).
 		SetName(up.Name).
-		SetStatus(int8(up.Status)).
+		SetStatus(int8(up.Status)). // #nosec G115 -- constrained value.
 		SetNote(up.Note).
 		SetPreservationActionID(int(up.PreservationActionID))
 

--- a/internal/persistence/ent/client/preservation_task_test.go
+++ b/internal/persistence/ent/client/preservation_task_test.go
@@ -132,7 +132,7 @@ func TestCreatePreservationTask(t *testing.T) {
 			pt := *tt.args.pt // Make a local copy of pt.
 
 			if !tt.args.zeroPreservationActionID {
-				pt.PreservationActionID = uint(pa.ID)
+				pt.PreservationActionID = pa.ID
 			}
 
 			err := svc.CreatePreservationTask(ctx, &pt)
@@ -149,7 +149,7 @@ func TestCreatePreservationTask(t *testing.T) {
 			assert.Equal(t, pt.StartedAt, tt.want.StartedAt)
 			assert.Equal(t, pt.CompletedAt, tt.want.CompletedAt)
 			assert.Equal(t, pt.Note, tt.want.Note)
-			assert.Equal(t, pt.PreservationActionID, uint(pa.ID))
+			assert.Equal(t, pt.PreservationActionID, pa.ID)
 		})
 	}
 }
@@ -286,10 +286,10 @@ func TestUpdatePreservationTask(t *testing.T) {
 			pa, pa2 := addDBFixtures(t, entc)
 
 			updater := tt.args.updater
-			var id uint
+			var id int
 			if tt.args.pt != nil {
 				pt := *tt.args.pt // Make a local copy of pt.
-				pt.PreservationActionID = uint(pa.ID)
+				pt.PreservationActionID = pa.ID
 
 				// Create preservation task to be updated.
 				err := svc.CreatePreservationTask(ctx, &pt)
@@ -304,7 +304,7 @@ func TestUpdatePreservationTask(t *testing.T) {
 					if err != nil {
 						return nil, err
 					}
-					pt.PreservationActionID = uint(pa2.ID)
+					pt.PreservationActionID = pa2.ID
 
 					return pt, nil
 				}
@@ -317,7 +317,7 @@ func TestUpdatePreservationTask(t *testing.T) {
 			}
 
 			tt.want.ID = id
-			tt.want.PreservationActionID = uint(pa2.ID)
+			tt.want.PreservationActionID = pa2.ID
 			assert.DeepEqual(t, pt, tt.want)
 		})
 	}

--- a/internal/persistence/fake/mock_persistence.go
+++ b/internal/persistence/fake/mock_persistence.go
@@ -156,7 +156,7 @@ func (c *MockServiceCreatePreservationTaskCall) DoAndReturn(f func(context.Conte
 }
 
 // UpdatePackage mocks base method.
-func (m *MockService) UpdatePackage(arg0 context.Context, arg1 uint, arg2 persistence.PackageUpdater) (*datatypes.Package, error) {
+func (m *MockService) UpdatePackage(arg0 context.Context, arg1 int, arg2 persistence.PackageUpdater) (*datatypes.Package, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePackage", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*datatypes.Package)
@@ -183,19 +183,19 @@ func (c *MockServiceUpdatePackageCall) Return(arg0 *datatypes.Package, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceUpdatePackageCall) Do(f func(context.Context, uint, persistence.PackageUpdater) (*datatypes.Package, error)) *MockServiceUpdatePackageCall {
+func (c *MockServiceUpdatePackageCall) Do(f func(context.Context, int, persistence.PackageUpdater) (*datatypes.Package, error)) *MockServiceUpdatePackageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceUpdatePackageCall) DoAndReturn(f func(context.Context, uint, persistence.PackageUpdater) (*datatypes.Package, error)) *MockServiceUpdatePackageCall {
+func (c *MockServiceUpdatePackageCall) DoAndReturn(f func(context.Context, int, persistence.PackageUpdater) (*datatypes.Package, error)) *MockServiceUpdatePackageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // UpdatePreservationTask mocks base method.
-func (m *MockService) UpdatePreservationTask(arg0 context.Context, arg1 uint, arg2 persistence.PresTaskUpdater) (*datatypes.PreservationTask, error) {
+func (m *MockService) UpdatePreservationTask(arg0 context.Context, arg1 int, arg2 persistence.PresTaskUpdater) (*datatypes.PreservationTask, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePreservationTask", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*datatypes.PreservationTask)
@@ -222,13 +222,13 @@ func (c *MockServiceUpdatePreservationTaskCall) Return(arg0 *datatypes.Preservat
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceUpdatePreservationTaskCall) Do(f func(context.Context, uint, persistence.PresTaskUpdater) (*datatypes.PreservationTask, error)) *MockServiceUpdatePreservationTaskCall {
+func (c *MockServiceUpdatePreservationTaskCall) Do(f func(context.Context, int, persistence.PresTaskUpdater) (*datatypes.PreservationTask, error)) *MockServiceUpdatePreservationTaskCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceUpdatePreservationTaskCall) DoAndReturn(f func(context.Context, uint, persistence.PresTaskUpdater) (*datatypes.PreservationTask, error)) *MockServiceUpdatePreservationTaskCall {
+func (c *MockServiceUpdatePreservationTaskCall) DoAndReturn(f func(context.Context, int, persistence.PresTaskUpdater) (*datatypes.PreservationTask, error)) *MockServiceUpdatePreservationTaskCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -28,10 +28,10 @@ type Service interface {
 	// the Package from the data store, adding auto-generated data
 	// (e.g. ID, CreatedAt).
 	CreatePackage(context.Context, *datatypes.Package) error
-	UpdatePackage(context.Context, uint, PackageUpdater) (*datatypes.Package, error)
+	UpdatePackage(context.Context, int, PackageUpdater) (*datatypes.Package, error)
 
 	CreatePreservationAction(context.Context, *datatypes.PreservationAction) error
 
 	CreatePreservationTask(context.Context, *datatypes.PreservationTask) error
-	UpdatePreservationTask(ctx context.Context, id uint, updater PresTaskUpdater) (*datatypes.PreservationTask, error)
+	UpdatePreservationTask(ctx context.Context, id int, updater PresTaskUpdater) (*datatypes.PreservationTask, error)
 }

--- a/internal/persistence/telemetry.go
+++ b/internal/persistence/telemetry.go
@@ -44,10 +44,10 @@ func (w *wrapper) CreatePackage(ctx context.Context, p *datatypes.Package) error
 	return nil
 }
 
-func (w *wrapper) UpdatePackage(ctx context.Context, id uint, updater PackageUpdater) (*datatypes.Package, error) {
+func (w *wrapper) UpdatePackage(ctx context.Context, id int, updater PackageUpdater) (*datatypes.Package, error) {
 	ctx, span := w.tracer.Start(ctx, "UpdatePackage")
 	defer span.End()
-	span.SetAttributes(attribute.Int("id", int(id)))
+	span.SetAttributes(attribute.Int("id", id))
 
 	r, err := w.wrapped.UpdatePackage(ctx, id, updater)
 	if err != nil {
@@ -86,12 +86,12 @@ func (w *wrapper) CreatePreservationTask(ctx context.Context, pt *datatypes.Pres
 
 func (w *wrapper) UpdatePreservationTask(
 	ctx context.Context,
-	id uint,
+	id int,
 	updater PresTaskUpdater,
 ) (*datatypes.PreservationTask, error) {
 	ctx, span := w.tracer.Start(ctx, "UpdatePreservationTask")
 	defer span.End()
-	span.SetAttributes(attribute.Int("id", int(id)))
+	span.SetAttributes(attribute.Int("id", id))
 
 	r, err := w.wrapped.UpdatePreservationTask(ctx, id, updater)
 	if err != nil {

--- a/internal/workflow/local_activities.go
+++ b/internal/workflow/local_activities.go
@@ -24,7 +24,7 @@ func createPackageLocalActivity(
 	ctx context.Context,
 	pkgsvc package_.Service,
 	params *createPackageLocalActivityParams,
-) (uint, error) {
+) (int, error) {
 	info := temporalsdk_activity.GetInfo(ctx)
 
 	col := &datatypes.Package{
@@ -42,7 +42,7 @@ func createPackageLocalActivity(
 }
 
 type updatePackageLocalActivityParams struct {
-	PackageID uint
+	PackageID int
 	Key       string
 	SIPID     string
 	StoredAt  time.Time
@@ -80,7 +80,7 @@ type setStatusInProgressLocalActivityResult struct{}
 func setStatusInProgressLocalActivity(
 	ctx context.Context,
 	pkgsvc package_.Service,
-	pkgID uint,
+	pkgID int,
 	startedAt time.Time,
 ) (*setStatusInProgressLocalActivityResult, error) {
 	return &setStatusInProgressLocalActivityResult{}, pkgsvc.SetStatusInProgress(ctx, pkgID, startedAt)
@@ -91,7 +91,7 @@ type setStatusLocalActivityResult struct{}
 func setStatusLocalActivity(
 	ctx context.Context,
 	pkgsvc package_.Service,
-	pkgID uint,
+	pkgID int,
 	status enums.PackageStatus,
 ) (*setStatusLocalActivityResult, error) {
 	return &setStatusLocalActivityResult{}, pkgsvc.SetStatus(ctx, pkgID, status)
@@ -102,14 +102,14 @@ type setLocationIDLocalActivityResult struct{}
 func setLocationIDLocalActivity(
 	ctx context.Context,
 	pkgsvc package_.Service,
-	pkgID uint,
+	pkgID int,
 	locationID uuid.UUID,
 ) (*setLocationIDLocalActivityResult, error) {
 	return &setLocationIDLocalActivityResult{}, pkgsvc.SetLocationID(ctx, pkgID, locationID)
 }
 
 type saveLocationMovePreservationActionLocalActivityParams struct {
-	PackageID   uint
+	PackageID   int
 	LocationID  uuid.UUID
 	WorkflowID  string
 	Type        enums.PreservationActionType
@@ -163,14 +163,14 @@ type createPreservationActionLocalActivityParams struct {
 	Status      enums.PreservationActionStatus
 	StartedAt   time.Time
 	CompletedAt time.Time
-	PackageID   uint
+	PackageID   int
 }
 
 func createPreservationActionLocalActivity(
 	ctx context.Context,
 	pkgsvc package_.Service,
 	params *createPreservationActionLocalActivityParams,
-) (uint, error) {
+) (int, error) {
 	pa := datatypes.PreservationAction{
 		WorkflowID: params.WorkflowID,
 		Type:       params.Type,
@@ -196,14 +196,14 @@ type setPreservationActionStatusLocalActivityResult struct{}
 func setPreservationActionStatusLocalActivity(
 	ctx context.Context,
 	pkgsvc package_.Service,
-	ID uint,
+	ID int,
 	status enums.PreservationActionStatus,
 ) (*setPreservationActionStatusLocalActivityResult, error) {
 	return &setPreservationActionStatusLocalActivityResult{}, pkgsvc.SetPreservationActionStatus(ctx, ID, status)
 }
 
 type completePreservationActionLocalActivityParams struct {
-	PreservationActionID uint
+	PreservationActionID int
 	Status               enums.PreservationActionStatus
 	CompletedAt          time.Time
 }
@@ -232,7 +232,7 @@ type createPreservationTaskLocalActivityParams struct {
 func createPreservationTaskLocalActivity(
 	ctx context.Context,
 	params *createPreservationTaskLocalActivityParams,
-) (uint, error) {
+) (int, error) {
 	pt := params.PreservationTask
 	if pt.TaskID == "" {
 		id, err := uuid.NewRandomFromReader(params.RNG)
@@ -250,7 +250,7 @@ func createPreservationTaskLocalActivity(
 }
 
 type completePreservationTaskLocalActivityParams struct {
-	ID          uint
+	ID          int
 	Status      enums.PreservationTaskStatus
 	CompletedAt time.Time
 	Note        *string

--- a/internal/workflow/localact/save_preprocessing_tasks.go
+++ b/internal/workflow/localact/save_preprocessing_tasks.go
@@ -23,7 +23,7 @@ type SavePreprocessingTasksActivityParams struct {
 	RNG io.Reader
 
 	// PreservationActionID is the primary key of the parent PreservationAction.
-	PreservationActionID uint
+	PreservationActionID int
 
 	// Tasks is a list of preprocessing tasks to save as PreservationTasks.
 	Tasks []preprocessing.Task

--- a/internal/workflow/move_test.go
+++ b/internal/workflow/move_test.go
@@ -57,7 +57,7 @@ func TestMoveWorkflow(t *testing.T) {
 }
 
 func (s *MoveWorkflowTestSuite) TestSuccessfulMove() {
-	pkgID := uint(1)
+	pkgID := 1
 	AIPID := uuid.NewString()
 	locationID := uuid.MustParse("51328c02-2b63-47be-958e-e8088aa1a61f")
 
@@ -114,7 +114,7 @@ func (s *MoveWorkflowTestSuite) TestSuccessfulMove() {
 }
 
 func (s *MoveWorkflowTestSuite) TestFailedMove() {
-	pkgID := uint(1)
+	pkgID := 1
 	AIPID := uuid.NewString()
 	locationID := uuid.MustParse("51328c02-2b63-47be-958e-e8088aa1a61f")
 

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -103,7 +103,7 @@ type TransferInfo struct {
 	// Identifier of the preservation action that creates the AIP
 	//
 	// It is populated by createPreservationActionLocalActivity .
-	PreservationActionID uint
+	PreservationActionID int
 
 	// Identifier of the preservation system task queue name
 	//
@@ -528,7 +528,7 @@ func (w *ProcessingWorkflow) SessionHandler(
 	}
 
 	// Identifier of the preservation task for upload to sips bucket.
-	var uploadPreservationTaskID uint
+	var uploadPreservationTaskID int
 
 	// Add preservation task for upload to review bucket.
 	if !tinfo.req.AutoApproveAIP {
@@ -586,7 +586,7 @@ func (w *ProcessingWorkflow) SessionHandler(
 	var reviewResult *package_.ReviewPerformedSignal
 
 	// Identifier of the preservation task for package review
-	var reviewPreservationTaskID uint
+	var reviewPreservationTaskID int
 
 	if tinfo.req.AutoApproveAIP {
 		reviewResult = &package_.ReviewPerformedSignal{
@@ -670,7 +670,7 @@ func (w *ProcessingWorkflow) SessionHandler(
 		}
 
 		// Identifier of the preservation task for permanent storage move.
-		var movePreservationTaskID uint
+		var movePreservationTaskID int
 
 		// Add preservation task for permanent storage move.
 		{
@@ -1068,8 +1068,8 @@ func (w *ProcessingWorkflow) preprocessing(ctx temporalsdk_workflow.Context, tin
 func (w *ProcessingWorkflow) createPreservationTask(
 	ctx temporalsdk_workflow.Context,
 	pt datatypes.PreservationTask,
-) (uint, error) {
-	var id uint
+) (int, error) {
+	var id int
 	ctx = withLocalActivityOpts(ctx)
 	err := temporalsdk_workflow.ExecuteLocalActivity(
 		ctx,

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -250,7 +250,7 @@ func (s *ProcessingWorkflowTestSuite) TestPackageConfirmation() {
 	}
 	s.SetupWorkflowTest(cfg)
 
-	pkgID := uint(1)
+	pkgID := 1
 	ctx := mock.AnythingOfType("*context.valueCtx")
 	sessionCtx := mock.AnythingOfType("*context.timerCtx")
 	key := "transfer.zip"
@@ -285,7 +285,7 @@ func (s *ProcessingWorkflowTestSuite) TestPackageConfirmation() {
 			StartedAt:  startTime,
 			PackageID:  1,
 		},
-	).Return(uint(0), nil)
+	).Return(0, nil)
 
 	s.env.OnActivity(activities.DownloadActivityName, sessionCtx,
 		&activities.DownloadActivityParams{Key: key, WatcherName: watcherName},
@@ -314,7 +314,7 @@ func (s *ProcessingWorkflowTestSuite) TestPackageConfirmation() {
 	s.env.OnActivity(updatePackageLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	s.env.OnActivity(createPreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).
-		Return(uint(0), nil)
+		Return(0, nil)
 	s.env.OnActivity(activities.UploadActivityName, mock.Anything, mock.Anything).Return(nil, nil)
 	s.env.OnActivity(setStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
@@ -364,7 +364,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 	}
 	s.SetupWorkflowTest(cfg)
 
-	pkgID := uint(1)
+	pkgID := 1
 	watcherName := "watcher"
 	key := "transfer.zip"
 	retentionPeriod := 1 * time.Second
@@ -399,7 +399,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 			StartedAt:  startTime,
 			PackageID:  1,
 		},
-	).Return(uint(0), nil)
+	).Return(0, nil)
 
 	s.env.OnActivity(activities.DownloadActivityName, sessionCtx,
 		&activities.DownloadActivityParams{Key: key, WatcherName: watcherName},
@@ -434,10 +434,10 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 					Time:  startTime,
 					Valid: true,
 				},
-				PreservationActionID: uint(0),
+				PreservationActionID: 0,
 			},
 		},
-	).Return(uint(101), nil)
+	).Return(101, nil)
 
 	s.env.OnActivity(
 		bagvalidate.Name,
@@ -453,7 +453,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 		ctx,
 		pkgsvc,
 		&completePreservationTaskLocalActivityParams{
-			ID:          uint(101),
+			ID:          101,
 			Status:      enums.PreservationTaskStatusDone,
 			CompletedAt: startTime,
 			Note:        ref.New("Bag is valid"),
@@ -489,10 +489,10 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 				Status:               enums.PreservationTaskStatusInProgress,
 				StartedAt:            sql.NullTime{Time: startTime, Valid: true},
 				Note:                 "Moving to permanent storage",
-				PreservationActionID: uint(0),
+				PreservationActionID: 0,
 			},
 		},
-	).Return(uint(102), nil)
+	).Return(102, nil)
 
 	s.env.OnActivity(activities.UploadActivityName, sessionCtx, mock.AnythingOfType("*activities.UploadActivityParams")).
 		Return(nil, nil).
@@ -509,7 +509,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 		ctx,
 		pkgsvc,
 		&completePreservationTaskLocalActivityParams{
-			ID:          uint(102),
+			ID:          102,
 			Status:      enums.PreservationTaskStatusDone,
 			CompletedAt: startTime,
 			Note:        ref.New("Moved to location f2cc963f-c14d-4eaa-b950-bd207189a1f1"),
@@ -549,7 +549,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 }
 
 func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
-	pkgID := uint(1)
+	pkgID := 1
 	watcherName := "watcher"
 	key := "transfer.zip"
 	retentionPeriod := 1 * time.Second
@@ -576,7 +576,7 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 
 	s.env.OnActivity(createPreservationActionLocalActivity, ctx,
 		pkgsvc, mock.AnythingOfType("*workflow.createPreservationActionLocalActivityParams"),
-	).Return(uint(0), nil)
+	).Return(0, nil)
 
 	s.env.OnActivity(activities.DownloadActivityName, sessionCtx,
 		&activities.DownloadActivityParams{Key: key, WatcherName: watcherName},
@@ -709,7 +709,7 @@ func (s *ProcessingWorkflowTestSuite) TestPackageRejection() {
 	}
 	s.SetupWorkflowTest(cfg)
 
-	pkgID := uint(1)
+	pkgID := 1
 	key := "transfer.zip"
 	watcherName := "watcher"
 	retentionPeriod := 1 * time.Second
@@ -732,7 +732,7 @@ func (s *ProcessingWorkflowTestSuite) TestPackageRejection() {
 	s.env.OnActivity(setStatusInProgressLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	s.env.OnActivity(createPreservationActionLocalActivity, mock.Anything, mock.Anything, mock.Anything).
-		Return(uint(0), nil)
+		Return(0, nil)
 
 	s.env.OnActivity(activities.DownloadActivityName, sessionCtx,
 		&activities.DownloadActivityParams{Key: key, WatcherName: watcherName},
@@ -776,7 +776,7 @@ func (s *ProcessingWorkflowTestSuite) TestPackageRejection() {
 	s.env.OnActivity(setPreservationActionStatusLocalActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	s.env.OnActivity(createPreservationTaskLocalActivity, mock.Anything, mock.Anything, mock.Anything).
-		Return(uint(0), nil)
+		Return(0, nil)
 	s.env.OnActivity(activities.RejectPackageActivityName, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 	s.env.OnActivity(
@@ -824,7 +824,7 @@ func (s *ProcessingWorkflowTestSuite) TestPreprocessingChildWorkflow() {
 	}
 	s.SetupWorkflowTest(cfg)
 
-	pkgID := uint(1)
+	pkgID := 1
 	watcherName := "watcher"
 	key := "transfer.zip"
 	retentionPeriod := 1 * time.Second
@@ -862,7 +862,7 @@ func (s *ProcessingWorkflowTestSuite) TestPreprocessingChildWorkflow() {
 			StartedAt:  startTime,
 			PackageID:  1,
 		},
-	).Return(uint(1), nil)
+	).Return(1, nil)
 
 	s.env.OnActivity(activities.DownloadActivityName, sessionCtx,
 		&activities.DownloadActivityParams{
@@ -940,10 +940,10 @@ func (s *ProcessingWorkflowTestSuite) TestPreprocessingChildWorkflow() {
 					Time:  startTime,
 					Valid: true,
 				},
-				PreservationActionID: uint(1),
+				PreservationActionID: 1,
 			},
 		},
-	).Return(uint(101), nil)
+	).Return(101, nil)
 
 	s.env.OnActivity(
 		bagvalidate.Name,
@@ -959,7 +959,7 @@ func (s *ProcessingWorkflowTestSuite) TestPreprocessingChildWorkflow() {
 		ctx,
 		pkgsvc,
 		&completePreservationTaskLocalActivityParams{
-			ID:          uint(101),
+			ID:          101,
 			Status:      enums.PreservationTaskStatusDone,
 			CompletedAt: startTime,
 			Note:        ref.New("Bag is valid"),
@@ -994,11 +994,11 @@ func (s *ProcessingWorkflowTestSuite) TestPreprocessingChildWorkflow() {
 				Name:                 "Move AIP",
 				Status:               enums.PreservationTaskStatusInProgress,
 				StartedAt:            sql.NullTime{Time: startTime, Valid: true},
-				PreservationActionID: uint(1),
+				PreservationActionID: 1,
 				Note:                 "Moving to permanent storage",
 			},
 		},
-	).Return(uint(102), nil)
+	).Return(102, nil)
 
 	s.env.OnActivity(
 		activities.UploadActivityName,
@@ -1011,7 +1011,7 @@ func (s *ProcessingWorkflowTestSuite) TestPreprocessingChildWorkflow() {
 		ctx,
 		pkgsvc,
 		&completePreservationTaskLocalActivityParams{
-			ID:          uint(102),
+			ID:          102,
 			Status:      enums.PreservationTaskStatusDone,
 			CompletedAt: startTime,
 			Note:        ref.New("Moved to location f2cc963f-c14d-4eaa-b950-bd207189a1f1"),


### PR DESCRIPTION
- Fix gosec integer overflow conversion warnings (G115/CWE-190)
- Use the `int` type for primary keys in `datatype` structs to avoid having to convert values returned from the database layer
- Check that user supplied `int` values are positive before converting them to `uint` values
- Validate that the `a3m.Config.AipCompressionLevel` value is between zero and nine [0-9]