### PR TITLE
Remove npm `vue-template-compiler` dependency

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -906,9 +906,9 @@
       "dev": true
     },
     "node_modules/@iconify/utils": {
-      "version": "2.1.32",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.1.32.tgz",
-      "integrity": "sha512-LeifFZPPKu28O3AEDpYJNdEbvS4/ojAPyIW+pF/vUpJTYnbTiXUHkCh0bwgFRzKvdpb8H4Fbfd/742++MF4fPQ==",
+      "version": "2.1.33",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.1.33.tgz",
+      "integrity": "sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4824,9 +4824,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.4.tgz",
-      "integrity": "sha512-RHFCkULitycHVTtelJ6jQLd+KSAAzOgEYorV32R2q++M6COBjKJR6BxqClwp5sf0XaBDjVMuJ9wnNfyAJwjMkA==",
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
+      "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5018,18 +5018,6 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
-      }
-    },
-    "node_modules/vue-template-compiler": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
       }
     },
     "node_modules/vue-tsc": {
@@ -5817,9 +5805,9 @@
       "dev": true
     },
     "@iconify/utils": {
-      "version": "2.1.32",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.1.32.tgz",
-      "integrity": "sha512-LeifFZPPKu28O3AEDpYJNdEbvS4/ojAPyIW+pF/vUpJTYnbTiXUHkCh0bwgFRzKvdpb8H4Fbfd/742++MF4fPQ==",
+      "version": "2.1.33",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.1.33.tgz",
+      "integrity": "sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==",
       "dev": true,
       "requires": {
         "@antfu/install-pkg": "^0.4.0",
@@ -8450,9 +8438,9 @@
       }
     },
     "vite": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.4.tgz",
-      "integrity": "sha512-RHFCkULitycHVTtelJ6jQLd+KSAAzOgEYorV32R2q++M6COBjKJR6BxqClwp5sf0XaBDjVMuJ9wnNfyAJwjMkA==",
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
+      "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
       "dev": true,
       "requires": {
         "esbuild": "^0.21.3",
@@ -8531,18 +8519,6 @@
       "integrity": "sha512-3MlnDqwRwZwCQVbtVfpsU+nrNymNjnXSsQtXName5925NVC1+326VVfYH9vSrA0N13teGEo8z5x7gbRnGjCDiQ==",
       "requires": {
         "@vue/devtools-api": "^6.6.4"
-      }
-    },
-    "vue-template-compiler": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
       }
     },
     "vue-tsc": {


### PR DESCRIPTION
Fixes https://www.herodevs.com/vulnerability-directory/cve-2024-6783

Steps taken:
- `npm uninstall unplugin-icons`
- `npm audit fix`
- `npm install unplugin-icons --save-dev`

It looks like the `npm audit fix` did some patch version package updates too.