### PR TITLE
Add total result count to package list API

### DIFF
--- a/internal/api/design/package_.go
+++ b/internal/api/design/package_.go
@@ -78,10 +78,12 @@ var _ = Service("package", func() {
 			Attribute("status", String, func() {
 				EnumPackageStatus()
 			})
-			Attribute("cursor", String, "Pagination cursor")
+			Attribute("limit", Int, "Limit number of results to return")
+			Attribute("offset", Int, "Offset from the beginning of the found set")
+
 			Token("token", String)
 		})
-		Result(PaginatedCollectionOf(StoredPackage))
+		Result(PackageList)
 		HTTP(func() {
 			GET("/")
 			Response(StatusOK)
@@ -92,7 +94,8 @@ var _ = Service("package", func() {
 				Param("latest_created_time")
 				Param("location_id")
 				Param("status")
-				Param("cursor")
+				Param("limit")
+				Param("offset")
 			})
 		})
 	})
@@ -317,6 +320,12 @@ var StoredPackage = ResultType("application/vnd.enduro.stored-package", func() {
 		Attribute("completed_at")
 	})
 	Required("id", "status", "created_at")
+})
+
+var PackageList = ResultType("application/vnd.enduro.packages", func() {
+	Attribute("items", CollectionOf(StoredPackage))
+	Attribute("page", Page)
+	Required("items", "page")
 })
 
 var PackageNotFound = Type("PackageNotFound", func() {

--- a/internal/api/design/pagination.go
+++ b/internal/api/design/pagination.go
@@ -1,6 +1,8 @@
 package design
 
-import "goa.design/goa/v3/dsl"
+import (
+	"goa.design/goa/v3/dsl"
+)
 
 func PaginatedCollectionOf(v interface{}, adsl ...func()) interface{} {
 	return func() {
@@ -9,3 +11,11 @@ func PaginatedCollectionOf(v interface{}, adsl ...func()) interface{} {
 		dsl.Required("items")
 	}
 }
+
+var Page = dsl.ResultType("application/vnd.enduro.page", func() {
+	dsl.Description("Page represents a subset of search results.")
+	dsl.Attribute("limit", dsl.Int, "Maximum items per page")
+	dsl.Attribute("offset", dsl.Int, "Offset from first result to start of page")
+	dsl.Attribute("total", dsl.Int, "Total result count before paging")
+	dsl.Required("limit", "offset", "total")
+})

--- a/internal/api/gen/http/cli/enduro/cli.go
+++ b/internal/api/gen/http/cli/enduro/cli.go
@@ -69,7 +69,8 @@ func ParseEndpoint(
 		package_ListLatestCreatedTimeFlag   = package_ListFlags.String("latest-created-time", "", "")
 		package_ListLocationIDFlag          = package_ListFlags.String("location-id", "", "")
 		package_ListStatusFlag              = package_ListFlags.String("status", "", "")
-		package_ListCursorFlag              = package_ListFlags.String("cursor", "", "")
+		package_ListLimitFlag               = package_ListFlags.String("limit", "", "")
+		package_ListOffsetFlag              = package_ListFlags.String("offset", "", "")
 		package_ListTokenFlag               = package_ListFlags.String("token", "", "")
 
 		package_ShowFlags     = flag.NewFlagSet("show", flag.ExitOnError)
@@ -319,7 +320,7 @@ func ParseEndpoint(
 				data, err = package_c.BuildMonitorPayload(*package_MonitorTicketFlag)
 			case "list":
 				endpoint = c.List()
-				data, err = package_c.BuildListPayload(*package_ListNameFlag, *package_ListAipIDFlag, *package_ListEarliestCreatedTimeFlag, *package_ListLatestCreatedTimeFlag, *package_ListLocationIDFlag, *package_ListStatusFlag, *package_ListCursorFlag, *package_ListTokenFlag)
+				data, err = package_c.BuildListPayload(*package_ListNameFlag, *package_ListAipIDFlag, *package_ListEarliestCreatedTimeFlag, *package_ListLatestCreatedTimeFlag, *package_ListLocationIDFlag, *package_ListStatusFlag, *package_ListLimitFlag, *package_ListOffsetFlag, *package_ListTokenFlag)
 			case "show":
 				endpoint = c.Show()
 				data, err = package_c.BuildShowPayload(*package_ShowIDFlag, *package_ShowTokenFlag)
@@ -439,7 +440,7 @@ Example:
 }
 
 func package_ListUsage() {
-	fmt.Fprintf(os.Stderr, `%[1]s [flags] package list -name STRING -aip-id STRING -earliest-created-time STRING -latest-created-time STRING -location-id STRING -status STRING -cursor STRING -token STRING
+	fmt.Fprintf(os.Stderr, `%[1]s [flags] package list -name STRING -aip-id STRING -earliest-created-time STRING -latest-created-time STRING -location-id STRING -status STRING -limit INT -offset INT -token STRING
 
 List all stored packages
     -name STRING: 
@@ -448,11 +449,12 @@ List all stored packages
     -latest-created-time STRING: 
     -location-id STRING: 
     -status STRING: 
-    -cursor STRING: 
+    -limit INT: 
+    -offset INT: 
     -token STRING: 
 
 Example:
-    %[1]s package list --name "abc123" --aip-id "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5" --earliest-created-time "1970-01-01T00:00:01Z" --latest-created-time "1970-01-01T00:00:01Z" --location-id "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5" --status "in progress" --cursor "abc123" --token "abc123"
+    %[1]s package list --name "abc123" --aip-id "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5" --earliest-created-time "1970-01-01T00:00:01Z" --latest-created-time "1970-01-01T00:00:01Z" --location-id "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5" --status "in progress" --limit 1 --offset 1 --token "abc123"
 `, os.Args[0])
 }
 

--- a/internal/api/gen/http/openapi.json
+++ b/internal/api/gen/http/openapi.json
@@ -206,6 +206,41 @@
       "title": "Mediatype identifier: application/vnd.enduro.package-preservation-task; type=collection; view=default",
       "type": "array"
     },
+    "EnduroPageResponseBody": {
+      "description": "Page represents a subset of search results. (default view)",
+      "example": {
+        "limit": 1,
+        "offset": 1,
+        "total": 1
+      },
+      "properties": {
+        "limit": {
+          "description": "Maximum items per page",
+          "example": 1,
+          "format": "int64",
+          "type": "integer"
+        },
+        "offset": {
+          "description": "Offset from first result to start of page",
+          "example": 1,
+          "format": "int64",
+          "type": "integer"
+        },
+        "total": {
+          "description": "Total result count before paging",
+          "example": 1,
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "limit",
+        "offset",
+        "total"
+      ],
+      "title": "Mediatype identifier: application/vnd.enduro.page; view=default",
+      "type": "object"
+    },
     "EnduroStoredPackageResponseBody": {
       "description": "StoredPackage describes a package retrieved by the service. (default view)",
       "example": {
@@ -534,6 +569,7 @@
       "type": "object"
     },
     "PackageListResponseBody": {
+      "description": "ListResponseBody result type (default view)",
       "example": {
         "items": [
           {
@@ -549,21 +585,25 @@
             "workflow_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
           }
         ],
-        "next_cursor": "abc123"
+        "page": {
+          "limit": 1,
+          "offset": 1,
+          "total": 1
+        }
       },
       "properties": {
         "items": {
           "$ref": "#/definitions/EnduroStoredPackageResponseBodyCollection"
         },
-        "next_cursor": {
-          "example": "abc123",
-          "type": "string"
+        "page": {
+          "$ref": "#/definitions/EnduroPageResponseBody"
         }
       },
       "required": [
-        "items"
+        "items",
+        "page"
       ],
-      "title": "PackageListResponseBody",
+      "title": "Mediatype identifier: application/vnd.enduro.packages; view=default",
       "type": "object"
     },
     "PackageMonitorNotAvailableResponseBody": {
@@ -2843,11 +2883,18 @@
             "type": "string"
           },
           {
-            "description": "Pagination cursor",
+            "description": "Limit number of results to return",
             "in": "query",
-            "name": "cursor",
+            "name": "limit",
             "required": false,
-            "type": "string"
+            "type": "integer"
+          },
+          {
+            "description": "Offset from the beginning of the found set",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "type": "integer"
           },
           {
             "in": "header",
@@ -2860,10 +2907,7 @@
           "200": {
             "description": "OK response.",
             "schema": {
-              "$ref": "#/definitions/PackageListResponseBody",
-              "required": [
-                "items"
-              ]
+              "$ref": "#/definitions/PackageListResponseBody"
             }
           },
           "401": {

--- a/internal/api/gen/http/openapi.yaml
+++ b/internal/api/gen/http/openapi.yaml
@@ -61,11 +61,16 @@ paths:
                     - queued
                     - abandoned
                     - pending
-                - name: cursor
+                - name: limit
                   in: query
-                  description: Pagination cursor
+                  description: Limit number of results to return
                   required: false
-                  type: string
+                  type: integer
+                - name: offset
+                  in: query
+                  description: Offset from the beginning of the found set
+                  required: false
+                  type: integer
                 - name: Authorization
                   in: header
                   required: false
@@ -75,8 +80,6 @@ paths:
                     description: OK response.
                     schema:
                         $ref: '#/definitions/PackageListResponseBody'
-                        required:
-                            - items
                 "401":
                     description: Unauthorized response.
                     schema:
@@ -1264,6 +1267,34 @@ definitions:
               started_at: "1970-01-01T00:00:01Z"
               status: in progress
               task_id: abc123
+    EnduroPageResponseBody:
+        title: 'Mediatype identifier: application/vnd.enduro.page; view=default'
+        type: object
+        properties:
+            limit:
+                type: integer
+                description: Maximum items per page
+                example: 1
+                format: int64
+            offset:
+                type: integer
+                description: Offset from first result to start of page
+                example: 1
+                format: int64
+            total:
+                type: integer
+                description: Total result count before paging
+                example: 1
+                format: int64
+        description: Page represents a subset of search results. (default view)
+        example:
+            limit: 1
+            offset: 1
+            total: 1
+        required:
+            - limit
+            - offset
+            - total
     EnduroStoredPackageResponseBody:
         title: 'Mediatype identifier: application/vnd.enduro.stored-package; view=default'
         type: object
@@ -1529,14 +1560,14 @@ definitions:
         required:
             - location_id
     PackageListResponseBody:
-        title: PackageListResponseBody
+        title: 'Mediatype identifier: application/vnd.enduro.packages; view=default'
         type: object
         properties:
             items:
                 $ref: '#/definitions/EnduroStoredPackageResponseBodyCollection'
-            next_cursor:
-                type: string
-                example: abc123
+            page:
+                $ref: '#/definitions/EnduroPageResponseBody'
+        description: ListResponseBody result type (default view)
         example:
             items:
                 - aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
@@ -1549,9 +1580,13 @@ definitions:
                   started_at: "1970-01-01T00:00:01Z"
                   status: in progress
                   workflow_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
-            next_cursor: abc123
+            page:
+                limit: 1
+                offset: 1
+                total: 1
         required:
             - items
+            - page
     PackageMonitorNotAvailableResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object

--- a/internal/api/gen/http/openapi3.json
+++ b/internal/api/gen/http/openapi3.json
@@ -389,6 +389,76 @@
         },
         "type": "array"
       },
+      "EnduroPackages": {
+        "example": {
+          "items": [
+            {
+              "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+              "completed_at": "1970-01-01T00:00:01Z",
+              "created_at": "1970-01-01T00:00:01Z",
+              "id": 1,
+              "location_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+              "name": "abc123",
+              "run_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+              "started_at": "1970-01-01T00:00:01Z",
+              "status": "in progress",
+              "workflow_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+            }
+          ],
+          "page": {
+            "limit": 1,
+            "offset": 1,
+            "total": 1
+          }
+        },
+        "properties": {
+          "items": {
+            "$ref": "#/components/schemas/EnduroStoredPackageCollection"
+          },
+          "page": {
+            "$ref": "#/components/schemas/EnduroPage"
+          }
+        },
+        "required": [
+          "items",
+          "page"
+        ],
+        "type": "object"
+      },
+      "EnduroPage": {
+        "description": "Page represents a subset of search results.",
+        "example": {
+          "limit": 1,
+          "offset": 1,
+          "total": 1
+        },
+        "properties": {
+          "limit": {
+            "description": "Maximum items per page",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          },
+          "offset": {
+            "description": "Offset from first result to start of page",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          },
+          "total": {
+            "description": "Total result count before paging",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "limit",
+          "offset",
+          "total"
+        ],
+        "type": "object"
+      },
       "EnduroStoredPackage": {
         "description": "StoredPackage describes a package retrieved by the service.",
         "example": {
@@ -548,38 +618,6 @@
           "temporary",
           "timeout",
           "fault"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody": {
-        "example": {
-          "items": [
-            {
-              "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
-              "completed_at": "1970-01-01T00:00:01Z",
-              "created_at": "1970-01-01T00:00:01Z",
-              "id": 1,
-              "location_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
-              "name": "abc123",
-              "run_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
-              "started_at": "1970-01-01T00:00:01Z",
-              "status": "in progress",
-              "workflow_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
-            }
-          ],
-          "next_cursor": "abc123"
-        },
-        "properties": {
-          "items": {
-            "$ref": "#/components/schemas/EnduroStoredPackageCollection"
-          },
-          "next_cursor": {
-            "example": "abc123",
-            "type": "string"
-          }
-        },
-        "required": [
-          "items"
         ],
         "type": "object"
       },
@@ -1431,14 +1469,28 @@
           },
           {
             "allowEmptyValue": true,
-            "description": "Pagination cursor",
-            "example": "abc123",
+            "description": "Limit number of results to return",
+            "example": 1,
             "in": "query",
-            "name": "cursor",
+            "name": "limit",
             "schema": {
-              "description": "Pagination cursor",
-              "example": "abc123",
-              "type": "string"
+              "description": "Limit number of results to return",
+              "example": 1,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "Offset from the beginning of the found set",
+            "example": 1,
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "description": "Offset from the beginning of the found set",
+              "example": 1,
+              "format": "int64",
+              "type": "integer"
             }
           }
         ],
@@ -1461,10 +1513,14 @@
                       "workflow_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
                     }
                   ],
-                  "next_cursor": "abc123"
+                  "page": {
+                    "limit": 1,
+                    "offset": 1,
+                    "total": 1
+                  }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody"
+                  "$ref": "#/components/schemas/EnduroPackages"
                 }
               }
             },

--- a/internal/api/gen/http/openapi3.yaml
+++ b/internal/api/gen/http/openapi3.yaml
@@ -72,22 +72,33 @@ paths:
                         - abandoned
                         - pending
                   example: in progress
-                - name: cursor
+                - name: limit
                   in: query
-                  description: Pagination cursor
+                  description: Limit number of results to return
                   allowEmptyValue: true
                   schema:
-                    type: string
-                    description: Pagination cursor
-                    example: abc123
-                  example: abc123
+                    type: integer
+                    description: Limit number of results to return
+                    example: 1
+                    format: int64
+                  example: 1
+                - name: offset
+                  in: query
+                  description: Offset from the beginning of the found set
+                  allowEmptyValue: true
+                  schema:
+                    type: integer
+                    description: Offset from the beginning of the found set
+                    example: 1
+                    format: int64
+                  example: 1
             responses:
                 "200":
                     description: OK response.
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/ListResponseBody'
+                                $ref: '#/components/schemas/EnduroPackages'
                             example:
                                 items:
                                     - aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
@@ -100,7 +111,10 @@ paths:
                                       started_at: "1970-01-01T00:00:01Z"
                                       status: in progress
                                       workflow_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
-                                next_cursor: abc123
+                                page:
+                                    limit: 1
+                                    offset: 1
+                                    total: 1
                 "401":
                     description: 'unauthorized: Unauthorized response.'
                     content:
@@ -1699,6 +1713,59 @@ components:
                   started_at: "1970-01-01T00:00:01Z"
                   status: in progress
                   task_id: abc123
+        EnduroPackages:
+            type: object
+            properties:
+                items:
+                    $ref: '#/components/schemas/EnduroStoredPackageCollection'
+                page:
+                    $ref: '#/components/schemas/EnduroPage'
+            example:
+                items:
+                    - aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                      completed_at: "1970-01-01T00:00:01Z"
+                      created_at: "1970-01-01T00:00:01Z"
+                      id: 1
+                      location_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                      name: abc123
+                      run_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                      started_at: "1970-01-01T00:00:01Z"
+                      status: in progress
+                      workflow_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                page:
+                    limit: 1
+                    offset: 1
+                    total: 1
+            required:
+                - items
+                - page
+        EnduroPage:
+            type: object
+            properties:
+                limit:
+                    type: integer
+                    description: Maximum items per page
+                    example: 1
+                    format: int64
+                offset:
+                    type: integer
+                    description: Offset from first result to start of page
+                    example: 1
+                    format: int64
+                total:
+                    type: integer
+                    description: Total result count before paging
+                    example: 1
+                    format: int64
+            description: Page represents a subset of search results.
+            example:
+                limit: 1
+                offset: 1
+                total: 1
+            required:
+                - limit
+                - offset
+                - total
         EnduroStoredPackage:
             type: object
             properties:
@@ -1831,29 +1898,6 @@ components:
                 - temporary
                 - timeout
                 - fault
-        ListResponseBody:
-            type: object
-            properties:
-                items:
-                    $ref: '#/components/schemas/EnduroStoredPackageCollection'
-                next_cursor:
-                    type: string
-                    example: abc123
-            example:
-                items:
-                    - aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
-                      completed_at: "1970-01-01T00:00:01Z"
-                      created_at: "1970-01-01T00:00:01Z"
-                      id: 1
-                      location_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
-                      name: abc123
-                      run_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
-                      started_at: "1970-01-01T00:00:01Z"
-                      status: in progress
-                      workflow_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
-                next_cursor: abc123
-            required:
-                - items
         Location:
             type: object
             properties:

--- a/internal/api/gen/http/package_/client/cli.go
+++ b/internal/api/gen/http/package_/client/cli.go
@@ -49,7 +49,7 @@ func BuildMonitorPayload(package_MonitorTicket string) (*package_.MonitorPayload
 
 // BuildListPayload builds the payload for the package list endpoint from CLI
 // flags.
-func BuildListPayload(package_ListName string, package_ListAipID string, package_ListEarliestCreatedTime string, package_ListLatestCreatedTime string, package_ListLocationID string, package_ListStatus string, package_ListCursor string, package_ListToken string) (*package_.ListPayload, error) {
+func BuildListPayload(package_ListName string, package_ListAipID string, package_ListEarliestCreatedTime string, package_ListLatestCreatedTime string, package_ListLocationID string, package_ListStatus string, package_ListLimit string, package_ListOffset string, package_ListToken string) (*package_.ListPayload, error) {
 	var err error
 	var name *string
 	{
@@ -109,10 +109,28 @@ func BuildListPayload(package_ListName string, package_ListAipID string, package
 			}
 		}
 	}
-	var cursor *string
+	var limit *int
 	{
-		if package_ListCursor != "" {
-			cursor = &package_ListCursor
+		if package_ListLimit != "" {
+			var v int64
+			v, err = strconv.ParseInt(package_ListLimit, 10, strconv.IntSize)
+			val := int(v)
+			limit = &val
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for limit, must be INT")
+			}
+		}
+	}
+	var offset *int
+	{
+		if package_ListOffset != "" {
+			var v int64
+			v, err = strconv.ParseInt(package_ListOffset, 10, strconv.IntSize)
+			val := int(v)
+			offset = &val
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for offset, must be INT")
+			}
 		}
 	}
 	var token *string
@@ -128,7 +146,8 @@ func BuildListPayload(package_ListName string, package_ListAipID string, package
 	v.LatestCreatedTime = latestCreatedTime
 	v.LocationID = locationID
 	v.Status = status
-	v.Cursor = cursor
+	v.Limit = limit
+	v.Offset = offset
 	v.Token = token
 
 	return v, nil

--- a/internal/api/gen/package_/client.go
+++ b/internal/api/gen/package_/client.go
@@ -80,13 +80,13 @@ func (c *Client) Monitor(ctx context.Context, p *MonitorPayload) (res MonitorCli
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
 //   - error: internal error
-func (c *Client) List(ctx context.Context, p *ListPayload) (res *ListResult, err error) {
+func (c *Client) List(ctx context.Context, p *ListPayload) (res *EnduroPackages, err error) {
 	var ires any
 	ires, err = c.ListEndpoint(ctx, p)
 	if err != nil {
 		return
 	}
-	return ires.(*ListResult), nil
+	return ires.(*EnduroPackages), nil
 }
 
 // Show calls the "show" endpoint of the "package" service.

--- a/internal/api/gen/package_/endpoints.go
+++ b/internal/api/gen/package_/endpoints.go
@@ -131,7 +131,12 @@ func NewListEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.Endpoint {
 		if err != nil {
 			return nil, err
 		}
-		return s.List(ctx, p)
+		res, err := s.List(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+		vres := NewViewedEnduroPackages(res, "default")
+		return vres, nil
 	}
 }
 

--- a/internal/datatypes/package_.go
+++ b/internal/datatypes/package_.go
@@ -33,7 +33,11 @@ type Package struct {
 }
 
 // Goa returns the API representation of the package.
-func (p Package) Goa() *goapackage.EnduroStoredPackage {
+func (p *Package) Goa() *goapackage.EnduroStoredPackage {
+	if p == nil {
+		return nil
+	}
+
 	var id uint
 	if p.ID > 0 {
 		id = uint(p.ID) // #nosec G115 -- range validated.

--- a/internal/package_/goa_test.go
+++ b/internal/package_/goa_test.go
@@ -2,16 +2,28 @@ package package_
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
+	"github.com/google/uuid"
+	"go.artefactual.dev/tools/mockutil"
+	"go.artefactual.dev/tools/ref"
 	"go.uber.org/mock/gomock"
 	"goa.design/goa/v3/security"
 	"gotest.tools/v3/assert"
 
 	"github.com/artefactual-sdps/enduro/internal/api/auth"
 	authfake "github.com/artefactual-sdps/enduro/internal/api/auth/fake"
+	goapackage "github.com/artefactual-sdps/enduro/internal/api/gen/package_"
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
+	"github.com/artefactual-sdps/enduro/internal/enums"
+	"github.com/artefactual-sdps/enduro/internal/persistence"
+	persistence_fake "github.com/artefactual-sdps/enduro/internal/persistence/fake"
+	"github.com/artefactual-sdps/enduro/internal/timerange"
 )
 
 func TestJWTAuth(t *testing.T) {
@@ -101,6 +113,260 @@ func TestJWTAuth(t *testing.T) {
 			}
 			assert.NilError(t, err)
 			assert.DeepEqual(t, auth.UserClaimsFromContext(ctx), tt.claims)
+		})
+	}
+}
+
+func nullUUID(s string) uuid.NullUUID {
+	return uuid.NullUUID{
+		UUID:  uuid.MustParse(s),
+		Valid: true,
+	}
+}
+
+var testPackages = []*datatypes.Package{
+	{
+		ID:         1,
+		Name:       "Test package 1",
+		WorkflowID: "workflow-1",
+		RunID:      "c5f7c35a-d5a6-4e00-b4da-b036ce5b40bc",
+		AIPID:      nullUUID("e2ace0da-8697-453d-9ea1-4c9b62309e54"),
+		LocationID: nullUUID("146182ff-9923-4869-bca1-0bbc0f822025"),
+		Status:     enums.PackageStatusDone,
+		CreatedAt:  time.Date(2024, 9, 25, 9, 31, 10, 0, time.UTC),
+		StartedAt: sql.NullTime{
+			Time:  time.Date(2024, 9, 25, 9, 31, 11, 0, time.UTC),
+			Valid: true,
+		},
+		CompletedAt: sql.NullTime{
+			Time:  time.Date(2024, 9, 25, 9, 31, 12, 0, time.UTC),
+			Valid: true,
+		},
+	},
+	{
+		ID:         2,
+		Name:       "Test package 2",
+		WorkflowID: "workflow-2",
+		RunID:      "d1f172c6-4ec8-4488-8a09-eef422b024cc",
+		AIPID:      nullUUID("ffdb12f4-1735-4022-b746-a9bf4a32109b"),
+		LocationID: nullUUID("659a93a0-2a6a-4931-a505-f07f71f5b010"),
+		Status:     enums.PackageStatusInProgress,
+		CreatedAt:  time.Date(2024, 10, 1, 17, 13, 26, 0, time.UTC),
+		StartedAt: sql.NullTime{
+			Time:  time.Date(2024, 10, 1, 17, 13, 27, 0, time.UTC),
+			Valid: true,
+		},
+		CompletedAt: sql.NullTime{
+			Time:  time.Date(2024, 10, 1, 17, 13, 28, 0, time.UTC),
+			Valid: true,
+		},
+	},
+}
+
+func TestList(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		name         string
+		payload      *goapackage.ListPayload
+		mockRecorder func(mr *persistence_fake.MockServiceMockRecorder)
+		want         *goapackage.EnduroPackages
+		wantErr      string
+	}
+	for _, tt := range []test{
+		{
+			name: "Returns all packages",
+			mockRecorder: func(mr *persistence_fake.MockServiceMockRecorder) {
+				mr.ListPackages(
+					mockutil.Context(),
+					&persistence.PackageFilter{
+						Sort: persistence.NewSort().AddCol("id", true),
+					},
+				).Return(
+					testPackages,
+					&persistence.Page{Limit: 20, Total: 2},
+					nil,
+				)
+			},
+			want: &goapackage.EnduroPackages{
+				Items: goapackage.EnduroStoredPackageCollection{
+					{
+						ID:          1,
+						Name:        ref.New("Test package 1"),
+						LocationID:  ref.New(uuid.MustParse("146182ff-9923-4869-bca1-0bbc0f822025")),
+						Status:      "done",
+						WorkflowID:  ref.New("workflow-1"),
+						RunID:       ref.New("c5f7c35a-d5a6-4e00-b4da-b036ce5b40bc"),
+						AipID:       ref.New("e2ace0da-8697-453d-9ea1-4c9b62309e54"),
+						CreatedAt:   "2024-09-25T09:31:10Z",
+						StartedAt:   ref.New("2024-09-25T09:31:11Z"),
+						CompletedAt: ref.New("2024-09-25T09:31:12Z"),
+					},
+					{
+						ID:          2,
+						Name:        ref.New("Test package 2"),
+						LocationID:  ref.New(uuid.MustParse("659a93a0-2a6a-4931-a505-f07f71f5b010")),
+						Status:      "in progress",
+						WorkflowID:  ref.New("workflow-2"),
+						RunID:       ref.New("d1f172c6-4ec8-4488-8a09-eef422b024cc"),
+						AipID:       ref.New("ffdb12f4-1735-4022-b746-a9bf4a32109b"),
+						CreatedAt:   "2024-10-01T17:13:26Z",
+						StartedAt:   ref.New("2024-10-01T17:13:27Z"),
+						CompletedAt: ref.New("2024-10-01T17:13:28Z"),
+					},
+				},
+				Page: &goapackage.EnduroPage{
+					Limit: 20,
+					Total: 2,
+				},
+			},
+		},
+		{
+			name: "Returns filtered packages",
+			payload: &goapackage.ListPayload{
+				Name:                ref.New("Test package 1"),
+				AipID:               ref.New("e2ace0da-8697-453d-9ea1-4c9b62309e54"),
+				LocationID:          ref.New("146182ff-9923-4869-bca1-0bbc0f822025"),
+				EarliestCreatedTime: ref.New("2024-09-25T09:30:00Z"),
+				LatestCreatedTime:   ref.New("2024-09-25T09:40:00Z"),
+				Status:              ref.New("done"),
+				Limit:               ref.New(10),
+				Offset:              ref.New(1),
+			},
+			mockRecorder: func(mr *persistence_fake.MockServiceMockRecorder) {
+				mr.ListPackages(
+					mockutil.Context(),
+					&persistence.PackageFilter{
+						Name:       ref.New("Test package 1"),
+						AIPID:      ref.New(uuid.MustParse("e2ace0da-8697-453d-9ea1-4c9b62309e54")),
+						LocationID: ref.New(uuid.MustParse("146182ff-9923-4869-bca1-0bbc0f822025")),
+						CreatedAt: &timerange.Range{
+							Start: time.Date(2024, 9, 25, 9, 30, 0, 0, time.UTC),
+							End:   time.Date(2024, 9, 25, 9, 40, 0, 0, time.UTC),
+						},
+						Status: ref.New(enums.PackageStatusDone),
+						Sort:   persistence.NewSort().AddCol("id", true),
+						Page: persistence.Page{
+							Limit:  10,
+							Offset: 1,
+						},
+					},
+				).Return(
+					testPackages[0:1],
+					&persistence.Page{Limit: 10, Total: 1},
+					nil,
+				)
+			},
+			want: &goapackage.EnduroPackages{
+				Items: goapackage.EnduroStoredPackageCollection{
+					{
+						ID:          1,
+						Name:        ref.New("Test package 1"),
+						LocationID:  ref.New(uuid.MustParse("146182ff-9923-4869-bca1-0bbc0f822025")),
+						Status:      "done",
+						WorkflowID:  ref.New("workflow-1"),
+						RunID:       ref.New("c5f7c35a-d5a6-4e00-b4da-b036ce5b40bc"),
+						AipID:       ref.New("e2ace0da-8697-453d-9ea1-4c9b62309e54"),
+						CreatedAt:   "2024-09-25T09:31:10Z",
+						StartedAt:   ref.New("2024-09-25T09:31:11Z"),
+						CompletedAt: ref.New("2024-09-25T09:31:12Z"),
+					},
+				},
+				Page: &goapackage.EnduroPage{
+					Limit: 10,
+					Total: 1,
+				},
+			},
+		},
+		{
+			name: "Errors on an internal service error",
+			payload: &goapackage.ListPayload{
+				Name: ref.New("Package 42"),
+			},
+			mockRecorder: func(mr *persistence_fake.MockServiceMockRecorder) {
+				mr.ListPackages(
+					mockutil.Context(),
+					&persistence.PackageFilter{
+						Name: ref.New("Package 42"),
+						Sort: persistence.NewSort().AddCol("id", true),
+					},
+				).Return(
+					[]*datatypes.Package{},
+					&persistence.Page{},
+					persistence.ErrNotFound,
+				)
+			},
+			wantErr: "not found error",
+		},
+		{
+			name: "Errors on a bad aip_id",
+			payload: &goapackage.ListPayload{
+				AipID: ref.New("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"),
+			},
+			wantErr: "aip_id: invalid UUID",
+		},
+		{
+			name: "Errors on a bad location_id",
+			payload: &goapackage.ListPayload{
+				LocationID: ref.New("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"),
+			},
+			wantErr: "location_id: invalid UUID",
+		},
+		{
+			name: "Errors on a bad status",
+			payload: &goapackage.ListPayload{
+				Status: ref.New("meditating"),
+			},
+			wantErr: "invalid status",
+		},
+		{
+			name: "Errors on a bad earliest_created_time",
+			payload: &goapackage.ListPayload{
+				EarliestCreatedTime: ref.New("2024-15-15T25:83:52Z"),
+			},
+			wantErr: "earliest_created_time: invalid time",
+		},
+		{
+			name: "Errors on a bad latest_created_time",
+			payload: &goapackage.ListPayload{
+				LatestCreatedTime: ref.New("2024-15-15T25:83:52Z"),
+			},
+			wantErr: "latest_created_time: invalid time",
+		},
+		{
+			name: "Errors on a bad created at range",
+			payload: &goapackage.ListPayload{
+				EarliestCreatedTime: ref.New("2024-10-01T17:43:52Z"),
+				LatestCreatedTime:   ref.New("2023-10-01T17:43:52Z"),
+			},
+			wantErr: "time range: end cannot be before start",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			ctrl := gomock.NewController(t)
+			svc := persistence_fake.NewMockService(ctrl)
+
+			if tt.mockRecorder != nil {
+				tt.mockRecorder(svc.EXPECT())
+			}
+
+			wrapper := goaWrapper{
+				packageImpl: &packageImpl{
+					logger: logr.Discard(),
+					perSvc: svc,
+				},
+			}
+
+			got, err := wrapper.List(ctx, tt.payload)
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
 		})
 	}
 }

--- a/internal/persistence/ent/client/package_test.go
+++ b/internal/persistence/ent/client/package_test.go
@@ -379,11 +379,11 @@ func TestListPackages(t *testing.T) {
 		page *persistence.Page
 	}
 	tests := []struct {
-		name    string
-		data    []*datatypes.Package
-		args    persistence.PackageFilter
-		want    results
-		wantErr string
+		name          string
+		data          []*datatypes.Package
+		packageFilter *persistence.PackageFilter
+		want          results
+		wantErr       string
 	}{
 		{
 			name: "Returns all packages",
@@ -409,7 +409,6 @@ func TestListPackages(t *testing.T) {
 					CompletedAt: completed2,
 				},
 			},
-			args: persistence.PackageFilter{},
 			want: results{
 				data: []*datatypes.Package{
 					{
@@ -467,7 +466,7 @@ func TestListPackages(t *testing.T) {
 					CompletedAt: completed2,
 				},
 			},
-			args: persistence.PackageFilter{
+			packageFilter: &persistence.PackageFilter{
 				Page: persistence.Page{Limit: 1},
 			},
 			want: results{
@@ -515,7 +514,7 @@ func TestListPackages(t *testing.T) {
 					CompletedAt: completed2,
 				},
 			},
-			args: persistence.PackageFilter{
+			packageFilter: &persistence.PackageFilter{
 				Page: persistence.Page{Limit: 1, Offset: 1},
 			},
 			want: results{
@@ -564,7 +563,7 @@ func TestListPackages(t *testing.T) {
 					CompletedAt: completed2,
 				},
 			},
-			args: persistence.PackageFilter{
+			packageFilter: &persistence.PackageFilter{
 				Name: ref.New("Test package 2"),
 			},
 			want: results{
@@ -612,7 +611,7 @@ func TestListPackages(t *testing.T) {
 					CompletedAt: completed2,
 				},
 			},
-			args: persistence.PackageFilter{
+			packageFilter: &persistence.PackageFilter{
 				AIPID: &aipID2.UUID,
 			},
 			want: results{
@@ -660,7 +659,7 @@ func TestListPackages(t *testing.T) {
 					CompletedAt: completed2,
 				},
 			},
-			args: persistence.PackageFilter{
+			packageFilter: &persistence.PackageFilter{
 				LocationID: &locID2.UUID,
 			},
 			want: results{
@@ -708,7 +707,7 @@ func TestListPackages(t *testing.T) {
 					CompletedAt: completed2,
 				},
 			},
-			args: persistence.PackageFilter{
+			packageFilter: &persistence.PackageFilter{
 				Status: ref.New(enums.PackageStatusInProgress),
 			},
 			want: results{
@@ -756,7 +755,7 @@ func TestListPackages(t *testing.T) {
 					CompletedAt: completed2,
 				},
 			},
-			args: persistence.PackageFilter{
+			packageFilter: &persistence.PackageFilter{
 				CreatedAt: func(t *testing.T) *timerange.Range {
 					r, err := timerange.New(
 						time.Now().Add(-1*time.Minute),
@@ -825,7 +824,7 @@ func TestListPackages(t *testing.T) {
 					CompletedAt: completed2,
 				},
 			},
-			args: persistence.PackageFilter{
+			packageFilter: &persistence.PackageFilter{
 				CreatedAt: func(t *testing.T) *timerange.Range {
 					r, err := timerange.New(
 						time.Now().Add(time.Minute),
@@ -861,7 +860,7 @@ func TestListPackages(t *testing.T) {
 				}
 			}
 
-			got, pg, err := svc.ListPackages(ctx, tt.args)
+			got, pg, err := svc.ListPackages(ctx, tt.packageFilter)
 			assert.NilError(t, err)
 
 			assert.DeepEqual(t, got, tt.want.data,

--- a/internal/persistence/fake/mock_persistence.go
+++ b/internal/persistence/fake/mock_persistence.go
@@ -156,7 +156,7 @@ func (c *MockServiceCreatePreservationTaskCall) DoAndReturn(f func(context.Conte
 }
 
 // ListPackages mocks base method.
-func (m *MockService) ListPackages(arg0 context.Context, arg1 persistence.PackageFilter) ([]*datatypes.Package, *persistence.Page, error) {
+func (m *MockService) ListPackages(arg0 context.Context, arg1 *persistence.PackageFilter) ([]*datatypes.Package, *persistence.Page, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPackages", arg0, arg1)
 	ret0, _ := ret[0].([]*datatypes.Package)
@@ -184,13 +184,13 @@ func (c *MockServiceListPackagesCall) Return(arg0 []*datatypes.Package, arg1 *pe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceListPackagesCall) Do(f func(context.Context, persistence.PackageFilter) ([]*datatypes.Package, *persistence.Page, error)) *MockServiceListPackagesCall {
+func (c *MockServiceListPackagesCall) Do(f func(context.Context, *persistence.PackageFilter) ([]*datatypes.Package, *persistence.Page, error)) *MockServiceListPackagesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceListPackagesCall) DoAndReturn(f func(context.Context, persistence.PackageFilter) ([]*datatypes.Package, *persistence.Page, error)) *MockServiceListPackagesCall {
+func (c *MockServiceListPackagesCall) DoAndReturn(f func(context.Context, *persistence.PackageFilter) ([]*datatypes.Package, *persistence.Page, error)) *MockServiceListPackagesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/persistence/filter.go
+++ b/internal/persistence/filter.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"github.com/google/uuid"
 
+	goapackage "github.com/artefactual-sdps/enduro/internal/api/gen/package_"
 	"github.com/artefactual-sdps/enduro/internal/enums"
 	"github.com/artefactual-sdps/enduro/internal/timerange"
 )
@@ -46,6 +47,18 @@ type Page struct {
 
 	// Total is the total number of search results before paging.
 	Total int
+}
+
+func (p *Page) Goa() *goapackage.EnduroPage {
+	if p == nil {
+		return nil
+	}
+
+	return &goapackage.EnduroPage{
+		Limit:  p.Limit,
+		Offset: p.Offset,
+		Total:  p.Total,
+	}
 }
 
 type PackageFilter struct {

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -29,7 +29,7 @@ type Service interface {
 	// (e.g. ID, CreatedAt).
 	CreatePackage(context.Context, *datatypes.Package) error
 	UpdatePackage(context.Context, int, PackageUpdater) (*datatypes.Package, error)
-	ListPackages(context.Context, PackageFilter) ([]*datatypes.Package, *Page, error)
+	ListPackages(context.Context, *PackageFilter) ([]*datatypes.Package, *Page, error)
 
 	CreatePreservationAction(context.Context, *datatypes.PreservationAction) error
 

--- a/internal/persistence/telemetry.go
+++ b/internal/persistence/telemetry.go
@@ -58,7 +58,7 @@ func (w *wrapper) UpdatePackage(ctx context.Context, id int, updater PackageUpda
 	return r, nil
 }
 
-func (w *wrapper) ListPackages(ctx context.Context, f PackageFilter) ([]*datatypes.Package, *Page, error) {
+func (w *wrapper) ListPackages(ctx context.Context, f *PackageFilter) ([]*datatypes.Package, *Page, error) {
 	ctx, span := w.tracer.Start(ctx, "ListPackages")
 	defer span.End()
 


### PR DESCRIPTION
Refs #988

This commit connects the API "GET /package" endpoint to the persistence layer `ListPackages()` method. The cursor request parameter is replaced by the optional limit and offset parameters. The response now returns the current page limit and offset, and the total number of results found before paging, instead of a cursor value.

These changes will break the existing cursor-based pagination in the Enduro Dashboard. I will fix the Dashboard paging in a subsequent commit.

- Add optional `limit` and `offset` parameters to the GET /package request
- Add page `limit`, `offset`, and `total` fields to GET /package response
- Use `persistence.ListPackages()` to populate API results
- Add an adapter to convert goa `package_.ListPayload` search filters to `persistence.Filter` filters
- Add tests for the conversion of the package API parameters to persistence layer parameters, and the persistence search results to API response results