### PR TITLE
Add Home dashboard to Grafana

### DIFF
--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -104,6 +104,7 @@ Keycloack:
 | Dashboard     | <http://localhost:8080> | `admin`     | `admin123`     |
 | MinIO console | <http://localhost:7460> | `admin`     | `admin123`     |
 | Temporal UI   | <http://localhost:7440> | `admin`     | `admin123`     |
+| Grafana       | <http://localhost:7490> | `admin`     | `admin123`     |
 | Keycloak      | <http://localhost:7470> | `keycloak`  | `keycloak123`  |
 
 ## Live updates

--- a/hack/kube/components/dev/grafana-tempo.yaml
+++ b/hack/kube/components/dev/grafana-tempo.yaml
@@ -88,7 +88,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
-        image: grafana/tempo:2.3.0
+        image: grafana/tempo:2.6.0
         imagePullPolicy: IfNotPresent
         name: grafana-tempo
         ports:

--- a/hack/kube/components/dev/grafana.yaml
+++ b/hack/kube/components/dev/grafana.yaml
@@ -46,12 +46,27 @@ data:
     provisioning = /etc/grafana/provisioning
     [server]
     domain = ''
-    [auth.anonymous]
-    enabled = true
+    root_url = http://localhost:7490
     [users]
     default_theme = system
     [dashboards]
     default_home_dashboard_path = /var/lib/grafana/dashboards/home.json
+    [auth.generic_oauth]
+    enabled = true
+    name = Keycloak
+    allow_sign_up = true
+    client_id = grafana
+    client_secret = wi8sSTRwP5lA2NuogV5bL6GmIyzVF2HP
+    scopes = openid email profile
+    email_attribute_path = email
+    login_attribute_path = username
+    name_attribute_path = full_name
+    auth_url = http://keycloak:7470/realms/artefactual/protocol/openid-connect/auth
+    token_url = http://keycloak:7470/realms/artefactual/protocol/openid-connect/token
+    api_url = http://keycloak:7470/realms/artefactual/protocol/openid-connect/userinfo
+    signout_redirect_url = http://keycloak:7470/realms/artefactual/protocol/openid-connect/logout?post_logout_redirect_uri=http%3A%2F%2Flocalhost:7490%2Flogin/generic_oauth
+    role_attribute_path = "'Admin'"
+    skip_org_role_sync = false
   datasources.yaml: |
     apiVersion: 1
     datasources:

--- a/hack/kube/components/dev/grafana.yaml
+++ b/hack/kube/components/dev/grafana.yaml
@@ -50,6 +50,8 @@ data:
     enabled = true
     [users]
     default_theme = system
+    [dashboards]
+    default_home_dashboard_path = /var/lib/grafana/dashboards/home.json
   datasources.yaml: |
     apiVersion: 1
     datasources:
@@ -67,6 +69,331 @@ data:
       uid: tempo
       url: http://grafana-tempo:3200
       version: 1
+  default.yaml: |
+    apiVersion: 1
+    providers:
+    - name: Default
+      type: file
+      options:
+        path: /var/lib/grafana/dashboards
+  home.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 3,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "description": "",
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "Howdy!",
+            "mode": "markdown"
+          },
+          "pluginVersion": "11.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "tempo",
+                "uid": "tempo"
+              },
+              "limit": 20,
+              "queryType": "traceql",
+              "refId": "A",
+              "tableType": "traces"
+            }
+          ],
+          "title": "Hello World",
+          "type": "text"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 7
+          },
+          "id": 2,
+          "panels": [],
+          "title": "Traces and spans",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Trace Service"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 118
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Trace Name"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 107
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Start time"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 160
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 4,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "11.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "tempo",
+                "uid": "tempo"
+              },
+              "limit": 20,
+              "query": "{name=\"StartWorkflow:processing-workflow\"}",
+              "queryType": "traceql",
+              "refId": "A",
+              "tableType": "spans"
+            }
+          ],
+          "title": "Processing workflows",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Trace Service"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 115
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Trace Name"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 109
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Start time"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 166
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "11.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "tempo",
+                "uid": "tempo"
+              },
+              "limit": 20,
+              "query": "{name=\"api\"}",
+              "queryType": "traceql",
+              "refId": "A",
+              "tableType": "spans"
+            }
+          ],
+          "title": "API requests",
+          "type": "table"
+        }
+      ],
+      "refresh": "",
+      "schemaVersion": 39,
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Home",
+      "uid": "de0u0l0scrri8e",
+      "version": 1,
+      "weekStart": "monday"
+    }
 ---
 # Source: grafana/templates/clusterrole.yaml
 kind: ClusterRole
@@ -171,7 +498,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "docker.io/grafana/grafana:10.3.3"
+          image: "docker.io/grafana/grafana:11.2.2"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -181,14 +508,20 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           volumeMounts:
-            - name: config
-              mountPath: "/etc/grafana/grafana.ini"
-              subPath: grafana.ini
             - name: storage
               mountPath: "/var/lib/grafana"
             - name: config
+              mountPath: "/etc/grafana/grafana.ini"
+              subPath: grafana.ini
+            - name: config
+              mountPath: "/etc/grafana/provisioning/dashboards/default.yaml"
+              subPath: "default.yaml"
+            - name: config
               mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
               subPath: "datasources.yaml"
+            - name: config
+              mountPath: "/var/lib/grafana/dashboards/home.json"
+              subPath: "home.json"
           ports:
             - name: grafana
               containerPort: 3000

--- a/hack/kube/components/dev/keycloak.yaml
+++ b/hack/kube/components/dev/keycloak.yaml
@@ -202,6 +202,16 @@ data:
           "secret": "K5do3lZeHEzR3ajzCEudH4OGe7KWUmfe",
           "redirectUris": ["http://localhost:7460/oauth_callback"],
           "protocol": "openid-connect"
+        },
+        {
+          "id": "42c7a9e6-d81c-4b3f-aaeb-32de8dea0bf2",
+          "clientId": "grafana",
+          "name": "Grafana",
+          "enabled": true,
+          "secret": "wi8sSTRwP5lA2NuogV5bL6GmIyzVF2HP",
+          "redirectUris": ["http://localhost:7490/login/generic_oauth"],
+          "protocol": "openid-connect",
+          "directAccessGrantsEnabled": true
         }
       ],
       "clientScopes": [


### PR DESCRIPTION
This pull request updates the config of Grafana to present a new Home dashboard as the landing page. The dashboard itself is simple for now, showing a hello message and a couple of tables with recent spans (processing workflows and API requests).

OAuth2 authentication has been configured in Grafana.

### Screenshots

![image](https://github.com/user-attachments/assets/fec5d0be-7dee-478b-a295-bd5c6d8a0b15)

![image](https://github.com/user-attachments/assets/a4f5b915-50ec-4df1-b8ee-a0690dbe54a1)
