### PR TITLE
Optimize Makefile with lazy evaluation of packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,9 @@ IGNORED_PACKAGES := \
 	github.com/artefactual-sdps/enduro/internal/storage/persistence/ent/db \
 	github.com/artefactual-sdps/enduro/internal/storage/persistence/ent/db/% \
 	github.com/artefactual-sdps/enduro/internal/storage/persistence/ent/schema
-PACKAGES := $(shell go list ./...)
-TEST_PACKAGES := $(filter-out $(IGNORED_PACKAGES),$(PACKAGES))
-TEST_IGNORED_PACKAGES := $(filter $(IGNORED_PACKAGES),$(PACKAGES))
+PACKAGES = $(shell go list ./...)
+TEST_PACKAGES = $(filter-out $(IGNORED_PACKAGES),$(PACKAGES))
+TEST_IGNORED_PACKAGES = $(filter $(IGNORED_PACKAGES),$(PACKAGES))
 
 
 


### PR DESCRIPTION
This commit updates the declarations of `PACKAGES` and related variables in the Makefile to implement lazy loading, so the computation is deferred until they are actually needed.

Running commands like `make help` should now be faster (~80ms compared to ~500ms).