### PR TITLE
Enable Tempo metrics generator

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -126,7 +126,7 @@ if PRES_SYS == 'am':
   k8s_resource("mysql-create-amss-location", labels=["Tools"])
 
 # Observability
-k8s_resource("grafana-agent", labels=["Observability"])
+k8s_resource("grafana-alloy", labels=["Observability"])
 k8s_resource("grafana-tempo", labels=["Observability"])
 k8s_resource("grafana", port_forwards="7490:3000", labels=["Observability"])
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -126,6 +126,7 @@ if PRES_SYS == 'am':
   k8s_resource("mysql-create-amss-location", labels=["Tools"])
 
 # Observability
+k8s_resource("prometheus-server", port_forwards="7491:9090", labels=["Observability"])
 k8s_resource("grafana-alloy", labels=["Observability"])
 k8s_resource("grafana-tempo", labels=["Observability"])
 k8s_resource("grafana", port_forwards="7490:3000", labels=["Observability"])

--- a/hack/kube/base/enduro.yaml
+++ b/hack/kube/base/enduro.yaml
@@ -67,7 +67,7 @@ spec:
             - name: ENDURO_TELEMETRY_TRACES_ENABLED
               value: "true"
             - name: ENDURO_TELEMETRY_TRACES_ADDRESS
-              value: "grafana-agent.enduro-sdps:4317"
+              value: "grafana-alloy.enduro-sdps:4317"
             - name: ENDURO_TELEMETRY_TRACES_SAMPLING_RATIO
               value: "1.0"
           ports:

--- a/hack/kube/components/dev/grafana-alloy.yaml
+++ b/hack/kube/components/dev/grafana-alloy.yaml
@@ -1,25 +1,26 @@
-# Generated with `helm template grafana/grafana-agent --set=agent.mode=flow --set=controller.type=statefulset` and modified.
+# Generated with `helm template grafana/alloy --name-template=grafana-alloy --set=controller.type=statefulset --set=configReloader.enabled=false --set=crds.create=false`.
 ---
-# Source: grafana-agent/templates/serviceaccount.yaml
+# Source: alloy/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: grafana-agent
+  name: grafana-alloy
+  namespace: enduro-sdps
   labels:
-    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/name: grafana-alloy
 ---
-# Source: grafana-agent/templates/configmap.yaml
+# Source: alloy/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-agent
+  name: grafana-alloy
   labels:
-    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/name: grafana-alloy
 data:
-  config.river: |-
+  config.alloy: |-
     logging {
-      level  = "info"
-      format = "logfmt"
+    	level  = "info"
+    	format = "logfmt"
     }
 
     otelcol.receiver.otlp "default" {
@@ -54,36 +55,36 @@ data:
     }
 
     discovery.kubernetes "pods" {
-      role = "pod"
+    	role = "pod"
     }
 
     discovery.kubernetes "nodes" {
-      role = "node"
+    	role = "node"
     }
 
     discovery.kubernetes "services" {
-      role = "service"
+    	role = "service"
     }
 
     discovery.kubernetes "endpoints" {
-      role = "endpoints"
+    	role = "endpoints"
     }
 
     discovery.kubernetes "endpointslices" {
-      role = "endpointslice"
+    	role = "endpointslice"
     }
 
     discovery.kubernetes "ingresses" {
-      role = "ingress"
+    	role = "ingress"
     }
 ---
-# Source: grafana-agent/templates/rbac.yaml
+# Source: alloy/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: grafana-agent
+  name: grafana-alloy
   labels:
-    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/name: grafana-alloy
 rules:
   # Rules which allow discovery.kubernetes to function.
   - apiGroups:
@@ -162,38 +163,46 @@ rules:
       - get
       - list
       - watch
+  # needed for otelcol.processor.k8sattributes
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
 ---
-# Source: grafana-agent/templates/rbac.yaml
+# Source: alloy/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: grafana-agent
+  name: grafana-alloy
   labels:
-    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/name: grafana-alloy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: grafana-agent
+  name: grafana-alloy
 subjects:
   - kind: ServiceAccount
-    name: grafana-agent
+    name: grafana-alloy
     namespace: enduro-sdps
 ---
-# Source: grafana-agent/templates/service.yaml
+# Source: alloy/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: grafana-agent
+  name: grafana-alloy
   labels:
-    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/name: grafana-alloy
 spec:
   type: ClusterIP
   selector:
-    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/name: grafana-alloy
+  internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 80
-      targetPort: 80
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"
     - name: otlp-grpc
       port: 4317
@@ -204,77 +213,62 @@ spec:
       targetPort: 4318
       protocol: "TCP"
 ---
-# Source: grafana-agent/templates/controllers/statefulset.yaml
+# Source: alloy/templates/controllers/statefulset.yaml
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: grafana-agent
+  name: grafana-alloy
   labels:
-    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/name: grafana-alloy
 spec:
   replicas: 1
   podManagementPolicy: Parallel
   minReadySeconds: 10
-  serviceName: grafana-agent
+  serviceName: grafana-alloy
   selector:
     matchLabels:
-      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/name: grafana-alloy
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: grafana-alloy
       labels:
-        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/name: grafana-alloy
     spec:
-      serviceAccountName: grafana-agent
+      serviceAccountName: grafana-alloy
       containers:
-        - name: grafana-agent
-          image: docker.io/grafana/agent:v0.38.1
+        - name: grafana-alloy
+          image: docker.io/grafana/alloy:v1.4.2
           imagePullPolicy: IfNotPresent
           args:
             - run
-            - /etc/agent/config.river
-            - --storage.path=/tmp/agent
-            - --server.http.listen-addr=0.0.0.0:80
+            - /etc/alloy/config.alloy
+            - --storage.path=/tmp/alloy
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --disable-reporting
+            - --stability.level=generally-available
           env:
-            - name: AGENT_MODE
-              value: flow
-            - name: AGENT_DEPLOY_MODE
+            - name: ALLOY_DEPLOY_MODE
               value: "helm"
             - name: HOSTNAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 80
+            - containerPort: 12345
               name: http-metrics
-            - containerPort: 4317
-              name: otlp-grpc
-            - containerPort: 4318
-              name: otlp-http
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 80
+              port: 12345
+              scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
           volumeMounts:
             - name: config
-              mountPath: /etc/agent
-        - name: config-reloader
-          image: docker.io/jimmidyson/configmap-reload:v0.8.0
-          args:
-            - --volume-dir=/etc/agent
-            - --webhook-url=http://localhost:80/-/reload
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-          resources:
-            requests:
-              cpu: 1m
-              memory: 5Mi
+              mountPath: /etc/alloy
       dnsPolicy: ClusterFirst
       volumes:
         - name: config
           configMap:
-            name: grafana-agent
+            name: grafana-alloy

--- a/hack/kube/components/dev/grafana-tempo.yaml
+++ b/hack/kube/components/dev/grafana-tempo.yaml
@@ -41,6 +41,35 @@ data:
           path: /var/tempo/traces
         wal:
           path: /var/tempo/wal
+    metrics_generator:
+      storage:
+        path: /var/tempo/generator-wal
+        remote_write:
+        - url: http://prometheus-server.enduro-sdps:9090/api/v1/write
+          send_exemplars: true
+      traces_storage:
+        path: /var/tempo/generator-traces
+      processor:
+        service_graphs:
+          dimensions:
+          - http.method
+          - http.target
+          - http.status_code
+          - service.version
+        span_metrics:
+          dimensions:
+          - http.method
+          - http.target
+          - http.status_code
+          - service.version
+      registry:
+        collection_interval: 5s
+        external_labels:
+          source: tempo
+    overrides:
+      metrics_generator_processors:
+      - service-graphs
+      - span-metrics
 ---
 # Source: tempo/templates/service.yaml
 apiVersion: v1

--- a/hack/kube/components/dev/grafana.yaml
+++ b/hack/kube/components/dev/grafana.yaml
@@ -136,7 +136,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 3,
+      "id": 1,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -221,7 +221,7 @@ data:
           },
           "gridPos": {
             "h": 5,
-            "w": 4,
+            "w": 24,
             "x": 0,
             "y": 5
           },
@@ -298,7 +298,7 @@ data:
           },
           "gridPos": {
             "h": 11,
-            "w": 24,
+            "w": 12,
             "x": 0,
             "y": 10
           },
@@ -406,10 +406,10 @@ data:
             ]
           },
           "gridPos": {
-            "h": 13,
-            "w": 24,
-            "x": 0,
-            "y": 21
+            "h": 11,
+            "w": 12,
+            "x": 12,
+            "y": 10
           },
           "id": 3,
           "options": {
@@ -441,6 +441,41 @@ data:
           ],
           "title": "API requests",
           "type": "table"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "gridPos": {
+            "h": 17,
+            "w": 24,
+            "x": 0,
+            "y": 21
+          },
+          "id": 6,
+          "options": {
+            "edges": {},
+            "nodes": {}
+          },
+          "pluginVersion": "11.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "tempo",
+                "uid": "tempo"
+              },
+              "hide": false,
+              "limit": 20,
+              "query": "{}",
+              "queryType": "serviceMap",
+              "refId": "A",
+              "tableType": "traces"
+            }
+          ],
+          "title": "Service graph",
+          "type": "nodeGraph"
         }
       ],
       "refresh": "",

--- a/hack/kube/components/dev/grafana.yaml
+++ b/hack/kube/components/dev/grafana.yaml
@@ -78,11 +78,29 @@ data:
       jsonData:
         httpMethod: GET
         tlsSkipVerify: true
+        tracesToMetrics:
+          datasourceUid: 'prometheus'
+        serviceMap:
+          datasourceUid: 'prometheus'
       name: Tempo
       orgId: 1
       type: tempo
       uid: tempo
       url: http://grafana-tempo:3200
+      version: 1
+    - access: proxy
+      apiVersion: 1
+      basicAuth: false
+      editable: false
+      isDefault: false
+      jsonData:
+        httpMethod: GET
+        tlsSkipVerify: true
+      name: Prometheus
+      orgId: 1
+      type: prometheus
+      uid: prometheus
+      url: http://prometheus-server.enduro-sdps:9090
       version: 1
   default.yaml: |
     apiVersion: 1

--- a/hack/kube/components/dev/grafana.yaml
+++ b/hack/kube/components/dev/grafana.yaml
@@ -147,7 +147,7 @@ data:
           },
           "description": "",
           "gridPos": {
-            "h": 7,
+            "h": 4,
             "w": 24,
             "x": 0,
             "y": 0
@@ -184,12 +184,82 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 7
+            "y": 4
           },
           "id": 2,
           "panels": [],
           "title": "Traces and spans",
           "type": "row"
+        },
+        {
+          "datasource": {
+            "default": false,
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 4,
+            "x": 0,
+            "y": 5
+          },
+          "id": 5,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum(traces_spanmetrics_size_total)",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of spans",
+          "type": "stat"
         },
         {
           "datasource": {
@@ -224,50 +294,13 @@ data:
                 ]
               }
             },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Trace Service"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 118
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Trace Name"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 107
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Start time"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 160
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
-            "h": 12,
-            "w": 12,
+            "h": 11,
+            "w": 24,
             "x": 0,
-            "y": 8
+            "y": 10
           },
           "id": 4,
           "options": {
@@ -373,10 +406,10 @@ data:
             ]
           },
           "gridPos": {
-            "h": 12,
-            "w": 12,
-            "x": 12,
-            "y": 8
+            "h": 13,
+            "w": 24,
+            "x": 0,
+            "y": 21
           },
           "id": 3,
           "options": {

--- a/hack/kube/components/dev/kustomization.yaml
+++ b/hack/kube/components/dev/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - minio-secret.yaml
   - mysql-secret.yaml
   - temporal-ui-secret.yaml
+  - prometheus.yaml
   - grafana-alloy.yaml
   - grafana-tempo.yaml
   - grafana.yaml

--- a/hack/kube/components/dev/kustomization.yaml
+++ b/hack/kube/components/dev/kustomization.yaml
@@ -8,6 +8,6 @@ resources:
   - minio-secret.yaml
   - mysql-secret.yaml
   - temporal-ui-secret.yaml
-  - grafana-agent.yaml
+  - grafana-alloy.yaml
   - grafana-tempo.yaml
   - grafana.yaml

--- a/hack/kube/components/dev/prometheus.yaml
+++ b/hack/kube/components/dev/prometheus.yaml
@@ -1,0 +1,515 @@
+# Generated with `helm template prometheus-community/prometheus --name-template=prometheus --set=alertmanager.enabled=false --set=kube-state-metrics.enabled=false --set=prometheus-node-exporter.enabled=false --set=prometheus-pushgateway.enabled=false --set=configmapReload.prometheus.enabled=false` and modified.
+---
+# Source: prometheus/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus
+  name: prometheus-server
+  namespace: enduro-sdps
+  annotations:
+    {}
+---
+# Source: prometheus/templates/cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus
+  name: prometheus-server
+  namespace: enduro-sdps
+data:
+  allow-snippet-annotations: "false"
+  alerting_rules.yml: |
+    {}
+  alerts: |
+    {}
+  prometheus.yml: |
+    global:
+      evaluation_interval: 1m
+      scrape_interval: 1m
+      scrape_timeout: 10s
+    rule_files:
+    - /etc/config/recording_rules.yml
+    - /etc/config/alerting_rules.yml
+    - /etc/config/rules
+    - /etc/config/alerts
+    scrape_configs:
+    - job_name: prometheus
+      static_configs:
+      - targets:
+        - localhost:9090
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-apiservers
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: default;kubernetes;https
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-nodes
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - replacement: kubernetes.default.svc:443
+        target_label: __address__
+      - regex: (.+)
+        replacement: /api/v1/nodes/$1/proxy/metrics
+        source_labels:
+        - __meta_kubernetes_node_name
+        target_label: __metrics_path__
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-nodes-cadvisor
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - replacement: kubernetes.default.svc:443
+        target_label: __address__
+      - regex: (.+)
+        replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+        source_labels:
+        - __meta_kubernetes_node_name
+        target_label: __metrics_path__
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - honor_labels: true
+      job_name: kubernetes-service-endpoints
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape
+      - action: drop
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (.+?)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        source_labels:
+        - __address__
+        - __meta_kubernetes_service_annotation_prometheus_io_port
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+    - honor_labels: true
+      job_name: kubernetes-service-endpoints-slow
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (.+?)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        source_labels:
+        - __address__
+        - __meta_kubernetes_service_annotation_prometheus_io_port
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+      scrape_interval: 5m
+      scrape_timeout: 30s
+    - honor_labels: true
+      job_name: prometheus-pushgateway
+      kubernetes_sd_configs:
+      - role: service
+      relabel_configs:
+      - action: keep
+        regex: pushgateway
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_probe
+    - honor_labels: true
+      job_name: kubernetes-services
+      kubernetes_sd_configs:
+      - role: service
+      metrics_path: /probe
+      params:
+        module:
+        - http_2xx
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_probe
+      - source_labels:
+        - __address__
+        target_label: __param_target
+      - replacement: blackbox
+        target_label: __address__
+      - source_labels:
+        - __param_target
+        target_label: instance
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+    - honor_labels: true
+      job_name: kubernetes-pods
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+      - action: drop
+        regex: true
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+        replacement: '[$2]:$1'
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: replace
+        regex: (\d+);((([0-9]+?)(\.|$)){4})
+        replacement: $2:$1
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: pod
+      - action: drop
+        regex: Pending|Succeeded|Failed|Completed
+        source_labels:
+        - __meta_kubernetes_pod_phase
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+    - honor_labels: true
+      job_name: kubernetes-pods-slow
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+        replacement: '[$2]:$1'
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: replace
+        regex: (\d+);((([0-9]+?)(\.|$)){4})
+        replacement: $2:$1
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: pod
+      - action: drop
+        regex: Pending|Succeeded|Failed|Completed
+        source_labels:
+        - __meta_kubernetes_pod_phase
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+      scrape_interval: 5m
+      scrape_timeout: 30s
+  recording_rules.yml: |
+    {}
+  rules: |
+    {}
+---
+# Source: prometheus/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus
+  name: prometheus-server
+  namespace: enduro-sdps
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "8Gi"
+---
+# Source: prometheus/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus
+  name: prometheus-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - ingresses
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses/status
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get
+---
+# Source: prometheus/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus
+  name: prometheus-server
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-server
+    namespace: enduro-sdps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-server
+---
+# Source: prometheus/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus
+  name: prometheus-server
+  namespace: enduro-sdps
+spec:
+  ports:
+    - name: http
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    app.kubernetes.io/name: prometheus
+  sessionAffinity: None
+  type: "ClusterIP"
+---
+# Source: prometheus/templates/deploy.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: prometheus
+  name: prometheus-server
+  namespace: enduro-sdps
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  replicas: 1
+  revisionHistoryLimit: 10
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus
+    spec:
+      enableServiceLinks: true
+      serviceAccountName: prometheus-server
+      containers:
+        - name: prometheus-server
+          image: "quay.io/prometheus/prometheus:v2.54.1"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --storage.tsdb.retention.time=15d
+            - --config.file=/etc/config/prometheus.yml
+            - --storage.tsdb.path=/data
+            - --web.console.libraries=/etc/prometheus/console_libraries
+            - --web.console.templates=/etc/prometheus/consoles
+            - --web.enable-lifecycle
+          ports:
+            - containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 4
+            failureThreshold: 3
+            successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+            successThreshold: 1
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+            - name: storage-volume
+              mountPath: /data
+              subPath: ""
+      dnsPolicy: ClusterFirst
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      terminationGracePeriodSeconds: 300
+      volumes:
+        - name: config-volume
+          configMap:
+            name: prometheus-server
+        - name: storage-volume
+          persistentVolumeClaim:
+            claimName: prometheus-server

--- a/hack/kube/components/dev/prometheus.yaml
+++ b/hack/kube/components/dev/prometheus.yaml
@@ -36,6 +36,10 @@ data:
     - /etc/config/rules
     - /etc/config/alerts
     scrape_configs:
+    - job_name: tempo
+      static_configs:
+      - targets:
+        - grafana-tempo.enduro-sdps:3200
     - job_name: prometheus
       static_configs:
       - targets:
@@ -471,6 +475,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --web.enable-lifecycle
+            - --web.enable-remote-write-receiver
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/hack/kube/overlays/dev-a3m/enduro-a3m.yaml
+++ b/hack/kube/overlays/dev-a3m/enduro-a3m.yaml
@@ -70,7 +70,7 @@ spec:
             - name: ENDURO_TELEMETRY_TRACES_ENABLED
               value: "true"
             - name: ENDURO_TELEMETRY_TRACES_ADDRESS
-              value: "grafana-agent.enduro-sdps:4317"
+              value: "grafana-alloy.enduro-sdps:4317"
             - name: ENDURO_TELEMETRY_TRACES_SAMPLING_RATIO
               value: "1.0"
           volumeMounts:

--- a/hack/kube/overlays/dev-am/enduro-am.yaml
+++ b/hack/kube/overlays/dev-am/enduro-am.yaml
@@ -118,7 +118,7 @@ spec:
             - name: ENDURO_TELEMETRY_TRACES_ENABLED
               value: "true"
             - name: ENDURO_TELEMETRY_TRACES_ADDRESS
-              value: "grafana-agent.enduro-sdps:4317"
+              value: "grafana-alloy.enduro-sdps:4317"
             - name: ENDURO_TELEMETRY_TRACES_SAMPLING_RATIO
               value: "1.0"
           volumeMounts:


### PR DESCRIPTION
This pull request installs Prometheus in the development environment so we can start capturing application metrics (as opposed to logs or traces). It also enables the [metrics generator](https://grafana.com/docs/tempo/latest/metrics-generator/) in Grafana Tempo, which is a mechanism that derives metrics from ingested traces and store them in Prometheus. These metrics are useful in a couple of main ways: [span metrics](https://grafana.com/docs/tempo/latest/metrics-generator/service_graphs/) and [service graphs](https://grafana.com/docs/tempo/latest/metrics-generator/service_graphs/).

The Prometheus datasource in Grafana has been configured with [exemplars](https://grafana.com/docs/grafana/latest/fundamentals/exemplars/) enabled, so you should be able to associate trace data with metric data, something that we can start exploring further once we start producing application metrics.

I've updated the dashboard with a simple service view panel:

![image](https://github.com/user-attachments/assets/492ec443-147e-41e5-95b4-966dac866eac)