### PR TITLE
Implement CreatePreservationTasks with CreateBulk

### DIFF
--- a/internal/persistence/ent/client/batch.go
+++ b/internal/persistence/ent/client/batch.go
@@ -1,0 +1,31 @@
+package entclient
+
+import "iter"
+
+var defaultBatchSize = 100
+
+// batch groups elements from the provided sequence into batches of size
+// defaultBatchSize, yielding a stream of slices, each containing at most
+// defaultBatchSize elements, except for the last batch which may contain fewer.
+// Note that the slices are reused internally to minimize allocations, so they
+// should not be retained or modified after being yielded to avoid unexpected
+// behavior.
+func batch[T any](seq iter.Seq[T]) iter.Seq[[]T] {
+	return func(yield func([]T) bool) {
+		b := make([]T, 0, defaultBatchSize)
+		seq(func(a T) bool {
+			b = append(b, a)
+			if len(b) == defaultBatchSize {
+				if !yield(b) {
+					return false
+				}
+
+				b = b[:0]
+			}
+			return true
+		})
+		if len(b) != 0 {
+			yield(b)
+		}
+	}
+}

--- a/internal/persistence/ent/client/batch.go
+++ b/internal/persistence/ent/client/batch.go
@@ -13,19 +13,19 @@ var defaultBatchSize = 100
 func batch[T any](seq iter.Seq[T]) iter.Seq[[]T] {
 	return func(yield func([]T) bool) {
 		b := make([]T, 0, defaultBatchSize)
-		seq(func(a T) bool {
+		for a := range seq {
 			b = append(b, a)
 			if len(b) == defaultBatchSize {
 				if !yield(b) {
-					return false
+					return
 				}
-
 				b = b[:0]
 			}
-			return true
-		})
+		}
 		if len(b) != 0 {
-			yield(b)
+			if !yield(b) {
+				return
+			}
 		}
 	}
 }

--- a/internal/persistence/ent/client/batch_test.go
+++ b/internal/persistence/ent/client/batch_test.go
@@ -1,0 +1,71 @@
+package entclient
+
+import (
+	"slices"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestBatch(t *testing.T) {
+	original := defaultBatchSize
+
+	tests := map[string]struct {
+		size     int
+		values   []int
+		expected [][]int
+	}{
+		"batch size 1": {
+			size:     1,
+			values:   []int{1, 2, 3},
+			expected: [][]int{{1}, {2}, {3}},
+		},
+		"batch size 2 with exact fit": {
+			size:     2,
+			values:   []int{1, 2, 3, 4},
+			expected: [][]int{{1, 2}, {3, 4}},
+		},
+		"batch size 2 with remainder": {
+			size:     2,
+			values:   []int{1, 2, 3},
+			expected: [][]int{{1, 2}, {3}},
+		},
+		"batch size larger than input": {
+			size:     5,
+			values:   []int{1, 2, 3},
+			expected: [][]int{{1, 2, 3}},
+		},
+		"empty input": {
+			size:     2,
+			values:   []int{},
+			expected: [][]int{},
+		},
+		"batch size 3 with partial last batch": {
+			size:     3,
+			values:   []int{1, 2, 3, 4, 5},
+			expected: [][]int{{1, 2, 3}, {4, 5}},
+		},
+		"batch size equals input length": {
+			size:     3,
+			values:   []int{1, 2, 3},
+			expected: [][]int{{1, 2, 3}},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			defaultBatchSize = tc.size
+			seq := batch(slices.Values(tc.values))
+
+			ret := [][]int{}
+			for item := range seq {
+				cp := make([]int, len(item))
+				copy(cp, item)
+				ret = append(ret, cp)
+			}
+
+			assert.DeepEqual(t, ret, tc.expected)
+		})
+	}
+
+	defaultBatchSize = original
+}

--- a/internal/persistence/ent/client/preservation_task.go
+++ b/internal/persistence/ent/client/preservation_task.go
@@ -2,47 +2,22 @@ package entclient
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/artefactual-sdps/enduro/internal/datatypes"
+	"github.com/artefactual-sdps/enduro/internal/enums"
 	"github.com/artefactual-sdps/enduro/internal/persistence"
+	"github.com/artefactual-sdps/enduro/internal/persistence/ent/db"
 )
 
 func (c *client) CreatePreservationTask(ctx context.Context, pt *datatypes.PreservationTask) error {
-	// Validate required fields.
-	taskID, err := uuid.Parse(pt.TaskID)
+	q, err := createPreservationTaskBuilder(c.ent.PreservationTask, pt)
 	if err != nil {
-		return newParseError(err, "TaskID")
+		return err
 	}
-	if pt.Name == "" {
-		return newRequiredFieldError("Name")
-	}
-	if pt.PreservationActionID == 0 {
-		return newRequiredFieldError("PreservationActionID")
-	}
-	// TODO: Validate Status.
-
-	// Handle nullable fields.
-	var startedAt *time.Time
-	if pt.StartedAt.Valid {
-		startedAt = &pt.StartedAt.Time
-	}
-
-	var completedAt *time.Time
-	if pt.CompletedAt.Valid {
-		completedAt = &pt.CompletedAt.Time
-	}
-
-	q := c.ent.PreservationTask.Create().
-		SetTaskID(taskID).
-		SetName(pt.Name).
-		SetStatus(int8(pt.Status)). // #nosec G115 -- constrained value.
-		SetNillableStartedAt(startedAt).
-		SetNillableCompletedAt(completedAt).
-		SetNote(pt.Note).
-		SetPreservationActionID(int(pt.PreservationActionID))
 
 	r, err := q.Save(ctx)
 	if err != nil {
@@ -53,6 +28,33 @@ func (c *client) CreatePreservationTask(ctx context.Context, pt *datatypes.Prese
 	*pt = *convertPreservationTask(r)
 
 	return nil
+}
+
+func (c *client) CreatePreservationTasks(
+	ctx context.Context,
+	seq func(yield func(*datatypes.PreservationTask) bool),
+) ([]*datatypes.PreservationTask, error) {
+	ret := make([]*datatypes.PreservationTask, 0, defaultBatchSize)
+
+	for pts := range batch(seq) {
+		builders := make([]*db.PreservationTaskCreate, len(pts))
+		for i, pt := range pts {
+			op, err := createPreservationTaskBuilder(c.ent.PreservationTask, pt)
+			if err != nil {
+				return nil, err
+			}
+			builders[i] = op
+		}
+		if pts, err := c.ent.PreservationTask.CreateBulk(builders...).Save(ctx); err != nil {
+			return nil, err
+		} else {
+			for _, pt := range pts {
+				ret = append(ret, convertPreservationTask(pt))
+			}
+		}
+	}
+
+	return ret, nil
 }
 
 func (c *client) UpdatePreservationTask(
@@ -105,4 +107,47 @@ func (c *client) UpdatePreservationTask(
 	}
 
 	return convertPreservationTask(pt), nil
+}
+
+func createPreservationTaskBuilder(
+	c *db.PreservationTaskClient,
+	pt *datatypes.PreservationTask,
+) (*db.PreservationTaskCreate, error) {
+	// Validate required fields.
+	taskID, err := uuid.Parse(pt.TaskID)
+	if err != nil {
+		return nil, newParseError(err, "TaskID")
+	}
+	if pt.Name == "" {
+		return nil, newRequiredFieldError("Name")
+	}
+	if pt.PreservationActionID == 0 {
+		return nil, newRequiredFieldError("PreservationActionID")
+	}
+
+	status := enums.PreservationTaskStatus(uint(pt.Status))
+	if !status.IsValid() {
+		return nil, newParseError(errors.New("invalid"), "Status")
+	}
+
+	// Handle nullable fields.
+	var startedAt *time.Time
+	if pt.StartedAt.Valid {
+		startedAt = &pt.StartedAt.Time
+	}
+	var completedAt *time.Time
+	if pt.CompletedAt.Valid {
+		completedAt = &pt.CompletedAt.Time
+	}
+
+	op := c.Create().
+		SetTaskID(taskID).
+		SetName(pt.Name).
+		SetStatus(int8(status)). // #nosec G115 -- constrained value.
+		SetNillableStartedAt(startedAt).
+		SetNillableCompletedAt(completedAt).
+		SetNote(pt.Note).
+		SetPreservationActionID(int(pt.PreservationActionID))
+
+	return op, nil
 }

--- a/internal/persistence/fake/mock_persistence.go
+++ b/internal/persistence/fake/mock_persistence.go
@@ -155,6 +155,45 @@ func (c *MockServiceCreatePreservationTaskCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
+// CreatePreservationTasks mocks base method.
+func (m *MockService) CreatePreservationTasks(arg0 context.Context, arg1 func(func(*datatypes.PreservationTask) bool)) ([]*datatypes.PreservationTask, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreatePreservationTasks", arg0, arg1)
+	ret0, _ := ret[0].([]*datatypes.PreservationTask)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreatePreservationTasks indicates an expected call of CreatePreservationTasks.
+func (mr *MockServiceMockRecorder) CreatePreservationTasks(arg0, arg1 any) *MockServiceCreatePreservationTasksCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePreservationTasks", reflect.TypeOf((*MockService)(nil).CreatePreservationTasks), arg0, arg1)
+	return &MockServiceCreatePreservationTasksCall{Call: call}
+}
+
+// MockServiceCreatePreservationTasksCall wrap *gomock.Call
+type MockServiceCreatePreservationTasksCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockServiceCreatePreservationTasksCall) Return(arg0 []*datatypes.PreservationTask, arg1 error) *MockServiceCreatePreservationTasksCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockServiceCreatePreservationTasksCall) Do(f func(context.Context, func(func(*datatypes.PreservationTask) bool)) ([]*datatypes.PreservationTask, error)) *MockServiceCreatePreservationTasksCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockServiceCreatePreservationTasksCall) DoAndReturn(f func(context.Context, func(func(*datatypes.PreservationTask) bool)) ([]*datatypes.PreservationTask, error)) *MockServiceCreatePreservationTasksCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListPackages mocks base method.
 func (m *MockService) ListPackages(arg0 context.Context, arg1 *persistence.PackageFilter) ([]*datatypes.Package, *persistence.Page, error) {
 	m.ctrl.T.Helper()

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -34,5 +34,9 @@ type Service interface {
 	CreatePreservationAction(context.Context, *datatypes.PreservationAction) error
 
 	CreatePreservationTask(context.Context, *datatypes.PreservationTask) error
+	CreatePreservationTasks(
+		context.Context,
+		func(yield func(*datatypes.PreservationTask) bool),
+	) ([]*datatypes.PreservationTask, error)
 	UpdatePreservationTask(ctx context.Context, id int, updater PresTaskUpdater) (*datatypes.PreservationTask, error)
 }

--- a/internal/persistence/telemetry.go
+++ b/internal/persistence/telemetry.go
@@ -97,6 +97,22 @@ func (w *wrapper) CreatePreservationTask(ctx context.Context, pt *datatypes.Pres
 	return nil
 }
 
+func (w *wrapper) CreatePreservationTasks(
+	ctx context.Context,
+	seq func(yield func(*datatypes.PreservationTask) bool),
+) ([]*datatypes.PreservationTask, error) {
+	ctx, span := w.tracer.Start(ctx, "CreatePreservationTasks")
+	defer span.End()
+
+	r, err := w.wrapped.CreatePreservationTasks(ctx, seq)
+	if err != nil {
+		telemetry.RecordError(span, err)
+		return nil, updateError(err, "CreatePreservationTasks")
+	}
+
+	return r, nil
+}
+
 func (w *wrapper) UpdatePreservationTask(
 	ctx context.Context,
 	id int,


### PR DESCRIPTION
This PR explores a new pattern for handling bulk database operations using [Go 1.23's range-over-function feature](https://tip.golang.org/doc/go1.23#language). It introduces a new `CreatePreservationTasks` method in the persistence package, which accepts a generator of preservation tasks ([`iter.Seq[*datatype.PreservationTask]`](https://pkg.go.dev/iter#Seq)). The method utilizes the `batch` function to group tasks into manageable batches and leverages [`CreateBulk`]((https://entgo.io/docs/crud/#create-many)) to perform efficient bulk inserts in a single INSERT operation.

To view the main idea of this proposal in isolation, visit: https://go.dev/play/p/y7tYvD7NO28.

In future PRs, this new function could be used in areas like CreateAIPActivity and JobTracker to improve bulk task creation.