### PR TITLE
Add a package list status filter

### DIFF
--- a/dashboard/src/pages/packages/index.vue
+++ b/dashboard/src/pages/packages/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { PackageListStatusEnum } from "@/openapi-generator";
 import PackageListLegend from "@/components/PackageListLegend.vue";
 import PageLoadingAlert from "@/components/PageLoadingAlert.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
@@ -50,6 +51,24 @@ const toggleLegend = () => {
       Showing {{ packageStore.page.offset + 1 }} -
       {{ packageStore.lastResultOnPage }} of
       {{ packageStore.page.total }}
+    </div>
+
+    <div class="d-flex flex-wrap gap-3 mb-3 p-3 border bg-light">
+      <h3 class="mb-0 pe-3 border-end">Filters</h3>
+      <div class="d-flex gap-2">
+        <label for="filter-status" class="align-self-center">Status</label>
+        <select
+          id="filter-status"
+          v-model="packageStore.filters.status"
+          @change="packageStore.fetchPackages(1)"
+          class="form-select"
+        >
+          <option value="">any</option>
+          <option v-for="item of PackageListStatusEnum" :value="item">
+            {{ item }}
+          </option>
+        </select>
+      </div>
     </div>
 
     <PageLoadingAlert :execute="execute" :error="error" />

--- a/dashboard/src/stores/package.ts
+++ b/dashboard/src/stores/package.ts
@@ -1,5 +1,8 @@
 import { api, client } from "@/client";
-import { MonitorEventEventTypeEnum } from "@/openapi-generator";
+import {
+  MonitorEventEventTypeEnum,
+  PackageListStatusEnum,
+} from "@/openapi-generator";
 import { useLayoutStore } from "@/stores/layout";
 import router from "@/router";
 import { defineStore, acceptHMRUpdate } from "pinia";
@@ -43,6 +46,10 @@ export const usePackageStore = defineStore("package", {
     // User-interface interactions between components.
     ui: {
       download: new UIRequest(),
+    },
+
+    filters: {
+      status: "" as PackageListStatusEnum,
     },
   }),
   getters: {
@@ -164,6 +171,7 @@ export const usePackageStore = defineStore("package", {
       const resp = await client.package.packageList({
         offset: page > 1 ? (page - 1) * this.page.limit : undefined,
         limit: this.page?.limit || undefined,
+        status: this.filters.status ? this.filters.status : undefined,
       });
       this.packages = resp.items;
       this.page = resp.page;

--- a/dashboard/src/styles/bootstrap.scss
+++ b/dashboard/src/styles/bootstrap.scss
@@ -25,6 +25,7 @@
 @import "bootstrap/scss/tooltip";
 @import "bootstrap/scss/offcanvas";
 @import "bootstrap/scss/pagination";
+@import "bootstrap/scss/forms";
 
 // Utilities API last to generate classes based on the Sass map in `_utilities.scss`.
 @import "bootstrap/scss/utilities/api";


### PR DESCRIPTION
Fixes #989.

Add a package status filter select box to the Dashboard package list page to allow filtering packages by status.

Changes:
- Add a "filters" section to the package list page
- Add a "status" selector to the filters section
- Filter package list results when the "status" filter is changed