### PR TITLE
Add poststorage child workflows

### DIFF
--- a/enduro.toml
+++ b/enduro.toml
@@ -236,6 +236,12 @@ workflowName = "preprocessing"
 enabled = true
 xsdPath = "/home/enduro/premis.xsd"
 
+# Temporal configurations to trigger poststorage child workflows, allows multiple sections.
+# [[poststorage]]
+# namespace = "default"
+# taskQueue = "poststorage"
+# workflowName = "poststorage"
+
 [failedSips]
 endpoint = "http://minio.enduro-sdps:9000"
 pathStyle = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/db"
 	"github.com/artefactual-sdps/enduro/internal/event"
 	"github.com/artefactual-sdps/enduro/internal/package_"
+	"github.com/artefactual-sdps/enduro/internal/poststorage"
 	"github.com/artefactual-sdps/enduro/internal/premis"
 	"github.com/artefactual-sdps/enduro/internal/preprocessing"
 	"github.com/artefactual-sdps/enduro/internal/pres"
@@ -48,6 +49,7 @@ type Configuration struct {
 	Database        db.Config
 	Event           event.Config
 	ExtractActivity archiveextract.Config
+	Poststorage     []poststorage.Config
 	Preprocessing   preprocessing.Config
 	Preservation    pres.Config
 	Storage         storage.Config

--- a/internal/poststorage/poststorage.go
+++ b/internal/poststorage/poststorage.go
@@ -1,0 +1,11 @@
+package poststorage
+
+type Config struct {
+	Namespace    string
+	TaskQueue    string
+	WorkflowName string
+}
+
+type WorkflowParams struct {
+	AIPUUID string
+}


### PR DESCRIPTION
Allow to configure a set of poststorage child workflows that will be
started after AIP storage. These workflows will receive the AIPUUID
as a parameter and the parent workflow will only wait for them to be
started by Temporal. They are started with a disconnected context and
using the abandon parent close policy, so they can continue running
after the parent workflow finishes, therefore their results are ignored.

Refs #886.