### PR TITLE
Copy premis.xsd into enduro image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,30 +56,31 @@ FROM gcr.io/distroless/base-debian12:latest AS base
 USER 1000
 
 FROM base AS enduro
-COPY --from=build-enduro --link /out/enduro /home/enduro/bin/enduro
-COPY --from=build-enduro --link /src/enduro.toml /home/enduro/.config/enduro.toml
+COPY --link --from=build-enduro /out/enduro /home/enduro/bin/enduro
+COPY --link --from=build-enduro /src/enduro.toml /home/enduro/.config/enduro.toml
+COPY --link hack/xsd/premis.xsd /home/enduro/premis.xsd
 CMD ["/home/enduro/bin/enduro", "--config", "/home/enduro/.config/enduro.toml"]
 
 FROM base AS enduro-a3m-worker
-COPY --from=build-enduro-a3m-worker --link /out/enduro-a3m-worker /home/enduro/bin/enduro-a3m-worker
-COPY --from=build-enduro-a3m-worker --link /src/enduro.toml /home/enduro/.config/enduro.toml
+COPY --link --from=build-libxml /usr/bin/xmllint /usr/bin/xmllint
+COPY --link --from=build-libxml /usr/lib/libxml2.so.2 /usr/lib/libxml2.so.2
+COPY --link --from=build-libxml /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --link --from=build-libxml /lib/libz.so.1 /lib/libz.so.1
+COPY --link --from=build-libxml /usr/lib/liblzma.so.5 /usr/lib/liblzma.so.5
+COPY --link --from=build-enduro-a3m-worker /out/enduro-a3m-worker /home/enduro/bin/enduro-a3m-worker
+COPY --link --from=build-enduro-a3m-worker /src/enduro.toml /home/enduro/.config/enduro.toml
+COPY --link hack/xsd/premis.xsd /home/enduro/premis.xsd
 CMD ["/home/enduro/bin/enduro-a3m-worker", "--config", "/home/enduro/.config/enduro.toml"]
-COPY hack/xsd/premis.xsd /home/enduro/premis.xsd
-COPY --from=build-libxml /usr/bin/xmllint /usr/bin/xmllint
-COPY --from=build-libxml /usr/lib/libxml2.so.2 /usr/lib/libxml2.so.2
-COPY --from=build-libxml /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
-COPY --from=build-libxml /lib/libz.so.1 /lib/libz.so.1
-COPY --from=build-libxml /usr/lib/liblzma.so.5 /usr/lib/liblzma.so.5
 
 FROM base AS enduro-am-worker
-COPY --from=build-enduro-am-worker --link /out/enduro-am-worker /home/enduro/bin/enduro-am-worker
-COPY --from=build-enduro-am-worker --link /src/enduro.toml /home/enduro/.config/enduro.toml
+COPY --link --from=build-libxml /usr/bin/xmllint /usr/bin/xmllint
+COPY --link --from=build-libxml /usr/lib/libxml2.so.2 /usr/lib/libxml2.so.2
+COPY --link --from=build-libxml /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --link --from=build-libxml /lib/libz.so.1 /lib/libz.so.1
+COPY --link --from=build-libxml /usr/lib/liblzma.so.5 /usr/lib/liblzma.so.5
+COPY --link --from=build-enduro-am-worker /out/enduro-am-worker /home/enduro/bin/enduro-am-worker
+COPY --link --from=build-enduro-am-worker /src/enduro.toml /home/enduro/.config/enduro.toml
+COPY --link hack/xsd/premis.xsd /home/enduro/premis.xsd
 CMD ["/home/enduro/bin/enduro-am-worker", "--config", "/home/enduro/.config/enduro.toml"]
-COPY hack/xsd/premis.xsd /home/enduro/premis.xsd
-COPY --from=build-libxml /usr/bin/xmllint /usr/bin/xmllint
-COPY --from=build-libxml /usr/lib/libxml2.so.2 /usr/lib/libxml2.so.2
-COPY --from=build-libxml /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
-COPY --from=build-libxml /lib/libz.so.1 /lib/libz.so.1
-COPY --from=build-libxml /usr/lib/liblzma.so.5 /usr/lib/liblzma.so.5
 
 FROM ${TARGET}

--- a/enduro.toml
+++ b/enduro.toml
@@ -84,6 +84,10 @@ redisChannel = "enduro-events"
 dirMode = "0o700"
 fileMode = "0o600"
 
+[validatePremis]
+enabled = true
+xsdPath = "/home/enduro/premis.xsd"
+
 [watcher.embedded]
 name = "dev-minio"
 redisAddress = "redis://redis.enduro-sdps:6379"
@@ -231,10 +235,6 @@ sharedPath = "/home/enduro/preprocessing"
 namespace = "default"
 taskQueue = "preprocessing"
 workflowName = "preprocessing"
-
-[validatePremis]
-enabled = true
-xsdPath = "/home/enduro/premis.xsd"
 
 # Temporal configurations to trigger poststorage child workflows, allows multiple sections.
 # [[poststorage]]

--- a/hack/kube/base/enduro.yaml
+++ b/hack/kube/base/enduro.yaml
@@ -70,8 +70,6 @@ spec:
               value: "grafana-alloy.enduro-sdps:4317"
             - name: ENDURO_TELEMETRY_TRACES_SAMPLING_RATIO
               value: "1.0"
-            - name: ENDURO_VALIDATEPREMIS_ENABLED
-              value: "false"
           ports:
             - containerPort: 9000
             - containerPort: 9002


### PR DESCRIPTION
This file should only be needed by the AM and a3m workers to do PREMIS validation when it's enabled. However, config validation is the same for all commands and, when PREMIS validation is enabled, it checks the existence of the XSD file in the filesystem. We tried to disable PREMIS validation only in the enduro container, but that config value is read in the workflow context, disabling the scheduling of the activity from the workflow worker.

Refs #951.