### PR TITLE
Fix API ABAC for access tokens without attributes

### DIFF
--- a/internal/api/auth/token_verifier.go
+++ b/internal/api/auth/token_verifier.go
@@ -108,7 +108,7 @@ func (t *OIDCTokenVerifier) parseAttributes(token *oidc.IDToken) ([]string, erro
 				)
 			}
 
-			var filteredValue []string
+			filteredValue := []string{}
 			for i := range val.Len() {
 				str, ok := val.Index(i).Interface().(string)
 				if ok {
@@ -122,7 +122,7 @@ func (t *OIDCTokenVerifier) parseAttributes(token *oidc.IDToken) ([]string, erro
 				return filteredValue, nil
 			}
 
-			var attributes []string
+			attributes := []string{}
 			for _, role := range filteredValue {
 				if attrs, ok := t.cfg.ABAC.RolesMapping[role]; ok {
 					attributes = append(attributes, attrs...)

--- a/internal/api/auth/token_verifier_test.go
+++ b/internal/api/auth/token_verifier_test.go
@@ -184,6 +184,47 @@ func TestParseAttributes(t *testing.T) {
 			},
 		},
 		{
+			name: "Parses attributes based on configuration (disabled)",
+			config: &auth.OIDCConfig{
+				ProviderURL: iss,
+				ClientID:    audience,
+				ABAC: auth.OIDCABACConfig{
+					Enabled: false,
+				},
+			},
+			token: token(t, signer, iss, customClaims{
+				Email:         "info@artefactual.com",
+				EmailVerified: true,
+				Attributes:    []string{"*"},
+			}),
+			wantClaims: &auth.Claims{
+				Email:         "info@artefactual.com",
+				EmailVerified: true,
+				Attributes:    nil,
+			},
+		},
+		{
+			name: "Parses attributes based on configuration (no attributes)",
+			config: &auth.OIDCConfig{
+				ProviderURL: iss,
+				ClientID:    audience,
+				ABAC: auth.OIDCABACConfig{
+					Enabled:   true,
+					ClaimPath: "attributes",
+				},
+			},
+			token: token(t, signer, iss, customClaims{
+				Email:         "info@artefactual.com",
+				EmailVerified: true,
+				Attributes:    []string{},
+			}),
+			wantClaims: &auth.Claims{
+				Email:         "info@artefactual.com",
+				EmailVerified: true,
+				Attributes:    []string{},
+			},
+		},
+		{
 			name: "Parses attributes based on configuration (nested)",
 			config: &auth.OIDCConfig{
 				ProviderURL: iss,
@@ -252,6 +293,29 @@ func TestParseAttributes(t *testing.T) {
 				Email:         "info@artefactual.com",
 				EmailVerified: true,
 				Attributes:    []string{"*", "package:list", "package:listActions", "package:move", "package:read", "package:upload"},
+			},
+		},
+		{
+			name: "Parses attributes based on configuration (mapping roles, no attributes)",
+			config: &auth.OIDCConfig{
+				ProviderURL: iss,
+				ClientID:    audience,
+				ABAC: auth.OIDCABACConfig{
+					Enabled:      true,
+					ClaimPath:    "attributes",
+					UseRoles:     true,
+					RolesMapping: map[string][]string{"admin": {"*"}},
+				},
+			},
+			token: token(t, signer, iss, customClaims{
+				Email:         "info@artefactual.com",
+				EmailVerified: true,
+				Attributes:    []string{"other", "random", "role"},
+			}),
+			wantClaims: &auth.Claims{
+				Email:         "info@artefactual.com",
+				EmailVerified: true,
+				Attributes:    []string{},
 			},
 		},
 		{

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -1284,7 +1284,6 @@ func (w *ProcessingWorkflow) validatePREMIS(
 		XMLPath: xmlPath,
 		XSDPath: w.cfg.ValidatePREMIS.XSDPath,
 	}).Get(activityOpts, &xmlvalidateResult)
-
 	if err != nil {
 		if strings.Contains(err.Error(), fmt.Sprintf("%s: no such file or directory", xmlPath)) {
 			// Allow PREMIS XML to not exist without failing workflow.


### PR DESCRIPTION
Make sure we return an empty slice of attributes in the claim if no Enduro attributes are found in the token after parsing, filtering and mapping roles. A nil attributes slice is considered as ABAC disabled in the API endpoints check.

Refs #1066.