### PR TITLE
Allow relation between child workflows

### DIFF
--- a/internal/poststorage/poststorage.go
+++ b/internal/poststorage/poststorage.go
@@ -7,5 +7,6 @@ type Config struct {
 }
 
 type WorkflowParams struct {
-	AIPUUID string
+	AIPUUID         string
+	PreprocessingID string
 }

--- a/internal/preprocessing/preprocessing.go
+++ b/internal/preprocessing/preprocessing.go
@@ -43,6 +43,9 @@ type WorkflowResult struct {
 	// PreservationTasks is a log of the preservation tasks performed by
 	// preprocessing.
 	PreservationTasks []Task
+
+	// Identifier from the preprocessing workflow.
+	PreprocessingID string
 }
 
 // Validate implements config.ConfigurationValidator.

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -978,6 +978,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	sessionCtx := mock.AnythingOfType("*context.timerCtx")
 	pkgsvc := s.workflow.pkgsvc
 	aipUUID := "56eebd45-5600-4768-a8c2-ec0114555a3d"
+	preprocessingID := "146182ff-9923-4869-bca1-0bbc0f822025"
 
 	downloadDir := strings.Replace(tempPath, "/tmp/", cfg.Preprocessing.SharedPath, 1)
 	prepDest := strings.Replace(extractPath, "/tmp/", cfg.Preprocessing.SharedPath, 1)
@@ -1040,6 +1041,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 					CompletedAt: time.Date(2024, 6, 14, 10, 5, 33, 0, time.UTC),
 				},
 			},
+			PreprocessingID: preprocessingID,
 		},
 		nil,
 	)
@@ -1190,7 +1192,8 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 		"poststorage_1",
 		mock.AnythingOfType("*internal.valueCtx"),
 		&poststorage.WorkflowParams{
-			AIPUUID: aipUUID,
+			AIPUUID:         aipUUID,
+			PreprocessingID: preprocessingID,
 		},
 	).Return(nil, nil)
 
@@ -1198,7 +1201,8 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 		"poststorage_2",
 		mock.AnythingOfType("*internal.valueCtx"),
 		&poststorage.WorkflowParams{
-			AIPUUID: aipUUID,
+			AIPUUID:         aipUUID,
+			PreprocessingID: preprocessingID,
 		},
 	).Return(nil, nil)
 


### PR DESCRIPTION
Consider a `PreprocessingID`received in the preprocessing child workflow result and pass it as parameter to poststorage child workflows.

Refs #886.