### PR TITLE
Make preservation task cards expandable

### DIFF
--- a/dashboard/src/components/PreservationActionCollapse.vue
+++ b/dashboard/src/components/PreservationActionCollapse.vue
@@ -1,13 +1,21 @@
 <script setup lang="ts">
-import { ref, toRefs } from "vue";
+import { computed, ref, toRefs } from "vue";
 
 import type { api } from "@/client";
 import PackageReviewAlert from "@/components/PackageReviewAlert.vue";
+import PreservationTask from "@/components/PreservationTask.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
-import type { EnduroPackagePreservationTask } from "@/openapi-generator";
 import { useAuthStore } from "@/stores/auth";
 
 const authStore = useAuthStore();
+const tasks = computed<api.EnduroPackagePreservationTask[]>(() => {
+  if (!props.action.tasks) {
+    return [];
+  }
+
+  // Show the last task first.
+  return props.action.tasks.slice().reverse();
+});
 
 const props = defineProps<{
   action: api.EnduroPackagePreservationAction;
@@ -17,10 +25,6 @@ const props = defineProps<{
 const { action, index } = toRefs(props);
 
 let expandCounter = ref<number>(0);
-
-function isComplete(task: EnduroPackagePreservationTask) {
-  return task.status == "done" || task.status == "error";
-}
 </script>
 
 <template>
@@ -59,70 +63,24 @@ function isComplete(task: EnduroPackagePreservationTask) {
     <div
       v-if="action.tasks"
       :id="'pa-body-' + index"
-      class="accordion-collapse collapse bg-light"
+      class="accordion-collapse collapse"
       :aria-labelledby="'pa-heading-' + index"
       data-bs-parent="#preservation-actions"
     >
-      <div class="accordion-body d-flex flex-column gap-1">
-        <PackageReviewAlert
-          v-model:expandCounter="expandCounter"
-          v-if="authStore.checkAttributes(['package:review'])"
-        />
-        <div
-          v-for="(task, index) in action.tasks.slice().reverse()"
-          :key="action.id"
-          class="card"
+      <PackageReviewAlert
+        v-model:expandCounter="expandCounter"
+        v-if="authStore.checkAttributes(['package:review'])"
+      />
+      <ul class="accordion-body d-flex flex-column gap-1">
+        <li
+          v-for="(task, index) of tasks"
+          :id="'prestask-' + (tasks.length - index)"
+          :key="task.id"
+          class="mb-2 card bg-light"
         >
-          <div class="card-body">
-            <div class="d-flex flex-row align-start gap-3">
-              <div class="fd-flex">
-                <span
-                  class="fs-6 badge rounded-pill border border-primary text-primary"
-                >
-                  {{ action.tasks.length - index }}
-                </span>
-              </div>
-              <div
-                class="d-flex flex-column flex-grow-1 align-content-stretch min-w-0"
-              >
-                <div class="d-flex flex-wrap pt-1">
-                  <div class="me-auto text-truncate fw-bold">
-                    {{ task.name }}
-                  </div>
-                  <div class="me-3">
-                    <span
-                      v-if="
-                        !isComplete(task) &&
-                        $filters.formatDateTime(task.startedAt)
-                      "
-                    >
-                      Started:
-                      {{ $filters.formatDateTime(task.startedAt) }}
-                    </span>
-                    <span
-                      v-if="
-                        isComplete(task) &&
-                        $filters.formatDateTime(task.completedAt)
-                      "
-                    >
-                      Completed:
-                      {{ $filters.formatDateTime(task.completedAt) }}
-                    </span>
-                  </div>
-                </div>
-                <div class="d-flex flex-row gap-4">
-                  <div class="flex-grow-1 line-break">
-                    {{ task.note }}
-                  </div>
-                </div>
-              </div>
-              <div class="d-flex pt-1">
-                <StatusBadge :status="task.status" />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+          <PreservationTask :index="tasks.length - index" :task="task" />
+        </li>
+      </ul>
     </div>
   </div>
 </template>

--- a/dashboard/src/components/PreservationTask.vue
+++ b/dashboard/src/components/PreservationTask.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+import StatusBadge from "@/components/StatusBadge.vue";
+import { FormatDateTime } from "@/composables/dateFormat";
+import type { EnduroPackagePreservationTask } from "@/openapi-generator";
+
+class Card {
+  isOpen: boolean;
+  note: string;
+  more: string;
+
+  constructor(task: EnduroPackagePreservationTask) {
+    this.isOpen = false;
+
+    if (task.note?.includes("\n")) {
+      const [firstLine, ...remainingLines] = task.note.split("\n");
+      this.note = firstLine;
+      this.more = remainingLines.join("\n");
+    } else {
+      this.note = task.note ? task.note : "";
+      this.more = "";
+    }
+  }
+
+  toggle() {
+    if (!this.more) {
+      return;
+    }
+
+    this.isOpen = !this.isOpen;
+  }
+}
+
+const isComplete = (task: EnduroPackagePreservationTask) => {
+  return task.status == "done" || task.status == "error";
+};
+
+const props = defineProps<{
+  index: number;
+  task: EnduroPackagePreservationTask;
+}>();
+
+const card = ref(new Card(props.task));
+</script>
+
+<template>
+  <div :id="'pt-' + props.index + '-body'" class="card-body">
+    <div class="d-flex flex-row align-start gap-3">
+      <div class="fd-flex">
+        <span
+          class="fs-6 badge rounded-pill border border-primary text-primary"
+        >
+          {{ index }}
+        </span>
+      </div>
+      <div
+        class="d-flex flex-column flex-grow-1 align-content-stretch min-w-0 gap-2"
+      >
+        <div class="d-flex flex-wrap pt-1">
+          <div class="me-auto text-truncate fw-bold">
+            {{ task.name }}
+          </div>
+          <div :id="'pt-' + index + '-time'" class="me-3">
+            <span v-if="!isComplete(task) && FormatDateTime(task.startedAt)">
+              Started:
+              {{ FormatDateTime(task.startedAt) }}
+            </span>
+            <span v-if="isComplete(task) && FormatDateTime(task.completedAt)">
+              Completed:
+              {{ FormatDateTime(task.completedAt) }}
+            </span>
+          </div>
+        </div>
+        <div class="flex-grow-1">
+          <span :id="'pt-' + index + '-note'">{{ card.note }}</span>
+          <span v-if="card.more">
+            <span v-show="!card.isOpen">... </span>
+            <Transition name="fade">
+              <p
+                v-show="card.isOpen"
+                :id="'pt-' + index + '-note-more'"
+                class="line-break"
+              >
+                {{ card.more }}
+              </p>
+            </Transition>
+            <a
+              :id="'pt-' + index + '-note-toggle'"
+              :aria-controls="'pt-' + index + '-note-more'"
+              aria-label="Toggle display of additional notes"
+              @click.prevent="card.toggle"
+              href="#"
+            >
+              {{ card.isOpen ? "Show less" : "Show more" }}
+            </a>
+          </span>
+        </div>
+      </div>
+      <div class="d-flex pt-1">
+        <StatusBadge :status="task.status" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/dashboard/src/components/__tests__/PreservationTask.test.ts
+++ b/dashboard/src/components/__tests__/PreservationTask.test.ts
@@ -1,0 +1,106 @@
+import { VueWrapper, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import PreservationTask from "../PreservationTask.vue";
+
+describe("PreservationTask.vue", () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    wrapper = mount(PreservationTask, {
+      attachTo: document.body,
+      props: {
+        index: 1,
+        task: {
+          id: 1,
+          name: "Task 1",
+          startedAt: new Date("2020-02-25T17:21:03Z"),
+          completedAt: new Date("2020-02-25T17:22:38Z"),
+          status: "done",
+          taskId: "9614f71f-c21e-4da9-a07e-1661bd010d1f",
+          note: "This is a note\nwith multiple lines",
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it("renders the component", async () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it("shows the time completed if the task is done", async () => {
+    const time = wrapper.find("#pt-1-time span");
+
+    expect(process.env.TZ).toEqual("America/Regina");
+    expect(time.text()).toEqual("Completed: 2020-02-25 11:22:38");
+  });
+
+  it("shows the time started if the task is in progress", async () => {
+    wrapper = mount(PreservationTask, {
+      props: {
+        index: 1,
+        task: {
+          id: 1,
+          name: "Task 1",
+          startedAt: new Date("2020-02-25T17:21:03Z"),
+          status: "in progress",
+          taskId: "9614f71f-c21e-4da9-a07e-1661bd010d1f",
+        },
+      },
+    });
+
+    const time = wrapper.find("#pt-1-time span");
+
+    expect(process.env.TZ).toEqual("America/Regina");
+    expect(time.text()).toEqual("Started: 2020-02-25 11:21:03");
+  });
+
+  it("shows the first line of the note by default", async () => {
+    const note = wrapper.find("#pt-1-note");
+    const more = wrapper.find("#pt-1-note-more");
+
+    expect(note.text()).toEqual("This is a note");
+    expect(more.isVisible()).toBe(false);
+  });
+
+  it("shows all lines of the note after expanding the card", async () => {
+    const note = wrapper.find("#pt-1-note");
+    const more = wrapper.find("#pt-1-note-more");
+    const toggle = wrapper.find("#pt-1-note-toggle");
+
+    await toggle.trigger("click");
+
+    expect(note.text()).toEqual("This is a note");
+    expect(more.isVisible()).toBe(true);
+    expect(more.text()).toEqual("with multiple lines");
+  });
+
+  it("doesn't have an expand link when the note is only one line", async () => {
+    wrapper = mount(PreservationTask, {
+      props: {
+        index: 1,
+        task: {
+          id: 1,
+          name: "Task 1",
+          startedAt: new Date("2020-02-25T17:21:03Z"),
+          completedAt: new Date("2020-02-25T17:22:38Z"),
+          status: "done",
+          taskId: "9614f71f-c21e-4da9-a07e-1661bd010d1f",
+          note: "This note is only one line",
+        },
+      },
+    });
+
+    const note = wrapper.find("#pt-1-note");
+    const more = wrapper.find("#pt-1-note-more");
+    const toggle = wrapper.find("#pt-1-note-toggle");
+
+    expect(note.text()).toEqual("This note is only one line");
+    expect(more.exists()).toBe(false);
+    expect(toggle.exists()).toEqual(false);
+  });
+});

--- a/dashboard/src/composables/dateFormat.ts
+++ b/dashboard/src/composables/dateFormat.ts
@@ -1,0 +1,18 @@
+import moment from "moment";
+
+export function FormatDateTime(value: Date | undefined) {
+  if (!value || Number.isNaN(value.getTime())) {
+    return "";
+  }
+  return moment(value).format("YYYY-MM-DD HH:mm:ss");
+}
+
+export function FormatDateTimeString(value: string) {
+  const date = new Date(value);
+  return moment(date).format("YYYY-MM-DD HH:mm:ss");
+}
+
+export function FormatDuration(from: Date, to: Date) {
+  const diff = moment(to).diff(from);
+  return moment.duration(diff).humanize();
+}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1,15 +1,17 @@
-import App from "./App.vue";
-import { api } from "./client";
-
 import "./styles/main.scss";
 import { PiniaDebounce } from "@pinia/plugin-debounce";
-import humanizeDuration from "humanize-duration";
-import moment from "moment";
 import { createPinia } from "pinia";
 import { debounce } from "ts-debounce";
 import { createApp } from "vue";
 import { PromiseDialog } from "vue3-promise-dialog";
 
+import App from "./App.vue";
+import { api } from "./client";
+import {
+  FormatDateTime,
+  FormatDateTimeString,
+  FormatDuration,
+} from "./composables/dateFormat";
 import router from "./router";
 
 const pinia = createPinia();
@@ -18,14 +20,11 @@ pinia.use(PiniaDebounce(debounce));
 const app = createApp(App);
 app.use(router);
 app.use(pinia);
-app.use({
-  install: (app: any): any => {
-    PromiseDialog.install(app, {});
-  },
-});
+app.use(PromiseDialog);
 app.mount("#app");
 
 interface Filters {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: (...value: any[]) => string;
 }
 
@@ -37,18 +36,13 @@ declare module "@vue/runtime-core" {
 
 app.config.globalProperties.$filters = {
   formatDateTimeString(value: string) {
-    const date = new Date(value);
-    return moment(date).format("YYYY-MM-DD HH:mm:ss");
+    return FormatDateTimeString(value);
   },
   formatDateTime(value: Date | undefined) {
-    if (!value || Number.isNaN(value.getTime())) {
-      return "";
-    }
-    return moment(value).format("YYYY-MM-DD HH:mm:ss");
+    return FormatDateTime(value);
   },
   formatDuration(from: Date, to: Date) {
-    const diff = moment(to).diff(from);
-    return humanizeDuration(moment.duration(diff).asMilliseconds());
+    return FormatDuration(from, to);
   },
   getPreservationActionLabel(
     value: api.EnduroPackagePreservationActionTypeEnum,

--- a/dashboard/src/styles/main.scss
+++ b/dashboard/src/styles/main.scss
@@ -49,3 +49,18 @@ a:not(.btn),
 .accordion-button.collapsed .h4 {
   color: $dark;
 }
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease-in;
+}
+
+.fade-enter-to,
+.fade-leave-from {
+  opacity: 1;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}

--- a/dashboard/src/test-globals.ts
+++ b/dashboard/src/test-globals.ts
@@ -1,0 +1,5 @@
+export const setup = () => {
+  // Set the local timezone to Newfoundland for consistent test results. We are
+  // using Regina because it has a constant offset (no DST) from UTC (-06:00).
+  process.env.TZ = "America/Regina";
+};

--- a/dashboard/tsconfig.node.json
+++ b/dashboard/tsconfig.node.json
@@ -5,7 +5,8 @@
     "vitest.config.*",
     "cypress.config.*",
     "nightwatch.conf.*",
-    "playwright.config.*"
+    "playwright.config.*",
+    "src/test-globals.ts"
   ],
   "compilerOptions": {
     "composite": true,

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -18,6 +18,7 @@ export default mergeConfig(
       coverage: {
         exclude: ["src/openapi-generator/**"],
       },
+      globalSetup: "./src/test-globals.ts",
       // Needed by vue-testing-library.
       globals: true,
     },


### PR DESCRIPTION
Fixes #1077.

- Show only the first line of a multi-line task note by default
- Show an icon on task cards with multi-line notes to toggle display of the subsequent lines of the note
- Add css animations for the expansion and contraction of the additional note content