### PR TITLE
Search for packages by name, fixes #1101

### DIFF
--- a/dashboard/src/components/Tabs.vue
+++ b/dashboard/src/components/Tabs.vue
@@ -2,7 +2,6 @@
 import type { FunctionalComponent, SVGAttributes } from "vue";
 import type { RouteLocationResolved } from "vue-router/auto";
 import { useRoute } from "vue-router/auto";
-import { isEqual } from "lodash-es";
 
 const route = useRoute();
 
@@ -13,12 +12,15 @@ type Tab = {
   show: boolean;
 };
 
-const { tabs } = defineProps<{
+const { tabs, param } = defineProps<{
   tabs: Tab[];
+  param: string;
 }>();
 
 function isActive(tab: Tab): boolean {
-  return tab.route.path == route.path && isEqual(tab.route.query, route.query);
+  return (
+    tab.route.path == route.path && tab.route.query[param] == route.query[param]
+  );
 }
 </script>
 

--- a/dashboard/src/components/__tests__/Tabs.test.ts
+++ b/dashboard/src/components/__tests__/Tabs.test.ts
@@ -33,6 +33,7 @@ describe("Tabs.vue", () => {
             show: false,
           },
         ],
+        param: "",
       },
       global: {
         plugins: [router],

--- a/dashboard/src/pages/locations/[id].vue
+++ b/dashboard/src/pages/locations/[id].vue
@@ -51,7 +51,7 @@ const tabs = [
       }}
     </h1>
 
-    <Tabs :tabs="tabs" />
+    <Tabs :tabs="tabs" param="id" />
 
     <router-view></router-view>
   </div>

--- a/dashboard/src/pages/packages/[id].vue
+++ b/dashboard/src/pages/packages/[id].vue
@@ -42,7 +42,7 @@ const tabs = [
       <IconBundleLine class="me-3 text-dark" />{{ packageStore.current.name }}
     </h1>
 
-    <Tabs :tabs="tabs" />
+    <Tabs :tabs="tabs" param="id" />
 
     <router-view></router-view>
   </div>

--- a/dashboard/src/stores/package.ts
+++ b/dashboard/src/stores/package.ts
@@ -50,6 +50,7 @@ export const usePackageStore = defineStore("package", {
 
     filters: {
       status: "" as PackageListStatusEnum,
+      name: "",
     },
   }),
   getters: {
@@ -139,8 +140,6 @@ export const usePackageStore = defineStore("package", {
       handlers[event.type](value);
     },
     async fetchCurrent(id: string) {
-      this.$reset();
-
       const packageId = +id;
       if (Number.isNaN(packageId)) {
         throw Error("Unexpected parameter");
@@ -171,7 +170,8 @@ export const usePackageStore = defineStore("package", {
       const resp = await client.package.packageList({
         offset: page > 1 ? (page - 1) * this.page.limit : undefined,
         limit: this.page?.limit || undefined,
-        status: this.filters.status ? this.filters.status : undefined,
+        status: this.filters.status ?? undefined,
+        name: this.filters.name ?? undefined,
       });
       this.packages = resp.items;
       this.page = resp.page;

--- a/internal/persistence/ent/client/filter.go
+++ b/internal/persistence/ent/client/filter.go
@@ -201,6 +201,17 @@ func validPtrValue(ptr any) bool {
 	}
 }
 
+// Contains adds a filter on column containing the given string.
+func (f *Filter[Q, O, P]) Contains(column string, value *string) {
+	if value == nil || *value == "" {
+		return
+	}
+
+	f.addFilter(column, func(s *sql.Selector) {
+		s.Where(sql.Contains(s.C(column), *value))
+	})
+}
+
 // Equals adds a filter on column being equal to value. If value implements the
 // validator interface, value is validated before the filter is added.
 func (f *Filter[Q, O, P]) Equals(column string, value any) {

--- a/internal/persistence/ent/client/package.go
+++ b/internal/persistence/ent/client/package.go
@@ -173,7 +173,7 @@ func filterPackages(q *db.PkgQuery, f *persistence.PackageFilter) (page, whole *
 	qf := NewFilter(q, SortableFields{
 		pkg.FieldID: {Name: "ID", Default: true},
 	})
-	qf.Equals(pkg.FieldName, f.Name)
+	qf.Contains(pkg.FieldName, f.Name)
 	qf.Equals(pkg.FieldAipID, f.AIPID)
 	qf.Equals(pkg.FieldLocationID, f.LocationID)
 	qf.Equals(pkg.FieldStatus, f.Status)

--- a/internal/persistence/ent/client/package_test.go
+++ b/internal/persistence/ent/client/package_test.go
@@ -540,10 +540,10 @@ func TestListPackages(t *testing.T) {
 			},
 		},
 		{
-			name: "Returns packages filtered by name",
+			name: "Returns packages whose names contain a string",
 			data: []*datatypes.Package{
 				{
-					Name:        "Test package 1",
+					Name:        "Test package",
 					WorkflowID:  "workflow-1",
 					RunID:       runID.String(),
 					AIPID:       aipID,
@@ -553,7 +553,7 @@ func TestListPackages(t *testing.T) {
 					CompletedAt: completed,
 				},
 				{
-					Name:        "Test package 2",
+					Name:        "small.zip",
 					WorkflowID:  "workflow-1",
 					RunID:       runID2.String(),
 					AIPID:       aipID2,
@@ -564,13 +564,13 @@ func TestListPackages(t *testing.T) {
 				},
 			},
 			packageFilter: &persistence.PackageFilter{
-				Name: ref.New("Test package 2"),
+				Name: ref.New("small"),
 			},
 			want: results{
 				data: []*datatypes.Package{
 					{
 						ID:          2,
-						Name:        "Test package 2",
+						Name:        "small.zip",
 						WorkflowID:  "workflow-1",
 						RunID:       runID2.String(),
 						AIPID:       aipID2,

--- a/internal/persistence/filter.go
+++ b/internal/persistence/filter.go
@@ -62,7 +62,9 @@ func (p *Page) Goa() *goapackage.EnduroPage {
 }
 
 type PackageFilter struct {
-	Name       *string
+	// Name filters for packages whose names contain the given string.
+	Name *string
+
 	AIPID      *uuid.UUID
 	LocationID *uuid.UUID
 	Status     *enums.PackageStatus


### PR DESCRIPTION
Add the ability to search for packages by name, including partial matches.  This implementation requires the user to click the search button (looks like a magnifying glass) or press the "Enter" key to perform the search.  It also includes a "reset" button that clears the search field.

Here's how it looks in action:
https://github.com/user-attachments/assets/b3fe047a-c768-42b7-9ae9-74e60ce2e8cc

