### PR TITLE
Add custom date range package filters

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@pinia/plugin-debounce": "^1.0.1",
+        "@popperjs/core": "^2.11.8",
         "@types/humanize-duration": "^3.27.4",
+        "@vuepic/vue-datepicker": "^11.0.1",
         "@vueuse/core": "^11.0.3",
         "buffer": "^6.0.3",
         "humanize-duration": "^3.32.1",
@@ -2374,7 +2376,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3639,6 +3641,21 @@
       "integrity": "sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==",
       "dev": true
     },
+    "node_modules/@vuepic/vue-datepicker": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-11.0.1.tgz",
+      "integrity": "sha512-xtGbgZAftBiU1H8pwM54vOCutLzEHsHiolRuDn+memTjqpfzT0x1Ml1tykJ53PLvdkCTyb6sB+1muv5Gsd4nQA==",
+      "license": "MIT",
+      "dependencies": {
+        "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "vue": ">=3.3.0"
+      }
+    },
     "node_modules/@vueuse/core": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.0.3.tgz",
@@ -4576,6 +4593,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/de-indent": {
@@ -12876,8 +12903,7 @@
     "@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "dev": true
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@rollup/pluginutils": {
       "version": "5.1.4",
@@ -13716,6 +13742,14 @@
       "integrity": "sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==",
       "dev": true
     },
+    "@vuepic/vue-datepicker": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-11.0.1.tgz",
+      "integrity": "sha512-xtGbgZAftBiU1H8pwM54vOCutLzEHsHiolRuDn+memTjqpfzT0x1Ml1tykJ53PLvdkCTyb6sB+1muv5Gsd4nQA==",
+      "requires": {
+        "date-fns": "^4.1.0"
+      }
+    },
     "@vueuse/core": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.0.3.tgz",
@@ -14305,6 +14339,11 @@
         "es-errors": "^1.3.0",
         "is-data-view": "^1.0.1"
       }
+    },
+    "date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "de-indent": {
       "version": "1.0.2",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,7 +17,9 @@
   },
   "dependencies": {
     "@pinia/plugin-debounce": "^1.0.1",
+    "@popperjs/core": "^2.11.8",
     "@types/humanize-duration": "^3.27.4",
+    "@vuepic/vue-datepicker": "^11.0.1",
     "@vueuse/core": "^11.0.3",
     "buffer": "^6.0.3",
     "humanize-duration": "^3.32.1",

--- a/dashboard/src/components/__tests__/PackageDetailsCard.test.ts
+++ b/dashboard/src/components/__tests__/PackageDetailsCard.test.ts
@@ -44,7 +44,6 @@ describe("PackageDetailsCard.vue", () => {
   });
 
   it("renders when the package is in pending status", async () => {
-    const now = new Date();
     const { getByText } = render(PackageDetailsCard, {
       global: {
         plugins: [

--- a/dashboard/src/pages/packages/[id]/index.vue
+++ b/dashboard/src/pages/packages/[id]/index.vue
@@ -121,6 +121,7 @@ const createAipWorkflow = computed(
           :index="index"
           v-for="(action, index) in packageStore.current_preservation_actions
             ?.actions"
+          v-bind:key="action.id"
         />
       </div>
     </div>

--- a/dashboard/src/stores/package.ts
+++ b/dashboard/src/stores/package.ts
@@ -52,6 +52,7 @@ export const usePackageStore = defineStore("package", {
       status: "" as IngestListSipsStatusEnum,
       name: "",
       earliestCreatedTime: undefined as Date | undefined,
+      latestCreatedTime: undefined as Date | undefined,
     },
   }),
   getters: {
@@ -155,6 +156,7 @@ export const usePackageStore = defineStore("package", {
         status: this.filters.status ?? undefined,
         name: this.filters.name ?? undefined,
         earliestCreatedTime: this.filters.earliestCreatedTime,
+        latestCreatedTime: this.filters.latestCreatedTime,
       });
       this.packages = resp.items;
       this.page = resp.page;


### PR DESCRIPTION
Refs #1102

- Convert pre-defined date range selector to a drop-down widget to reduce size of list
- Add start and end date pickers to a allow selecting a custom times for filtering the package list

Note: Vitest shows a very low coverage for statements in the TimeDrodown component, even though the unit tests should cover most of the code. I've tried to fix the coverage report a number of different ways, but I haven't been able to determine why it's not working correctly.