### PR TITLE
Fix unzipped AM transfer deletion and failed bucket upload

### DIFF
--- a/enduro.toml
+++ b/enduro.toml
@@ -181,7 +181,7 @@ transferSourcePath = ""
 
 # zipPIP specifies whether or not a PIP should be zipped before being sent from
 # Enduro to Archivematica.
-zipPIP = true
+zipPIP = false
 
 [am.sftp]
 host = "" # The Archivematica Storage Service hostname.

--- a/internal/am/delete_transfer_test.go
+++ b/internal/am/delete_transfer_test.go
@@ -56,12 +56,12 @@ func TestDeleteTransferActivity(t *testing.T) {
 				client.EXPECT().
 					Delete(mockutil.Context(), td.Join("missing")).
 					Return(
-						errors.New("SFTP: unable to remove file \"test.txt\": file does not exist"),
+						errors.New("SFTP: unable to remove \"test.txt\": file does not exist"),
 					)
 
 				return client
 			},
-			errMsg: fmt.Sprintf("delete transfer: path: %q: %v", td.Join("missing"), errors.New("SFTP: unable to remove file \"test.txt\": file does not exist")),
+			errMsg: fmt.Sprintf("delete transfer: path: %q: %v", td.Join("missing"), errors.New("SFTP: unable to remove \"test.txt\": file does not exist")),
 		},
 		{
 			name: "Errors when Delete fails",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,7 +86,6 @@ func Read(config *Configuration, configFile string) (found bool, configFileUsed 
 	v.SetDefault("a3m.processing", a3m.ProcessingDefault)
 	v.SetDefault("am.capacity", 1)
 	v.SetDefault("am.pollInterval", 10*time.Second)
-	v.SetDefault("am.zipPIP", true)
 	v.SetDefault("api.listen", "127.0.0.1:9000")
 	v.SetDefault("debugListen", "127.0.0.1:9001")
 	v.SetDefault("preservation.taskqueue", temporal.A3mWorkerTaskQueue)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -87,6 +87,7 @@ func TestConfig(t *testing.T) {
 		assert.Equal(t, c.A3m.Processing, a3m.ProcessingDefault)
 		assert.Equal(t, c.AM.Capacity, 1)
 		assert.Equal(t, c.AM.PollInterval, 10*time.Second)
+		assert.Equal(t, c.AM.ZipPIP, false)
 		assert.Equal(t, c.API.Listen, "127.0.0.1:9000")
 		assert.Equal(t, c.BagIt.ChecksumAlgorithm, "sha512")
 		assert.Equal(t, c.DebugListen, "127.0.0.1:9001")

--- a/internal/sftp/goclient.go
+++ b/internal/sftp/goclient.go
@@ -31,8 +31,8 @@ func NewGoClient(logger logr.Logger, cfg Config) *GoClient {
 	return &GoClient{cfg: cfg, logger: logger}
 }
 
-// Delete removes the data from dest. A new SFTP connection is opened before
-// removing the file, and closed when the delete is complete.
+// Delete removes the file or directory from dest. A new SFTP connection is
+// opened before removing it, and closed when the delete is complete.
 func (c *GoClient) Delete(ctx context.Context, dest string) error {
 	remotePath := sftp.Join(c.cfg.RemoteDir, dest)
 
@@ -42,8 +42,8 @@ func (c *GoClient) Delete(ctx context.Context, dest string) error {
 	}
 	defer conn.Close()
 
-	if err := conn.Remove(remotePath); err != nil {
-		head := fmt.Sprintf("SFTP: unable to remove file %q", dest)
+	if err := conn.RemoveAll(remotePath); err != nil {
+		head := fmt.Sprintf("SFTP: unable to remove %q", dest)
 		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrPermission) {
 			return fmt.Errorf("%s: %w", head, err)
 		}

--- a/internal/sftp/goclient_test.go
+++ b/internal/sftp/goclient_test.go
@@ -464,7 +464,7 @@ func TestDelete(t *testing.T) {
 				},
 				file: "test.txt",
 			},
-			wantErr: "SFTP: unable to remove file \"test.txt\": file does not exist",
+			wantErr: "SFTP: unable to remove \"test.txt\": file does not exist",
 		},
 		{
 			name: "Errors when there are insufficient permissions",
@@ -477,7 +477,7 @@ func TestDelete(t *testing.T) {
 				restrictDir: "restricted",
 				file:        "restricted/test.txt",
 			},
-			wantErr: "SFTP: unable to remove file \"restricted/test.txt\": permission denied",
+			wantErr: "SFTP: unable to remove \"restricted/test.txt\": permission denied",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
- Fix unzipped AM transfer deletion
- Set `am.zipPIP` config value to false by default
- Fix failed PIP upload when it's not zipped for AM

Refs #1136.