### PR TITLE
Show SIP list error message on invalid time range

### DIFF
--- a/internal/api/design/ingest.go
+++ b/internal/api/design/ingest.go
@@ -84,9 +84,11 @@ var _ = Service("ingest", func() {
 			Token("token", String)
 		})
 		Result(SIPs)
+		Error("not_valid")
 		HTTP(func() {
 			GET("/sips")
 			Response(StatusOK)
+			Response("not_valid", StatusBadRequest)
 			Params(func() {
 				Param("name")
 				Param("aip_id")

--- a/internal/api/gen/http/ingest/client/types.go
+++ b/internal/api/gen/http/ingest/client/types.go
@@ -131,6 +131,24 @@ type MonitorNotAvailableResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// ListSipsNotValidResponseBody is the type of the "ingest" service "list_sips"
+// endpoint HTTP response body for the "not_valid" error.
+type ListSipsNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // ShowSipNotAvailableResponseBody is the type of the "ingest" service
 // "show_sip" endpoint HTTP response body for the "not_available" error.
 type ShowSipNotAvailableResponseBody struct {
@@ -606,6 +624,21 @@ func NewListSipsSIPsOK(body *ListSipsResponseBody) *ingestviews.SIPsView {
 	return v
 }
 
+// NewListSipsNotValid builds a ingest service list_sips endpoint not_valid
+// error.
+func NewListSipsNotValid(body *ListSipsNotValidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // NewListSipsForbidden builds a ingest service list_sips endpoint forbidden
 // error.
 func NewListSipsForbidden(body string) ingest.Forbidden {
@@ -1061,6 +1094,30 @@ func ValidateMonitorRequestNotAvailableResponseBody(body *MonitorRequestNotAvail
 // ValidateMonitorNotAvailableResponseBody runs the validations defined on
 // monitor_not_available_response_body
 func ValidateMonitorNotAvailableResponseBody(body *MonitorNotAvailableResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateListSipsNotValidResponseBody runs the validations defined on
+// list_sips_not_valid_response_body
+func ValidateListSipsNotValidResponseBody(body *ListSipsNotValidResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/internal/api/gen/http/ingest/server/encode_decode.go
+++ b/internal/api/gen/http/ingest/server/encode_decode.go
@@ -299,6 +299,19 @@ func EncodeListSipsError(encoder func(context.Context, http.ResponseWriter) goah
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
+		case "not_valid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListSipsNotValidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
 		case "forbidden":
 			var res ingest.Forbidden
 			errors.As(v, &res)

--- a/internal/api/gen/http/ingest/server/types.go
+++ b/internal/api/gen/http/ingest/server/types.go
@@ -131,6 +131,24 @@ type MonitorNotAvailableResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// ListSipsNotValidResponseBody is the type of the "ingest" service "list_sips"
+// endpoint HTTP response body for the "not_valid" error.
+type ListSipsNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // ShowSipNotAvailableResponseBody is the type of the "ingest" service
 // "show_sip" endpoint HTTP response body for the "not_available" error.
 type ShowSipNotAvailableResponseBody struct {
@@ -583,6 +601,20 @@ func NewMonitorRequestNotAvailableResponseBody(res *goa.ServiceError) *MonitorRe
 // result of the "monitor" endpoint of the "ingest" service.
 func NewMonitorNotAvailableResponseBody(res *goa.ServiceError) *MonitorNotAvailableResponseBody {
 	body := &MonitorNotAvailableResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewListSipsNotValidResponseBody builds the HTTP response body from the
+// result of the "list_sips" endpoint of the "ingest" service.
+func NewListSipsNotValidResponseBody(res *goa.ServiceError) *ListSipsNotValidResponseBody {
+	body := &ListSipsNotValidResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,

--- a/internal/api/gen/http/openapi.json
+++ b/internal/api/gen/http/openapi.json
@@ -413,6 +413,59 @@
       "title": "Mediatype identifier: application/vnd.enduro.ingest.sip.preservation-actions; view=default",
       "type": "object"
     },
+    "IngestListSipsNotValidResponseBody": {
+      "description": "list_sips_not_valid_response_body result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
     "IngestListSipsResponseBody": {
       "description": "list_sips_response_body result type (default view)",
       "example": {
@@ -3141,6 +3194,12 @@
             "description": "OK response.",
             "schema": {
               "$ref": "#/definitions/IngestListSipsResponseBody"
+            }
+          },
+          "400": {
+            "description": "Bad Request response.",
+            "schema": {
+              "$ref": "#/definitions/IngestListSipsNotValidResponseBody"
             }
           },
           "401": {

--- a/internal/api/gen/http/openapi.yaml
+++ b/internal/api/gen/http/openapi.yaml
@@ -170,6 +170,10 @@ paths:
                     description: OK response.
                     schema:
                         $ref: '#/definitions/IngestListSipsResponseBody'
+                "400":
+                    description: Bad Request response.
+                    schema:
+                        $ref: '#/definitions/IngestListSipsNotValidResponseBody'
                 "401":
                     description: Unauthorized response.
                     schema:
@@ -1447,6 +1451,49 @@ definitions:
                       task_id: abc123
                   type: create aip
                   workflow_id: abc123
+    IngestListSipsNotValidResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: list_sips_not_valid_response_body result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
     IngestListSipsResponseBody:
         title: 'Mediatype identifier: application/vnd.enduro.ingest.sips; view=default'
         type: object

--- a/internal/api/gen/http/openapi3.json
+++ b/internal/api/gen/http/openapi3.json
@@ -1798,6 +1798,16 @@
             },
             "description": "OK response."
           },
+          "400": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "not_valid: Bad Request response."
+          },
           "401": {
             "content": {
               "application/json": {

--- a/internal/api/gen/http/openapi3.yaml
+++ b/internal/api/gen/http/openapi3.yaml
@@ -242,6 +242,12 @@ paths:
                                     limit: 1
                                     offset: 1
                                     total: 1
+                "400":
+                    description: 'not_valid: Bad Request response.'
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
                 "401":
                     description: 'unauthorized: Unauthorized response.'
                     content:

--- a/internal/api/gen/ingest/client.go
+++ b/internal/api/gen/ingest/client.go
@@ -77,6 +77,7 @@ func (c *Client) Monitor(ctx context.Context, p *MonitorPayload) (res MonitorCli
 
 // ListSips calls the "list_sips" endpoint of the "ingest" service.
 // ListSips may return the following errors:
+//   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
 //   - error: internal error

--- a/internal/ingest/convert.go
+++ b/internal/ingest/convert.go
@@ -87,26 +87,26 @@ func preservationTaskToGoa(pt *datatypes.PreservationTask) *goaingest.SIPPreserv
 func listSipsPayloadToSIPFilter(payload *goaingest.ListSipsPayload) (*persistence.SIPFilter, error) {
 	aipID, err := stringToUUIDPtr(payload.AipID)
 	if err != nil {
-		return nil, fmt.Errorf("aip_id: %v", err)
+		return nil, goaingest.MakeNotValid(errors.New("aip_id: invalid UUID"))
 	}
 
 	locID, err := stringToUUIDPtr(payload.LocationID)
 	if err != nil {
-		return nil, fmt.Errorf("location_id: %v", err)
+		return nil, goaingest.MakeNotValid(errors.New("location_id: invalid UUID"))
 	}
 
 	var status *enums.SIPStatus
 	if payload.Status != nil {
 		s, err := enums.ParseSIPStatus(*payload.Status)
 		if err != nil {
-			return nil, fmt.Errorf("invalid status")
+			return nil, goaingest.MakeNotValid(errors.New("status: invalid value"))
 		}
 		status = &s
 	}
 
 	createdAt, err := parseCreatedAtRange(payload.EarliestCreatedTime, payload.LatestCreatedTime)
 	if err != nil {
-		return nil, err
+		return nil, goaingest.MakeNotValid(err)
 	}
 
 	pf := persistence.SIPFilter{
@@ -167,7 +167,7 @@ func parseCreatedAtRange(start, end *string) (*timerange.Range, error) {
 
 	r, err := timerange.New(s, e)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("created at: %v", err)
 	}
 
 	return &r, nil

--- a/internal/ingest/goa.go
+++ b/internal/ingest/goa.go
@@ -17,8 +17,6 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/datatypes"
 )
 
-var ErrBulkStatusUnavailable = errors.New("bulk status unavailable")
-
 // GoaWrapper returns a ingestImpl wrapper that implements
 // goaingest.Service. It can handle types that are specific to the Goa API.
 type goaWrapper struct {
@@ -28,8 +26,9 @@ type goaWrapper struct {
 var _ goaingest.Service = (*goaWrapper)(nil)
 
 var (
-	ErrUnauthorized error = goaingest.Unauthorized("Unauthorized")
-	ErrForbidden    error = goaingest.Forbidden("Forbidden")
+	ErrBulkStatusUnavailable error = errors.New("bulk status unavailable")
+	ErrForbidden             error = goaingest.Forbidden("Forbidden")
+	ErrUnauthorized          error = goaingest.Unauthorized("Unauthorized")
 )
 
 func (w *goaWrapper) JWTAuth(

--- a/internal/ingest/goa_test.go
+++ b/internal/ingest/goa_test.go
@@ -317,7 +317,7 @@ func TestList(t *testing.T) {
 			payload: &goaingest.ListSipsPayload{
 				Status: ref.New("meditating"),
 			},
-			wantErr: "invalid status",
+			wantErr: "status: invalid value",
 		},
 		{
 			name: "Errors on a bad earliest_created_time",
@@ -339,7 +339,7 @@ func TestList(t *testing.T) {
 				EarliestCreatedTime: ref.New("2024-10-01T17:43:52Z"),
 				LatestCreatedTime:   ref.New("2023-10-01T17:43:52Z"),
 			},
-			wantErr: "time range: end cannot be before start",
+			wantErr: "created at: time range: end cannot be before start",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #1141 

- Return a "400 Bad Request" HTTP error from the Enduro API when invalid package list parameters are sent in the request (it was returning a "500 Internal Server Error")
- Show a Dashboard error message on the SIP list when receiving an error response from the API
- Don't pass empty request parameters (name, status) from the SIP list to the back-end
- Remove some duplicate code for setting package request parameters
- Improve the API error messages for the "ListSIPs" endpoint