### PR TITLE
Set date env var for golang-ling CI action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,17 +15,16 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Get date
-        id: get-date
         shell: bash
         run: |
-          echo "::set-output name=date::$(date -u "+%Y-%m")"
+          echo "DATE=$(date -u '+%Y-%m')" >> $GITHUB_ENV
       - name: Restore golangci-lint cache
         uses: actions/cache@v4
         timeout-minutes: 10
         continue-on-error: true
         with:
           path: ${{ runner.temp }}/golangci-lint-cache
-          key: ${{ runner.os }}-golangci-lint-cache-${{ steps.get-date.outputs.date }}
+          key: ${{ runner.os }}-golangci-lint-cache-${{ env.DATE }}
           restore-keys: |
             ${{ runner.os }}-golangci-lint-cache-
       - name: Run golangci-lint


### PR DESCRIPTION
Replace deprecated "set-output" command with the recommended method of setting an environment variable.

See:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/