### PR TITLE
Add a dashboard pager component (#1168)

### DIFF
--- a/dashboard/src/components/Pager.vue
+++ b/dashboard/src/components/Pager.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import IconPrev from "~icons/bi/caret-left-fill";
+import IconNext from "~icons/bi/caret-right-fill";
+
+const props = defineProps({
+  offset: {
+    type: Number,
+    default: 0,
+  },
+  limit: {
+    type: Number,
+    default: 20,
+  },
+  total: {
+    type: Number,
+    required: true,
+  },
+  maxVisiblePages: {
+    type: Number,
+    default: 7, // An odd number of pages makes the pager symmetrical.
+  },
+});
+
+const emit = defineEmits<{
+  (e: "page-change", page: number): void;
+}>();
+
+const currentPage = computed(() => {
+  // Calculate current page based on offset and limit.
+  return Math.floor(props.offset / props.limit) + 1;
+});
+
+const totalPages = computed(() => {
+  // Calculate total pages based on total and limit.
+  return Math.ceil(props.total / props.limit);
+});
+
+const visiblePages = computed(() => {
+  if (totalPages.value <= props.maxVisiblePages) {
+    // If total pages is less than max visible, show all pages.
+    return Array.from({ length: totalPages.value }, (_, i) => i + 1);
+  }
+
+  // Calculate range of pages to show.
+  const halfVisible = Math.floor(props.maxVisiblePages / 2);
+  let startPage = Math.max(currentPage.value - halfVisible, 1);
+  let endPage = startPage + props.maxVisiblePages - 1;
+
+  // Adjust if end page exceeds total pages.
+  if (endPage > totalPages.value) {
+    endPage = totalPages.value;
+    startPage = Math.max(endPage - props.maxVisiblePages + 1, 1);
+  }
+
+  return Array.from(
+    { length: endPage - startPage + 1 },
+    (_, i) => startPage + i,
+  );
+});
+
+const goToPage = (page: number) => {
+  if (page < 1 || page > totalPages.value || page === currentPage.value) {
+    return;
+  }
+  emit("page-change", page);
+};
+</script>
+
+<template>
+  <nav role="navigation" aria-label="Pagination navigation">
+    <ul class="pagination justify-content-center">
+      <!-- Previous page -->
+      <li class="page-item" :class="{ disabled: currentPage === 1 }">
+        <a
+          id="prev-page"
+          class="page-link"
+          href="#"
+          @click.prevent="goToPage(currentPage - 1)"
+          aria-label="Go to previous page"
+          title="Previous page"
+        >
+          <IconPrev />
+        </a>
+      </li>
+
+      <!-- First page and ellipses-->
+      <template v-if="visiblePages[0] > 1">
+        <li class="page-item">
+          <a
+            id="first-page"
+            class="page-link"
+            href="#"
+            @click.prevent="goToPage(1)"
+            >1</a
+          >
+        </li>
+        <li v-if="visiblePages[0] > 2" class="page-item" aria-hidden="true">
+          <a href="#" class="page-link disabled">…</a>
+        </li>
+      </template>
+
+      <!-- Page numbers -->
+      <li
+        v-for="page in visiblePages"
+        :key="page"
+        class="page-item"
+        :class="{ active: currentPage === page }"
+      >
+        <a
+          :id="`page-${page}`"
+          class="page-link"
+          href="#"
+          @click.prevent="goToPage(page)"
+          :aria-label="`Go to page ${page}`"
+          >{{ page }}</a
+        >
+      </li>
+
+      <!-- Last page and ellipses-->
+      <template v-if="visiblePages[visiblePages.length - 1] < totalPages">
+        <li
+          v-if="visiblePages[visiblePages.length - 1] < totalPages - 1"
+          class="page-item"
+          aria-hidden="true"
+        >
+          <a href="#" class="page-link disabled">…</a>
+        </li>
+        <li class="page-item">
+          <a
+            id="last-page"
+            class="page-link"
+            href="#"
+            @click.prevent="goToPage(totalPages)"
+            >{{ totalPages }}</a
+          >
+        </li>
+      </template>
+
+      <!-- Next page -->
+      <li class="page-item" :class="{ disabled: currentPage === totalPages }">
+        <a
+          id="next-page"
+          class="page-link"
+          href="#"
+          @click.prevent="goToPage(currentPage + 1)"
+          aria-label="Go to next page"
+          title="Next page"
+        >
+          <IconNext />
+        </a>
+      </li>
+    </ul>
+  </nav>
+</template>

--- a/dashboard/src/components/ResultCounter.vue
+++ b/dashboard/src/components/ResultCounter.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { computed } from "vue";
+const props = defineProps({
+  offset: {
+    type: Number,
+    default: 0,
+  },
+  limit: {
+    type: Number,
+    default: 20,
+  },
+  total: {
+    type: Number,
+    default: 0,
+  },
+});
+
+const last = computed(() => {
+  // Calculate the last result shown on the page.
+  return Math.min(props.offset + props.limit, props.total);
+});
+</script>
+
+<template>
+  <template v-if="props.total === 0">No results found</template>
+  <template v-else-if="props.total === 1">
+    Found {{ props.total }} result
+  </template>
+  <template v-else-if="props.total <= props.limit">
+    Found {{ props.total }} results
+  </template>
+  <template v-else>
+    Showing {{ props.offset + 1 }} - {{ last }} of {{ props.total }}
+    results
+  </template>
+</template>

--- a/dashboard/src/components/__tests__/Pager.test.ts
+++ b/dashboard/src/components/__tests__/Pager.test.ts
@@ -1,0 +1,135 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import Pager from "../Pager.vue";
+
+describe("Pager", () => {
+  it("renders the correct number of pages when there are less than maxVisiblePages", () => {
+    const wrapper = mount(Pager, {
+      props: {
+        total: 80,
+        maxVisiblePages: 5,
+      },
+    });
+
+    // "< 1 2 3 4 >"
+    const pageLinks = wrapper.findAll(".page-item a");
+    expect(pageLinks.length).toBe(6);
+    expect(pageLinks[0].attributes("title")).toBe("Previous page");
+    expect(pageLinks[1].text()).toBe("1");
+    expect(pageLinks[4].text()).toBe("4");
+    expect(pageLinks[5].attributes("title")).toBe("Next page");
+  });
+
+  it("renders the correct range of pages when there are more than maxVisiblePages", () => {
+    const wrapper = mount(Pager, {
+      props: {
+        offset: 100,
+        total: 200,
+        maxVisiblePages: 5,
+      },
+    });
+
+    // "< 1 … 4 5 [6] 7 8 … 10 >"
+    const pageLinks = wrapper.findAll(".page-item a");
+    expect(pageLinks.length).toBe(11);
+    expect(pageLinks[0].attributes("title")).toBe("Previous page");
+    expect(pageLinks[1].text()).toBe("1");
+    expect(pageLinks[2].text()).toBe("…");
+    expect(pageLinks[3].text()).toBe("4");
+    expect(wrapper.find(".page-item.active").text()).toBe("6");
+    expect(pageLinks[7].text()).toBe("8");
+    expect(pageLinks[8].text()).toBe("…");
+    expect(pageLinks[9].text()).toBe("10");
+    expect(pageLinks[10].attributes("title")).toBe("Next page");
+  });
+
+  it("disables the Previous button on the first page", () => {
+    const wrapper = mount(Pager, { props: { total: 100 } });
+
+    const prevButton = wrapper.find("li.page-item:first-child");
+
+    expect(prevButton.classes()).toContain("disabled");
+  });
+
+  it("disables the Next button on the last page", () => {
+    const wrapper = mount(Pager, {
+      props: {
+        offset: 80,
+        total: 100,
+      },
+    });
+
+    const nextButton = wrapper.find("li.page-item:last-child");
+
+    expect(nextButton.classes()).toContain("disabled");
+  });
+
+  it("emits 'page-change' event when a page is clicked", async () => {
+    const wrapper = mount(Pager, { props: { total: 100 } });
+
+    await wrapper.find("#page-3").trigger("click");
+
+    expect(wrapper.emitted("page-change")![0]).toEqual([3]);
+  });
+
+  it("does not emit 'page-change' event when clicking on the current page", async () => {
+    const wrapper = mount(Pager, {
+      props: {
+        offset: 20,
+        total: 100,
+      },
+    });
+
+    const currentPage = wrapper.find(".page-item.active");
+    await currentPage.find("a").trigger("click");
+
+    expect(wrapper.emitted("page-change")).toBeFalsy();
+  });
+
+  it("emits 'page-change' event when navigating to the next page", async () => {
+    const wrapper = mount(Pager, { props: { total: 100 } });
+
+    await wrapper.find("#next-page").trigger("click");
+
+    expect(wrapper.emitted("page-change")).toBeTruthy();
+    expect(wrapper.emitted("page-change")![0]).toEqual([2]);
+  });
+
+  it("emits 'page-change' event when navigating to the previous page", async () => {
+    const wrapper = mount(Pager, {
+      props: {
+        offset: 80,
+        total: 100,
+      },
+    });
+
+    await wrapper.find("#prev-page").trigger("click");
+
+    expect(wrapper.emitted("page-change")).toBeTruthy();
+    expect(wrapper.emitted("page-change")![0]).toEqual([4]);
+  });
+
+  it("emits 'page-change' event when navigating to the first page", async () => {
+    const wrapper = mount(Pager, {
+      props: {
+        offset: 80,
+        total: 100,
+      },
+    });
+
+    await wrapper.find("#page-1").trigger("click");
+
+    expect(wrapper.emitted("page-change")).toBeTruthy();
+    expect(wrapper.emitted("page-change")![0]).toEqual([1]);
+  });
+
+  it("emits 'page-change' event when navigating to the last page", async () => {
+    const wrapper = mount(Pager, { props: { total: 100 } });
+
+    await wrapper.find("#page-5").trigger("click");
+
+    expect(wrapper.emitted("page-change")).toBeTruthy();
+    expect(wrapper.emitted("page-change")![0]).toEqual([5]);
+  });
+});

--- a/dashboard/src/components/__tests__/ResultCounter.test.ts
+++ b/dashboard/src/components/__tests__/ResultCounter.test.ts
@@ -1,0 +1,52 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import ResultCounter from "../ResultCounter.vue";
+
+describe("ResultCounter", () => {
+  it("renders correctly with zero results", () => {
+    const wrapper = mount(ResultCounter, {
+      props: {
+        total: 0,
+      },
+    });
+    expect(wrapper.text()).toContain("No results found");
+  });
+
+  it("renders correctly with one result", () => {
+    const wrapper = mount(ResultCounter, {
+      props: {
+        total: 1,
+      },
+    });
+    expect(wrapper.text()).toContain("Found 1 result");
+  });
+
+  it("renders correctly with one page of results", () => {
+    const wrapper = mount(ResultCounter, {
+      props: {
+        total: 20,
+      },
+    });
+    expect(wrapper.text()).toContain("Found 20 results");
+  });
+
+  it("renders correctly more than one page of results", () => {
+    const wrapper = mount(ResultCounter, {
+      props: {
+        total: 35,
+      },
+    });
+    expect(wrapper.text()).toContain("Showing 1 - 20 of 35 results");
+  });
+
+  it("renders correctly on a page showing fewer results than the limit", () => {
+    const wrapper = mount(ResultCounter, {
+      props: {
+        offset: 20,
+        total: 35,
+      },
+    });
+    expect(wrapper.text()).toContain("Showing 21 - 35 of 35 results");
+  });
+});

--- a/dashboard/src/stores/__tests__/aip.test.ts
+++ b/dashboard/src/stores/__tests__/aip.test.ts
@@ -2,7 +2,6 @@ import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { api, client } from "@/client";
-import type { Pager } from "@/stores/aip";
 import { useAipStore } from "@/stores/aip";
 import { useLayoutStore } from "@/stores/layout";
 
@@ -68,58 +67,6 @@ describe("useAipStore", () => {
       },
     });
     expect(aipStore.isStored).toEqual(true);
-  });
-
-  it("hasNextPage", () => {
-    const aipStore = useAipStore();
-
-    aipStore.$patch({
-      page: { limit: 20, offset: 0, total: 20 },
-    });
-    expect(aipStore.hasNextPage).toEqual(false);
-
-    aipStore.$patch({
-      page: { limit: 20, offset: 20, total: 40 },
-    });
-    expect(aipStore.hasNextPage).toEqual(false);
-
-    aipStore.$patch({
-      page: { limit: 20, offset: 0, total: 21 },
-    });
-    expect(aipStore.hasNextPage).toEqual(true);
-  });
-
-  it("hasPrevPage", () => {
-    const aipStore = useAipStore();
-
-    aipStore.$patch({
-      page: { limit: 20, offset: 0, total: 40 },
-    });
-    expect(aipStore.hasPrevPage).toEqual(false);
-
-    aipStore.$patch({
-      page: { limit: 20, offset: 20, total: 40 },
-    });
-    expect(aipStore.hasPrevPage).toEqual(true);
-  });
-
-  it("returns lastResultOnPage", () => {
-    const aipStore = useAipStore();
-
-    aipStore.$patch({
-      page: { limit: 20, offset: 0, total: 40 },
-    });
-    expect(aipStore.lastResultOnPage).toEqual(20);
-
-    aipStore.$patch({
-      page: { limit: 20, offset: 0, total: 7 },
-    });
-    expect(aipStore.lastResultOnPage).toEqual(7);
-
-    aipStore.$patch({
-      page: { limit: 20, offset: 20, total: 35 },
-    });
-    expect(aipStore.lastResultOnPage).toEqual(35);
   });
 
   it("fetches current", async () => {
@@ -189,48 +136,5 @@ describe("useAipStore", () => {
 
     expect(store.aips).toEqual(mockAips.items);
     expect(store.page).toEqual(mockAips.page);
-  });
-
-  it("updates the pager", () => {
-    const aipStore = useAipStore();
-
-    aipStore.$patch({
-      page: { limit: 20, offset: 60, total: 125 },
-    });
-    aipStore.updatePager();
-    expect(aipStore.pager).toEqual(<Pager>{
-      maxPages: 7,
-      current: 4,
-      first: 1,
-      last: 7,
-      total: 7,
-      pages: [1, 2, 3, 4, 5, 6, 7],
-    });
-
-    aipStore.$patch({
-      page: { limit: 20, offset: 160, total: 573 },
-    });
-    aipStore.updatePager();
-    expect(aipStore.pager).toEqual(<Pager>{
-      maxPages: 7,
-      current: 9,
-      first: 6,
-      last: 12,
-      total: 29,
-      pages: [6, 7, 8, 9, 10, 11, 12],
-    });
-
-    aipStore.$patch({
-      page: { limit: 20, offset: 540, total: 573 },
-    });
-    aipStore.updatePager();
-    expect(aipStore.pager).toEqual(<Pager>{
-      maxPages: 7,
-      current: 28,
-      first: 23,
-      last: 29,
-      total: 29,
-      pages: [23, 24, 25, 26, 27, 28, 29],
-    });
   });
 });

--- a/dashboard/src/stores/__tests__/sip.test.ts
+++ b/dashboard/src/stores/__tests__/sip.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { api, client } from "@/client";
 import { useLayoutStore } from "@/stores/layout";
-import type { Pager } from "@/stores/sip";
 import { useSipStore } from "@/stores/sip";
 
 vi.mock("@/client");
@@ -27,58 +26,6 @@ describe("useSipStore", () => {
       },
     });
     expect(sipStore.isPending).toEqual(true);
-  });
-
-  it("hasNextPage", () => {
-    const sipStore = useSipStore();
-
-    sipStore.$patch({
-      page: { limit: 20, offset: 0, total: 20 },
-    });
-    expect(sipStore.hasNextPage).toEqual(false);
-
-    sipStore.$patch({
-      page: { limit: 20, offset: 20, total: 40 },
-    });
-    expect(sipStore.hasNextPage).toEqual(false);
-
-    sipStore.$patch({
-      page: { limit: 20, offset: 0, total: 21 },
-    });
-    expect(sipStore.hasNextPage).toEqual(true);
-  });
-
-  it("hasPrevPage", () => {
-    const sipStore = useSipStore();
-
-    sipStore.$patch({
-      page: { limit: 20, offset: 0, total: 40 },
-    });
-    expect(sipStore.hasPrevPage).toEqual(false);
-
-    sipStore.$patch({
-      page: { limit: 20, offset: 20, total: 40 },
-    });
-    expect(sipStore.hasPrevPage).toEqual(true);
-  });
-
-  it("returns lastResultOnPage", () => {
-    const sipStore = useSipStore();
-
-    sipStore.$patch({
-      page: { limit: 20, offset: 0, total: 40 },
-    });
-    expect(sipStore.lastResultOnPage).toEqual(20);
-
-    sipStore.$patch({
-      page: { limit: 20, offset: 0, total: 7 },
-    });
-    expect(sipStore.lastResultOnPage).toEqual(7);
-
-    sipStore.$patch({
-      page: { limit: 20, offset: 20, total: 35 },
-    });
-    expect(sipStore.lastResultOnPage).toEqual(35);
   });
 
   it("getActionById finds actions", () => {
@@ -274,48 +221,5 @@ describe("useSipStore", () => {
 
     expect(store.sips).toEqual(mockSips.items);
     expect(store.page).toEqual(mockSips.page);
-  });
-
-  it("updates the pager", () => {
-    const sipStore = useSipStore();
-
-    sipStore.$patch({
-      page: { limit: 20, offset: 60, total: 125 },
-    });
-    sipStore.updatePager();
-    expect(sipStore.pager).toEqual(<Pager>{
-      maxPages: 7,
-      current: 4,
-      first: 1,
-      last: 7,
-      total: 7,
-      pages: [1, 2, 3, 4, 5, 6, 7],
-    });
-
-    sipStore.$patch({
-      page: { limit: 20, offset: 160, total: 573 },
-    });
-    sipStore.updatePager();
-    expect(sipStore.pager).toEqual(<Pager>{
-      maxPages: 7,
-      current: 9,
-      first: 6,
-      last: 12,
-      total: 29,
-      pages: [6, 7, 8, 9, 10, 11, 12],
-    });
-
-    sipStore.$patch({
-      page: { limit: 20, offset: 540, total: 573 },
-    });
-    sipStore.updatePager();
-    expect(sipStore.pager).toEqual(<Pager>{
-      maxPages: 7,
-      current: 28,
-      first: 23,
-      last: 29,
-      total: 29,
-      pages: [23, 24, 25, 26, 27, 28, 29],
-    });
   });
 });

--- a/hack/genpkgs/load.sh
+++ b/hack/genpkgs/load.sh
@@ -4,7 +4,8 @@ set -eux
 
 __dir=$(cd "$(dirname "$0")" && pwd)
 
-go run ${__dir}/main.go > ${__dir}/data.csv
+# Generate SIPs
+go run ${__dir}/main.go sip > ${__dir}/data.csv
 
 mysql -h127.0.0.1 -uroot -proot123 -P3306 enduro \
 	-e "SET GLOBAL local_infile=1;"
@@ -15,5 +16,17 @@ mysql -h127.0.0.1 -uroot -proot123 -P3306 enduro \
 mysql -h127.0.0.1 -uroot -proot123 -P3306 --local-infile=1 enduro \
 	-e "LOAD DATA LOCAL INFILE '${__dir}/data.csv' INTO TABLE sip FIELDS TERMINATED BY ','"
 
-mysql -h127.0.0.1 -uroot -proot123 -P3306 enduro \
+# Generate AIPs
+go run ${__dir}/main.go aip > ${__dir}/data.csv
+
+mysql -h127.0.0.1 -uroot -proot123 -P3306 enduro_storage \
+	-e "SET GLOBAL local_infile=1;"
+
+mysql -h127.0.0.1 -uroot -proot123 -P3306 enduro_storage \
+	-e "DELETE FROM aip;"
+
+mysql -h127.0.0.1 -uroot -proot123 -P3306 --local-infile=1 enduro_storage \
+	-e "LOAD DATA LOCAL INFILE '${__dir}/data.csv' INTO TABLE aip FIELDS TERMINATED BY ','"
+
+mysql -h127.0.0.1 -uroot -proot123 -P3306 enduro_storage \
 	-e "SET GLOBAL local_infile=0;"

--- a/hack/genpkgs/main.go
+++ b/hack/genpkgs/main.go
@@ -16,22 +16,39 @@ const (
 
 	// Size of each batch that we write to the CSV.
 	batchSize = 100
+
+	usage = `Usage: genpkgs TYPE
+
+Generate a dataset of packages for testing.
+
+TYPE: "sip" or "aip"
+`
 )
 
 func main() {
+	args := os.Args[1:]
+	if len(args) != 1 {
+		log.Fatal(usage)
+	}
+	if args[0] != "sip" && args[0] != "aip" {
+		log.Fatal(usage)
+	}
+
 	w := csv.NewWriter(os.Stdout)
 
-	var c int
-	for {
-		c++
-		if err := w.Write(gen(c)); err != nil {
+	for i := range datasetSize {
+		var row []string
+		if args[0] == "sip" {
+			row = sip(i + 1)
+		} else {
+			row = aip(i + 1)
+		}
+
+		if err := w.Write(row); err != nil {
 			log.Println("error writing record to csv:", err)
 		}
-		if c%batchSize == 0 {
+		if i%batchSize == 0 {
 			w.Flush()
-		}
-		if c == datasetSize {
-			break
 		}
 	}
 
@@ -45,15 +62,27 @@ func id() string {
 	return uuid.New().String()
 }
 
-func gen(c int) []string {
+func sip(c int) []string {
 	const doneStatus string = "2"
 	return []string{
-		strconv.Itoa(c),
+		strconv.Itoa(c),                     // id
 		fmt.Sprintf("DPJ-SIP-%s.tar", id()), // name
 		id(),                                // aip_id
 		doneStatus,                          // status
 		"2019-11-21 17:36:10",               // created_at
 		"2019-11-21 17:36:11",               // started_at
 		"2019-11-21 17:42:12",               // completed_at
+	}
+}
+
+func aip(i int) []string {
+	return []string{
+		strconv.Itoa(i),             // id
+		fmt.Sprintf("AIP-%s", id()), // name
+		id(),                        // aip_id
+		"stored",                    // status
+		id(),                        // object_key
+		"1",                         // location_id
+		"2019-11-21 17:43:51",       // created_at
 	}
 }


### PR DESCRIPTION
Create a general Vue.js Pager component that can be used for all dashboard lists.

- Create a Vue.js Pager component
- Use the Pager component on the `ingest/sips` and `storage/aips` pages
- Update the page URL when the page changes with the current page
  number, to allow bookmarking a specific page in the results
- Remove pager properties and methods from the AIP and SIP stores