### PR TITLE
Use go-mod-outdated to discover outdated deps

### DIFF
--- a/.bine.json
+++ b/.bine.json
@@ -20,6 +20,12 @@
       "asset_pattern": "{name}_{os}_{arch}"
     },
     {
+      "name": "go-mod-outdated",
+      "url": "https://github.com/psampaz/go-mod-outdated",
+      "version": "0.9.0",
+      "asset_pattern": "{name}_{version}_{os}_{arch}.tar.gz"
+    },
+    {
       "name": "goa",
       "go_package": "goa.design/goa/v3/cmd/goa",
       "version": "3.15.2"

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ db:
 	mysql -h127.0.0.1 -P3306 -uroot -proot123 enduro
 
 deps: # @HELP List available module dependency updates.
-deps: tool-gomajor
-	gomajor list
+deps: tool-go-mod-outdated
+	go list -u -m -json all | go-mod-outdated -direct -update
 
 env: # @HELP Print Go env variables.
 env:

--- a/hack/make/tools.mk
+++ b/hack/make/tools.mk
@@ -3,6 +3,7 @@ TOOLS = \
     atlas \
     ent \
     go-enum \
+    go-mod-outdated \
     goa \
     golangci-lint \
     gomajor \


### PR DESCRIPTION
I've been finding `go-mod-outdated` simpler and faster compared to `gomajor`, but I believe the latter still has its use when switching to new major versions where the module path is changing.

`go-mod-outdated` relies on the output generated by `go list`, e.g.: `make deps` will use:

    go list -u -m -json all | go-mod-outdated -direct -update

`-direct` is used to list direct dependencies only
`-update` is used to list oudated dependencies only

For example:

```
$ go list -u -m -json all | go-mod-outdated -direct -update | head -n 10
+------------------------------------------------------------------------------+--------------------------------------------+---------------------------------------+--------+------------------+
|                                    MODULE                                    |                  VERSION                   |              NEW VERSION              | DIRECT | VALID TIMESTAMPS |
+------------------------------------------------------------------------------+--------------------------------------------+---------------------------------------+--------+------------------+
| ariga.io/atlas                                                               | v0.32.0                                    | v0.32.1                               | true   | true             |
| buf.build/gen/go/artefactual/a3m/grpc/go                                     | v1.3.0-20230508184533-2e9432075630.2       | v1.5.1-20240927084026-213011354143.2  | true   | true             |
| buf.build/gen/go/artefactual/a3m/protocolbuffers/go                          | v1.31.0-20230508184533-2e9432075630.2      | v1.36.6-20240927084026-213011354143.1 | true   | true             |
| chainguard.dev/go-oidctest                                                   | v0.3.1                                     | v0.4.0                                | true   | true             |
| github.com/XSAM/otelsql                                                      | v0.29.0                                    | v0.38.0                               | true   | true             |
| github.com/alicebob/miniredis/v2                                             | v2.32.1                                    | v2.34.0                               | true   | true             |
| github.com/artefactual-sdps/temporal-activities                              | v0.0.0-20250411163551-a3b6ecf735e5         | v0.0.0-20250414234605-ca680164c966    | true   | true             |
```