### PR TITLE
Fix usage of golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,11 +28,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-golangci-lint-cache-
       - name: Run golangci-lint
-        run: make lint
-        env:
-          GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-lint-cache
-      - name: Run golangci-lint fmt
-        run: make fmt
+        run: make lint LINT_FLAGS=--fix=0
         env:
           GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-lint-cache
   shfmt:

--- a/Makefile
+++ b/Makefile
@@ -141,8 +141,8 @@ fmt: FMT_FLAGS ?=
 fmt: tool-golangci-lint
 	golangci-lint fmt $(FMT_FLAGS)
 
-lint: # @HELP Lint the project Go files with golangci-lint.
-lint: LINT_FLAGS ?= --timeout=5m --fix --output.text.colors
+lint: # @HELP Lint the project Go files with golangci-lint (linters + formatters).
+lint: LINT_FLAGS ?= --fix=1
 lint: tool-golangci-lint
 	golangci-lint run $(LINT_FLAGS)
 

--- a/internal/storage/persistence/ent/client/client.go
+++ b/internal/storage/persistence/ent/client/client.go
@@ -185,7 +185,10 @@ func (c *Client) UpdateAIPLocationID(ctx context.Context, aipID, locationID uuid
 	return nil
 }
 
-func (c *Client) ListWorkflows(ctx context.Context, f *persistence.WorkflowFilter) (goastorage.AIPWorkflowCollection, error) {
+func (c *Client) ListWorkflows(
+	ctx context.Context,
+	f *persistence.WorkflowFilter,
+) (goastorage.AIPWorkflowCollection, error) {
 	q := c.c.Workflow.Query()
 
 	if f.AIPUUID != nil {


### PR DESCRIPTION
Previously we relied on `golangci-lint fmt` in CI, but it only reformats code without ever returning a non‐zero exit code on violations. By switching to `golangci-lint run`, we get both formatter and linter checks in one command (TIL!).

We use `--fix` locally (via make lint) to automatically correct issues during development, but disable it in CI (`--fix=0`) so that the pipeline reports problems without mutating the code.

We can still use `make fmt` (equals to `golangci-lint fmt`) if you need faster formatting, as it does not invoke the linters.