### PR TITLE
Add delete SIP method to persistence

### DIFF
--- a/internal/persistence/ent/client/client_test.go
+++ b/internal/persistence/ent/client/client_test.go
@@ -1,7 +1,6 @@
 package entclient_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -32,6 +31,7 @@ func setUpClient(t *testing.T, logger logr.Logger) (*db.Client, persistence.Serv
 }
 
 func createSIP(
+	t *testing.T,
 	entc *db.Client,
 	name string,
 	status enums.SIPStatus,
@@ -43,10 +43,11 @@ func createSIP(
 		SetName(name).
 		SetAipID(aipID).
 		SetStatus(status).
-		Save(context.Background())
+		Save(t.Context())
 }
 
 func createWorkflow(
+	t *testing.T,
 	entc *db.Client,
 	sipID int,
 	status enums.WorkflowStatus,
@@ -56,7 +57,7 @@ func createWorkflow(
 		SetType(enums.WorkflowTypeCreateAip).
 		SetStatus(int8(status)). // #nosec G115 -- constrained value.
 		SetSipID(sipID).
-		Save(context.Background())
+		Save(t.Context())
 }
 
 func TestNew(t *testing.T) {
@@ -67,6 +68,7 @@ func TestNew(t *testing.T) {
 
 		entc, _ := setUpClient(t, logr.Discard())
 		s, err := createSIP(
+			t,
 			entc,
 			"testing 1-2-3",
 			enums.SIPStatusProcessing,

--- a/internal/persistence/ent/client/sip.go
+++ b/internal/persistence/ent/client/sip.go
@@ -112,6 +112,15 @@ func (c *client) UpdateSIP(
 	return convertSIP(s), nil
 }
 
+// DeleteSIP deletes the persisted SIP identified by id.
+func (c *client) DeleteSIP(ctx context.Context, id int) error {
+	if err := c.ent.SIP.DeleteOneID(id).Exec(ctx); err != nil {
+		return newDBErrorWithDetails(err, "delete SIP")
+	}
+
+	return nil
+}
+
 // ListSIPs returns a slice of SIPs filtered according to f.
 func (c *client) ListSIPs(ctx context.Context, f *persistence.SIPFilter) (
 	[]*datatypes.SIP, *persistence.Page, error,

--- a/internal/persistence/ent/client/sip_test.go
+++ b/internal/persistence/ent/client/sip_test.go
@@ -1,7 +1,6 @@
 package entclient_test
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 	"testing"
@@ -98,7 +97,7 @@ func TestCreateSIP(t *testing.T) {
 			t.Parallel()
 
 			_, svc := setUpClient(t, logr.Discard())
-			ctx := context.Background()
+			ctx := t.Context()
 			sip := *tt.args.sip // Make a local copy of sip.
 
 			err := svc.CreateSIP(ctx, &sip)
@@ -243,7 +242,7 @@ func TestUpdateSIP(t *testing.T) {
 			t.Parallel()
 
 			_, svc := setUpClient(t, logr.Discard())
-			ctx := context.Background()
+			ctx := t.Context()
 
 			var id int
 			if tt.args.sip != nil {
@@ -289,7 +288,7 @@ func TestDeleteSIP(t *testing.T) {
 			t.Parallel()
 
 			client, svc := setUpClient(t, logr.Discard())
-			ctx := context.Background()
+			ctx := t.Context()
 
 			sip := &datatypes.SIP{
 				UUID:   sipUUID,
@@ -728,7 +727,7 @@ func TestListSIPs(t *testing.T) {
 			t.Parallel()
 
 			_, svc := setUpClient(t, logr.Discard())
-			ctx := context.Background()
+			ctx := t.Context()
 
 			if len(tt.data) > 0 {
 				for _, sip := range tt.data {

--- a/internal/persistence/ent/client/task_test.go
+++ b/internal/persistence/ent/client/task_test.go
@@ -1,7 +1,6 @@
 package entclient_test
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -21,17 +20,17 @@ import (
 func addDBFixtures(t *testing.T, entc *db.Client) (*db.Workflow, *db.Workflow) {
 	t.Helper()
 
-	sip, err := createSIP(entc, "S1", enums.SIPStatusProcessing)
+	sip, err := createSIP(t, entc, "S1", enums.SIPStatusProcessing)
 	if err != nil {
 		t.Errorf("create SIP: %v", err)
 	}
 
-	w, err := createWorkflow(entc, sip.ID, enums.WorkflowStatusInProgress)
+	w, err := createWorkflow(t, entc, sip.ID, enums.WorkflowStatusInProgress)
 	if err != nil {
 		t.Errorf("create workflow: %v", err)
 	}
 
-	pa2, err := createWorkflow(entc, sip.ID, enums.WorkflowStatusDone)
+	pa2, err := createWorkflow(t, entc, sip.ID, enums.WorkflowStatusDone)
 	if err != nil {
 		t.Errorf("create workflow 2: %v", err)
 	}
@@ -114,13 +113,15 @@ func TestCreateTask(t *testing.T) {
 			t.Parallel()
 
 			entc, svc := setUpClient(t, logr.Discard())
-			ctx := context.Background()
+			ctx := t.Context()
 			sip, _ := createSIP(
+				t,
 				entc,
 				"Test SIP",
 				enums.SIPStatusIngested,
 			)
 			w, _ := createWorkflow(
+				t,
 				entc,
 				sip.ID,
 				enums.WorkflowStatusDone,
@@ -278,7 +279,7 @@ func TestUpdateTask(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			entc, svc := setUpClient(t, logr.Discard())
 			w, w2 := addDBFixtures(t, entc)
 

--- a/internal/persistence/ent/client/workflow_test.go
+++ b/internal/persistence/ent/client/workflow_test.go
@@ -1,7 +1,6 @@
 package entclient_test
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -89,8 +88,8 @@ func TestCreateWorkflow(t *testing.T) {
 			t.Parallel()
 
 			entc, svc := setUpClient(t, logr.Discard())
-			ctx := context.Background()
-			_, _ = createSIP(entc, "Test SIP", enums.SIPStatusProcessing)
+			ctx := t.Context()
+			_, _ = createSIP(t, entc, "Test SIP", enums.SIPStatusProcessing)
 
 			err := svc.CreateWorkflow(ctx, tt.args)
 			if tt.wantErr != "" {

--- a/internal/persistence/fake/mock_persistence.go
+++ b/internal/persistence/fake/mock_persistence.go
@@ -155,6 +155,44 @@ func (c *MockServiceCreateWorkflowCall) DoAndReturn(f func(context.Context, *dat
 	return c
 }
 
+// DeleteSIP mocks base method.
+func (m *MockService) DeleteSIP(arg0 context.Context, arg1 int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSIP", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteSIP indicates an expected call of DeleteSIP.
+func (mr *MockServiceMockRecorder) DeleteSIP(arg0, arg1 any) *MockServiceDeleteSIPCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSIP", reflect.TypeOf((*MockService)(nil).DeleteSIP), arg0, arg1)
+	return &MockServiceDeleteSIPCall{Call: call}
+}
+
+// MockServiceDeleteSIPCall wrap *gomock.Call
+type MockServiceDeleteSIPCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockServiceDeleteSIPCall) Return(arg0 error) *MockServiceDeleteSIPCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockServiceDeleteSIPCall) Do(f func(context.Context, int) error) *MockServiceDeleteSIPCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockServiceDeleteSIPCall) DoAndReturn(f func(context.Context, int) error) *MockServiceDeleteSIPCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListSIPs mocks base method.
 func (m *MockService) ListSIPs(arg0 context.Context, arg1 *persistence.SIPFilter) ([]*datatypes.SIP, *persistence.Page, error) {
 	m.ctrl.T.Helper()

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -29,6 +29,7 @@ type Service interface {
 	// (e.g. ID, CreatedAt).
 	CreateSIP(context.Context, *datatypes.SIP) error
 	UpdateSIP(context.Context, int, SIPUpdater) (*datatypes.SIP, error)
+	DeleteSIP(context.Context, int) error
 	ListSIPs(context.Context, *SIPFilter) ([]*datatypes.SIP, *Page, error)
 
 	CreateWorkflow(context.Context, *datatypes.Workflow) error

--- a/internal/persistence/telemetry.go
+++ b/internal/persistence/telemetry.go
@@ -58,6 +58,20 @@ func (w *wrapper) UpdateSIP(ctx context.Context, id int, updater SIPUpdater) (*d
 	return r, nil
 }
 
+func (w *wrapper) DeleteSIP(ctx context.Context, id int) error {
+	ctx, span := w.tracer.Start(ctx, "DeleteSIP")
+	defer span.End()
+	span.SetAttributes(attribute.Int("id", id))
+
+	err := w.wrapped.DeleteSIP(ctx, id)
+	if err != nil {
+		telemetry.RecordError(span, err)
+		return updateError(err, "DeleteSIP")
+	}
+
+	return nil
+}
+
 func (w *wrapper) ListSIPs(ctx context.Context, f *SIPFilter) ([]*datatypes.SIP, *Page, error) {
 	ctx, span := w.tracer.Start(ctx, "ListSIPs")
 	defer span.End()

--- a/internal/watcher/fake/mock_watcher.go
+++ b/internal/watcher/fake/mock_watcher.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 	time "time"
 
+	enums "github.com/artefactual-sdps/enduro/internal/enums"
 	watcher "github.com/artefactual-sdps/enduro/internal/watcher"
 	gomock "go.uber.org/mock/gomock"
 	blob "gocloud.dev/blob"
@@ -345,6 +346,44 @@ func (c *MockWatcherWatchCall) Do(f func(context.Context) (*watcher.BlobEvent, w
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockWatcherWatchCall) DoAndReturn(f func(context.Context) (*watcher.BlobEvent, watcher.Cleanup, error)) *MockWatcherWatchCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// WorkflowType mocks base method.
+func (m *MockWatcher) WorkflowType() enums.WorkflowType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkflowType")
+	ret0, _ := ret[0].(enums.WorkflowType)
+	return ret0
+}
+
+// WorkflowType indicates an expected call of WorkflowType.
+func (mr *MockWatcherMockRecorder) WorkflowType() *MockWatcherWorkflowTypeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkflowType", reflect.TypeOf((*MockWatcher)(nil).WorkflowType))
+	return &MockWatcherWorkflowTypeCall{Call: call}
+}
+
+// MockWatcherWorkflowTypeCall wrap *gomock.Call
+type MockWatcherWorkflowTypeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockWatcherWorkflowTypeCall) Return(arg0 enums.WorkflowType) *MockWatcherWorkflowTypeCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockWatcherWorkflowTypeCall) Do(f func() enums.WorkflowType) *MockWatcherWorkflowTypeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockWatcherWorkflowTypeCall) DoAndReturn(f func() enums.WorkflowType) *MockWatcherWorkflowTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
Will be used in case of an error starting the ingest workflow from the upload endpoint, to do a manual rollback of the SIP creation.

Refs #1210.