### PR TITLE
Update processing workflow request

### DIFF
--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -392,6 +392,7 @@ func main() {
 									IsDir:           event.IsDir,
 									Type:            event.WorkflowType,
 									SIPUUID:         uuid.New(),
+									SIPName:         event.Key,
 								}
 								if err := ingest.InitProcessingWorkflow(ctx, temporalClient, cfg.Temporal.TaskQueue, &req); err != nil {
 									logger.Error(err, "Error initializing processing workflow.")

--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -385,14 +385,13 @@ func main() {
 							go func() {
 								defer span.End()
 								req := ingest.ProcessingWorkflowRequest{
-									WatcherName:      event.WatcherName,
-									RetentionPeriod:  event.RetentionPeriod,
-									CompletedDir:     event.CompletedDir,
-									StripTopLevelDir: event.StripTopLevelDir,
-									Key:              event.Key,
-									IsDir:            event.IsDir,
-									Type:             event.WorkflowType,
-									SIPUUID:          uuid.New(),
+									WatcherName:     event.WatcherName,
+									RetentionPeriod: event.RetentionPeriod,
+									CompletedDir:    event.CompletedDir,
+									Key:             event.Key,
+									IsDir:           event.IsDir,
+									Type:            event.WorkflowType,
+									SIPUUID:         uuid.New(),
 								}
 								if err := ingest.InitProcessingWorkflow(ctx, temporalClient, cfg.Temporal.TaskQueue, &req); err != nil {
 									logger.Error(err, "Error initializing processing workflow.")

--- a/enduro.toml
+++ b/enduro.toml
@@ -98,7 +98,6 @@ key = "minio"
 secret = "minio123"
 region = "us-west-1"
 bucket = "sips"
-stripTopLevelDir = true
 # workflowType is the processing workflow type related to this watcher.
 # Available workflow types are "create aip" and "create and review aip",
 # the later only works properly when the preservation system is "a3m".

--- a/internal/ingest/workflows.go
+++ b/internal/ingest/workflows.go
@@ -29,6 +29,9 @@ type ProcessingWorkflowRequest struct {
 	// Unique identifier of the SIP.
 	SIPUUID uuid.UUID
 
+	// Name of the SIP.
+	SIPName string
+
 	// Type of workflow to execute.
 	Type enums.WorkflowType
 

--- a/internal/ingest/workflows.go
+++ b/internal/ingest/workflows.go
@@ -43,9 +43,6 @@ type ProcessingWorkflowRequest struct {
 	// successfully.
 	CompletedDir string
 
-	// Whether the top-level directory is meant to be stripped.
-	StripTopLevelDir bool
-
 	// Key of the blob.
 	Key string
 

--- a/internal/watcher/config.go
+++ b/internal/watcher/config.go
@@ -84,8 +84,7 @@ type FilesystemConfig struct {
 	Ignore       string
 	Inotify      bool
 
-	RetentionPeriod  *time.Duration
-	StripTopLevelDir bool
+	RetentionPeriod *time.Duration
 
 	// PollInterval sets the length of time between filesystem polls (default:
 	// 200ms). If Inotify is true then PollInterval is ignored.
@@ -119,8 +118,7 @@ type MinioConfig struct {
 	Bucket          string
 	URL             string
 
-	RetentionPeriod  *time.Duration
-	StripTopLevelDir bool
+	RetentionPeriod *time.Duration
 
 	// PollInterval sets the length of time between Redis polls (default: 1s).
 	PollInterval time.Duration

--- a/internal/watcher/event.go
+++ b/internal/watcher/event.go
@@ -25,9 +25,6 @@ type BlobEvent struct {
 	// successfully.
 	CompletedDir string
 
-	// Whether the top-level directory is meant to be stripped.
-	StripTopLevelDir bool
-
 	// Key of the blob.
 	Key string
 
@@ -43,13 +40,12 @@ type BlobEvent struct {
 
 func NewBlobEvent(w Watcher, key string, isDir bool) *BlobEvent {
 	return &BlobEvent{
-		WatcherName:      w.String(),
-		RetentionPeriod:  w.RetentionPeriod(),
-		CompletedDir:     w.CompletedDir(),
-		StripTopLevelDir: w.StripTopLevelDir(),
-		WorkflowType:     w.WorkflowType(),
-		Key:              key,
-		IsDir:            isDir,
+		WatcherName:     w.String(),
+		RetentionPeriod: w.RetentionPeriod(),
+		CompletedDir:    w.CompletedDir(),
+		WorkflowType:    w.WorkflowType(),
+		Key:             key,
+		IsDir:           isDir,
 	}
 }
 

--- a/internal/watcher/fake/mock_watcher.go
+++ b/internal/watcher/fake/mock_watcher.go
@@ -272,44 +272,6 @@ func (c *MockWatcherStringCall) DoAndReturn(f func() string) *MockWatcherStringC
 	return c
 }
 
-// StripTopLevelDir mocks base method.
-func (m *MockWatcher) StripTopLevelDir() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StripTopLevelDir")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// StripTopLevelDir indicates an expected call of StripTopLevelDir.
-func (mr *MockWatcherMockRecorder) StripTopLevelDir() *MockWatcherStripTopLevelDirCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StripTopLevelDir", reflect.TypeOf((*MockWatcher)(nil).StripTopLevelDir))
-	return &MockWatcherStripTopLevelDirCall{Call: call}
-}
-
-// MockWatcherStripTopLevelDirCall wrap *gomock.Call
-type MockWatcherStripTopLevelDirCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockWatcherStripTopLevelDirCall) Return(arg0 bool) *MockWatcherStripTopLevelDirCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockWatcherStripTopLevelDirCall) Do(f func() bool) *MockWatcherStripTopLevelDirCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockWatcherStripTopLevelDirCall) DoAndReturn(f func() bool) *MockWatcherStripTopLevelDirCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // Watch mocks base method.
 func (m *MockWatcher) Watch(arg0 context.Context) (*watcher.BlobEvent, watcher.Cleanup, error) {
 	m.ctrl.T.Helper()

--- a/internal/watcher/filesystem.go
+++ b/internal/watcher/filesystem.go
@@ -71,11 +71,10 @@ func NewFilesystemWatcher(ctx context.Context, config *FilesystemConfig) (*files
 		path:  abspath,
 		regex: regex,
 		commonWatcherImpl: &commonWatcherImpl{
-			name:             config.Name,
-			retentionPeriod:  config.RetentionPeriod,
-			completedDir:     config.CompletedDir,
-			stripTopLevelDir: config.StripTopLevelDir,
-			workflowType:     config.WorkflowType,
+			name:            config.Name,
+			retentionPeriod: config.RetentionPeriod,
+			completedDir:    config.CompletedDir,
+			workflowType:    config.WorkflowType,
 		},
 	}
 

--- a/internal/watcher/minio.go
+++ b/internal/watcher/minio.go
@@ -87,10 +87,9 @@ func NewMinioWatcher(
 		logger:       logger,
 		bucketConfig: bucketConfig,
 		commonWatcherImpl: &commonWatcherImpl{
-			name:             config.Name,
-			retentionPeriod:  config.RetentionPeriod,
-			stripTopLevelDir: config.StripTopLevelDir,
-			workflowType:     config.WorkflowType,
+			name:            config.Name,
+			retentionPeriod: config.RetentionPeriod,
+			workflowType:    config.WorkflowType,
 		},
 	}, nil
 }

--- a/internal/watcher/minio_test.go
+++ b/internal/watcher/minio_test.go
@@ -30,19 +30,18 @@ func newWatcher(t *testing.T, updateCfg func(c *watcher.MinioConfig)) (*miniredi
 
 	// Default config.
 	config := &watcher.MinioConfig{
-		Name:             "minio-watcher",
-		RedisAddress:     fmt.Sprintf("redis://%s", m.Addr()),
-		RedisList:        "minio-events",
-		Region:           "eu-south-1",
-		Endpoint:         "endpoint",
-		PathStyle:        true,
-		Profile:          "profile",
-		Key:              "key",
-		Secret:           "secret",
-		Token:            "token",
-		Bucket:           "bucket",
-		RetentionPeriod:  &dur,
-		StripTopLevelDir: true,
+		Name:            "minio-watcher",
+		RedisAddress:    fmt.Sprintf("redis://%s", m.Addr()),
+		RedisList:       "minio-events",
+		Region:          "eu-south-1",
+		Endpoint:        "endpoint",
+		PathStyle:       true,
+		Profile:         "profile",
+		Key:             "key",
+		Secret:          "secret",
+		Token:           "token",
+		Bucket:          "bucket",
+		RetentionPeriod: &dur,
 	}
 
 	// Modify default config.

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -41,7 +41,6 @@ type Watcher interface {
 
 	RetentionPeriod() *time.Duration
 	CompletedDir() string
-	StripTopLevelDir() bool
 	WorkflowType() enums.WorkflowType
 
 	// Full path of the watched bucket when available, empty string otherwise.
@@ -51,11 +50,10 @@ type Watcher interface {
 }
 
 type commonWatcherImpl struct {
-	name             string
-	retentionPeriod  *time.Duration
-	completedDir     string
-	stripTopLevelDir bool
-	workflowType     enums.WorkflowType
+	name            string
+	retentionPeriod *time.Duration
+	completedDir    string
+	workflowType    enums.WorkflowType
 }
 
 func (w *commonWatcherImpl) String() string {
@@ -68,10 +66,6 @@ func (w *commonWatcherImpl) RetentionPeriod() *time.Duration {
 
 func (w *commonWatcherImpl) CompletedDir() string {
 	return w.completedDir
-}
-
-func (w *commonWatcherImpl) StripTopLevelDir() bool {
-	return w.stripTopLevelDir
 }
 
 func (w *commonWatcherImpl) WorkflowType() enums.WorkflowType {

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -249,7 +249,7 @@ func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *inge
 						activityOpts,
 						activities.DeleteOriginalActivityName,
 						req.WatcherName,
-						state.sip.name,
+						req.Key,
 					).Get(activityOpts, nil)
 				}
 			} else if req.CompletedDir != "" {
@@ -259,7 +259,7 @@ func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *inge
 					activities.DisposeOriginalActivityName,
 					req.WatcherName,
 					req.CompletedDir,
-					state.sip.name,
+					req.Key,
 				).Get(activityOpts, nil)
 			}
 		}
@@ -269,6 +269,7 @@ func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *inge
 		"Workflow completed successfully!",
 		"SIPUUID", state.sip.uuid,
 		"watcher", req.WatcherName,
+		"key", req.Key,
 		"name", state.sip.name,
 		"status", state.status,
 	)
@@ -327,7 +328,7 @@ func (w *ProcessingWorkflow) SessionHandler(
 		var downloadResult activities.DownloadActivityResult
 		activityOpts := withActivityOptsForLongLivedRequest(sessCtx)
 		params := &activities.DownloadActivityParams{
-			Key:         state.sip.name,
+			Key:         state.req.Key,
 			WatcherName: state.req.WatcherName,
 		}
 		if w.cfg.Preprocessing.Enabled {

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -282,6 +282,7 @@ func (s *ProcessingWorkflowTestSuite) TestConfirmation() {
 	s.SetupWorkflowTest(cfg)
 
 	sipID := 1
+	sipName := "name.zip"
 	wID := 1
 	valPREMISTaskID := 102
 	ctx := mock.AnythingOfType("*context.valueCtx")
@@ -415,11 +416,12 @@ func (s *ProcessingWorkflowTestSuite) TestConfirmation() {
 	s.env.ExecuteWorkflow(
 		s.workflow.Execute,
 		&ingest.ProcessingWorkflowRequest{
-			Key:             "transfer.zip",
+			Key:             key,
 			WatcherName:     watcherName,
 			RetentionPeriod: &retentionPeriod,
 			Type:            enums.WorkflowTypeCreateAndReviewAip,
 			SIPUUID:         sipUUID,
+			SIPName:         sipName,
 		},
 	)
 
@@ -438,6 +440,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 	s.SetupWorkflowTest(cfg)
 
 	sipID := 1
+	sipName := "name.zip"
 	wID := 1
 	valBagTaskID := 101
 	moveAIPTaskID := 103
@@ -454,7 +457,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 		createSIPLocalActivity,
 		ctx,
 		ingestsvc,
-		&createSIPLocalActivityParams{UUID: sipUUID, Name: key, Status: enums.SIPStatusQueued},
+		&createSIPLocalActivityParams{UUID: sipUUID, Name: sipName, Status: enums.SIPStatusQueued},
 	).Return(sipID, nil).Once()
 	s.env.OnActivity(
 		setStatusInProgressLocalActivity,
@@ -616,6 +619,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 			RetentionPeriod: &retentionPeriod,
 			Type:            enums.WorkflowTypeCreateAip,
 			SIPUUID:         sipUUID,
+			SIPName:         sipName,
 		},
 	)
 
@@ -625,6 +629,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 
 func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 	sipID := 1
+	sipName := "name.zip"
 	wID := 1
 	valPREMISTaskID := 102
 	watcherName := "watcher"
@@ -653,7 +658,7 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 	// Activity mocks/assertions sequence
 	s.env.OnActivity(createSIPLocalActivity, ctx,
 		ingestsvc,
-		&createSIPLocalActivityParams{UUID: sipUUID, Name: key, Status: enums.SIPStatusQueued},
+		&createSIPLocalActivityParams{UUID: sipUUID, Name: sipName, Status: enums.SIPStatusQueued},
 	).Return(sipID, nil)
 
 	s.env.OnActivity(setStatusInProgressLocalActivity, ctx, ingestsvc, sipUUID, mock.AnythingOfType("time.Time")).
@@ -747,7 +752,7 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 	)
 
 	s.env.OnActivity(am.StartTransferActivityName, sessionCtx,
-		&am.StartTransferActivityParams{Name: key, RelativePath: "transfer.zip", ZipPIP: true},
+		&am.StartTransferActivityParams{Name: sipName, RelativePath: "transfer.zip", ZipPIP: true},
 	).Return(
 		&am.StartTransferActivityResult{TransferID: transferID.String()}, nil,
 	)
@@ -766,7 +771,7 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 
 	s.env.OnActivity(activities.CreateStorageAIPActivityName, sessionCtx,
 		&activities.CreateStorageAIPActivityParams{
-			Name:       key,
+			Name:       sipName,
 			AIPID:      aipUUID.String(),
 			ObjectKey:  aipUUID.String(),
 			Status:     "stored",
@@ -811,6 +816,7 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 			Type:            enums.WorkflowTypeCreateAip,
 			Key:             key,
 			SIPUUID:         sipUUID,
+			SIPName:         sipName,
 		},
 	)
 
@@ -829,6 +835,7 @@ func (s *ProcessingWorkflowTestSuite) TestRejection() {
 	s.SetupWorkflowTest(cfg)
 
 	sipID := 1
+	sipName := "name.zip"
 	key := "transfer.zip"
 	watcherName := "watcher"
 	retentionPeriod := 1 * time.Second
@@ -912,11 +919,12 @@ func (s *ProcessingWorkflowTestSuite) TestRejection() {
 	s.env.ExecuteWorkflow(
 		s.workflow.Execute,
 		&ingest.ProcessingWorkflowRequest{
-			Key:             "transfer.zip",
+			Key:             key,
 			WatcherName:     watcherName,
 			RetentionPeriod: &retentionPeriod,
 			Type:            enums.WorkflowTypeCreateAndReviewAip,
 			SIPUUID:         sipUUID,
+			SIPName:         sipName,
 		},
 	)
 
@@ -957,6 +965,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	s.SetupWorkflowTest(cfg)
 
 	sipID := 1
+	sipName := "name.zip"
 	valBagTaskID := 101
 	moveAIPTaskID := 103
 	watcherName := "watcher"
@@ -975,7 +984,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 		createSIPLocalActivity,
 		ctx,
 		ingestsvc,
-		&createSIPLocalActivityParams{UUID: sipUUID, Name: key, Status: enums.SIPStatusQueued},
+		&createSIPLocalActivityParams{UUID: sipUUID, Name: sipName, Status: enums.SIPStatusQueued},
 	).Return(sipID, nil)
 
 	s.env.OnActivity(
@@ -1204,6 +1213,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 			RetentionPeriod: &retentionPeriod,
 			Type:            enums.WorkflowTypeCreateAip,
 			SIPUUID:         sipUUID,
+			SIPName:         sipName,
 		},
 	)
 
@@ -1230,6 +1240,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 	s.SetupWorkflowTest(cfg)
 
 	sipID := 1
+	sipName := "name.zip"
 	watcherName := "watcher"
 	key := "transfer.zip"
 	retentionPeriod := 1 * time.Second
@@ -1243,7 +1254,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 		createSIPLocalActivity,
 		ctx,
 		ingestsvc,
-		&createSIPLocalActivityParams{UUID: sipUUID, Name: key, Status: enums.SIPStatusQueued},
+		&createSIPLocalActivityParams{UUID: sipUUID, Name: sipName, Status: enums.SIPStatusQueued},
 	).Return(sipID, nil)
 
 	s.env.OnActivity(
@@ -1296,7 +1307,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 		sessionCtx,
 		&bucketupload.Params{
 			Path:       downloadDir + "/" + key,
-			Key:        fmt.Sprintf("Failed_%s", key),
+			Key:        fmt.Sprintf("Failed_%s", sipName),
 			BufferSize: 100_000_000,
 		},
 	).Return(&bucketupload.Result{}, nil)
@@ -1329,6 +1340,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 			RetentionPeriod: &retentionPeriod,
 			Type:            enums.WorkflowTypeCreateAip,
 			SIPUUID:         sipUUID,
+			SIPName:         sipName,
 		},
 	)
 
@@ -1345,6 +1357,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPA3m() {
 	s.SetupWorkflowTest(cfg)
 
 	sipID := 1
+	sipName := "name.zip"
 	valBagTaskID := 101
 	watcherName := "watcher"
 	key := "transfer.zip"
@@ -1358,7 +1371,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPA3m() {
 		createSIPLocalActivity,
 		ctx,
 		ingestsvc,
-		&createSIPLocalActivityParams{UUID: sipUUID, Name: key, Status: enums.SIPStatusQueued},
+		&createSIPLocalActivityParams{UUID: sipUUID, Name: sipName, Status: enums.SIPStatusQueued},
 	).Return(sipID, nil)
 
 	s.env.OnActivity(
@@ -1461,7 +1474,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPA3m() {
 		sessionCtx,
 		&bucketupload.Params{
 			Path:       transferPath + ".zip",
-			Key:        fmt.Sprintf("Failed_%s", key),
+			Key:        fmt.Sprintf("Failed_%s", sipName),
 			BufferSize: 100_000_000,
 		},
 	).Return(&bucketupload.Result{}, nil)
@@ -1494,6 +1507,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPA3m() {
 			RetentionPeriod: &retentionPeriod,
 			Type:            enums.WorkflowTypeCreateAip,
 			SIPUUID:         sipUUID,
+			SIPName:         sipName,
 		},
 	)
 
@@ -1510,6 +1524,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPAM() {
 	s.SetupWorkflowTest(cfg)
 
 	sipID := 1
+	sipName := "name.zip"
 	wID := 1
 	watcherName := "watcher"
 	key := "transfer.zip"
@@ -1522,7 +1537,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPAM() {
 		createSIPLocalActivity,
 		ctx,
 		ingestsvc,
-		&createSIPLocalActivityParams{UUID: sipUUID, Name: key, Status: enums.SIPStatusQueued},
+		&createSIPLocalActivityParams{UUID: sipUUID, Name: sipName, Status: enums.SIPStatusQueued},
 	).Return(sipID, nil)
 
 	s.env.OnActivity(setStatusInProgressLocalActivity, ctx, ingestsvc, sipUUID, mock.AnythingOfType("time.Time")).
@@ -1576,7 +1591,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPAM() {
 		sessionCtx,
 		&bucketupload.Params{
 			Path:       extractPath + "/transfer.zip",
-			Key:        fmt.Sprintf("Failed_%s", key),
+			Key:        fmt.Sprintf("Failed_%s", sipName),
 			BufferSize: 100_000_000,
 		},
 	).Return(&bucketupload.Result{}, nil)
@@ -1609,6 +1624,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPAM() {
 			Type:            enums.WorkflowTypeCreateAip,
 			Key:             key,
 			SIPUUID:         sipUUID,
+			SIPName:         sipName,
 		},
 	)
 

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -42,7 +42,7 @@ func newWorkflowState(req *ingest.ProcessingWorkflowRequest) *workflowState {
 		status: enums.WorkflowStatusUnspecified,
 		sip: &sipInfo{
 			uuid:  req.SIPUUID,
-			name:  req.Key,
+			name:  req.SIPName,
 			isDir: req.IsDir,
 
 			// All SIPs start in queued status.


### PR DESCRIPTION
A couple more changes to the workflow request:

- Remove stripTopLevelDir configuration:

No longer used in the processing workflow, remove it from the watcher
configuration and the workflow request.

- Add SIPName to processing workflow request :

Allows to differnetiate between the object key and the SIP name. For now
they are the same value in the existing workflow request, but we'll need
to make the distinction when the workflow is also started from the API.

Refs #1210.