### PR TITLE
Add failed as and failed key to SIPs

### DIFF
--- a/dashboard/src/openapi-generator/models/EnduroIngestSip.ts
+++ b/dashboard/src/openapi-generator/models/EnduroIngestSip.ts
@@ -38,6 +38,18 @@ export interface EnduroIngestSip {
      */
     createdAt: Date;
     /**
+     * Package type in case of failure (SIP or PIP)
+     * @type {string}
+     * @memberof EnduroIngestSip
+     */
+    failedAs?: EnduroIngestSipFailedAsEnum;
+    /**
+     * Object key of the failed package in the internal bucket
+     * @type {string}
+     * @memberof EnduroIngestSip
+     */
+    failedKey?: string;
+    /**
      * Name of the SIP
      * @type {string}
      * @memberof EnduroIngestSip
@@ -63,6 +75,15 @@ export interface EnduroIngestSip {
     uuid: string;
 }
 
+
+/**
+ * @export
+ */
+export const EnduroIngestSipFailedAsEnum = {
+    Sip: 'SIP',
+    Pip: 'PIP'
+} as const;
+export type EnduroIngestSipFailedAsEnum = typeof EnduroIngestSipFailedAsEnum[keyof typeof EnduroIngestSipFailedAsEnum];
 
 /**
  * @export
@@ -103,6 +124,8 @@ export function EnduroIngestSipFromJSONTyped(json: any, ignoreDiscriminator: boo
         'aipId': !exists(json, 'aip_id') ? undefined : json['aip_id'],
         'completedAt': !exists(json, 'completed_at') ? undefined : (new Date(json['completed_at'])),
         'createdAt': (new Date(json['created_at'])),
+        'failedAs': !exists(json, 'failed_as') ? undefined : json['failed_as'],
+        'failedKey': !exists(json, 'failed_key') ? undefined : json['failed_key'],
         'name': !exists(json, 'name') ? undefined : json['name'],
         'startedAt': !exists(json, 'started_at') ? undefined : (new Date(json['started_at'])),
         'status': json['status'],
@@ -122,6 +145,8 @@ export function EnduroIngestSipToJSON(value?: EnduroIngestSip | null): any {
         'aip_id': value.aipId,
         'completed_at': value.completedAt === undefined ? undefined : (value.completedAt.toISOString()),
         'created_at': (value.createdAt.toISOString()),
+        'failed_as': value.failedAs,
+        'failed_key': value.failedKey,
         'name': value.name,
         'started_at': value.startedAt === undefined ? undefined : (value.startedAt.toISOString()),
         'status': value.status,

--- a/internal/api/design/ingest.go
+++ b/internal/api/design/ingest.go
@@ -233,6 +233,10 @@ var EnumSIPStatus = func() {
 	Enum(enums.SIPStatusInterfaces()...)
 }
 
+var EnumSIPFailedAs = func() {
+	Enum(enums.SIPFailedAsInterfaces()...)
+}
+
 var SIP = ResultType("application/vnd.enduro.ingest.sip", func() {
 	Description("SIP describes an ingest SIP type.")
 	TypeName("SIP")
@@ -252,6 +256,10 @@ var SIP = ResultType("application/vnd.enduro.ingest.sip", func() {
 		Attribute("completed_at", String, "Completion datetime", func() {
 			Format(FormatDateTime)
 		})
+		Attribute("failed_as", String, "Package type in case of failure (SIP or PIP)", func() {
+			EnumSIPFailedAs()
+		})
+		Attribute("failed_key", String, "Object key of the failed package in the internal bucket")
 	})
 	View("default", func() {
 		Attribute("uuid")
@@ -261,6 +269,8 @@ var SIP = ResultType("application/vnd.enduro.ingest.sip", func() {
 		Attribute("created_at")
 		Attribute("started_at")
 		Attribute("completed_at")
+		Attribute("failed_as")
+		Attribute("failed_key")
 	})
 	Required("uuid", "status", "created_at")
 })

--- a/internal/api/gen/about/service.go
+++ b/internal/api/gen/about/service.go
@@ -91,6 +91,10 @@ type SIP struct {
 	StartedAt *string
 	// Completion datetime
 	CompletedAt *string
+	// Package type in case of failure (SIP or PIP)
+	FailedAs *string
+	// Object key of the failed package in the internal bucket
+	FailedKey *string
 }
 
 type SIPCreatedEvent struct {

--- a/internal/api/gen/http/ingest/client/encode_decode.go
+++ b/internal/api/gen/http/ingest/client/encode_decode.go
@@ -1140,6 +1140,8 @@ func unmarshalSIPResponseBodyToIngestviewsSIPView(v *SIPResponseBody) *ingestvie
 		CreatedAt:   v.CreatedAt,
 		StartedAt:   v.StartedAt,
 		CompletedAt: v.CompletedAt,
+		FailedAs:    v.FailedAs,
+		FailedKey:   v.FailedKey,
 	}
 
 	return res

--- a/internal/api/gen/http/ingest/client/types.go
+++ b/internal/api/gen/http/ingest/client/types.go
@@ -67,6 +67,10 @@ type ShowSipResponseBody struct {
 	StartedAt *string `form:"started_at,omitempty" json:"started_at,omitempty" xml:"started_at,omitempty"`
 	// Completion datetime
 	CompletedAt *string `form:"completed_at,omitempty" json:"completed_at,omitempty" xml:"completed_at,omitempty"`
+	// Package type in case of failure (SIP or PIP)
+	FailedAs *string `form:"failed_as,omitempty" json:"failed_as,omitempty" xml:"failed_as,omitempty"`
+	// Object key of the failed package in the internal bucket
+	FailedKey *string `form:"failed_key,omitempty" json:"failed_key,omitempty" xml:"failed_key,omitempty"`
 }
 
 // ListSipWorkflowsResponseBody is the type of the "ingest" service
@@ -336,6 +340,10 @@ type SIPResponseBody struct {
 	StartedAt *string `form:"started_at,omitempty" json:"started_at,omitempty" xml:"started_at,omitempty"`
 	// Completion datetime
 	CompletedAt *string `form:"completed_at,omitempty" json:"completed_at,omitempty" xml:"completed_at,omitempty"`
+	// Package type in case of failure (SIP or PIP)
+	FailedAs *string `form:"failed_as,omitempty" json:"failed_as,omitempty" xml:"failed_as,omitempty"`
+	// Object key of the failed package in the internal bucket
+	FailedKey *string `form:"failed_key,omitempty" json:"failed_key,omitempty" xml:"failed_key,omitempty"`
 }
 
 // EnduroPageResponseBody is used to define fields on response body types.
@@ -559,6 +567,8 @@ func NewShowSipSIPOK(body *ShowSipResponseBody) *ingestviews.SIPView {
 		CreatedAt:   body.CreatedAt,
 		StartedAt:   body.StartedAt,
 		CompletedAt: body.CompletedAt,
+		FailedAs:    body.FailedAs,
+		FailedKey:   body.FailedKey,
 	}
 
 	return v
@@ -1226,6 +1236,11 @@ func ValidateSIPResponseBody(body *SIPResponseBody) (err error) {
 	}
 	if body.CompletedAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.completed_at", *body.CompletedAt, goa.FormatDateTime))
+	}
+	if body.FailedAs != nil {
+		if !(*body.FailedAs == "SIP" || *body.FailedAs == "PIP") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.failed_as", *body.FailedAs, []any{"SIP", "PIP"}))
+		}
 	}
 	return
 }

--- a/internal/api/gen/http/ingest/server/encode_decode.go
+++ b/internal/api/gen/http/ingest/server/encode_decode.go
@@ -890,6 +890,8 @@ func marshalIngestviewsSIPViewToSIPResponseBody(v *ingestviews.SIPView) *SIPResp
 		CreatedAt:   *v.CreatedAt,
 		StartedAt:   v.StartedAt,
 		CompletedAt: v.CompletedAt,
+		FailedAs:    v.FailedAs,
+		FailedKey:   v.FailedKey,
 	}
 
 	return res

--- a/internal/api/gen/http/ingest/server/types.go
+++ b/internal/api/gen/http/ingest/server/types.go
@@ -67,6 +67,10 @@ type ShowSipResponseBody struct {
 	StartedAt *string `form:"started_at,omitempty" json:"started_at,omitempty" xml:"started_at,omitempty"`
 	// Completion datetime
 	CompletedAt *string `form:"completed_at,omitempty" json:"completed_at,omitempty" xml:"completed_at,omitempty"`
+	// Package type in case of failure (SIP or PIP)
+	FailedAs *string `form:"failed_as,omitempty" json:"failed_as,omitempty" xml:"failed_as,omitempty"`
+	// Object key of the failed package in the internal bucket
+	FailedKey *string `form:"failed_key,omitempty" json:"failed_key,omitempty" xml:"failed_key,omitempty"`
 }
 
 // ListSipWorkflowsResponseBody is the type of the "ingest" service
@@ -336,6 +340,10 @@ type SIPResponseBody struct {
 	StartedAt *string `form:"started_at,omitempty" json:"started_at,omitempty" xml:"started_at,omitempty"`
 	// Completion datetime
 	CompletedAt *string `form:"completed_at,omitempty" json:"completed_at,omitempty" xml:"completed_at,omitempty"`
+	// Package type in case of failure (SIP or PIP)
+	FailedAs *string `form:"failed_as,omitempty" json:"failed_as,omitempty" xml:"failed_as,omitempty"`
+	// Object key of the failed package in the internal bucket
+	FailedKey *string `form:"failed_key,omitempty" json:"failed_key,omitempty" xml:"failed_key,omitempty"`
 }
 
 // EnduroPageResponseBody is used to define fields on response body types.
@@ -456,6 +464,8 @@ func NewShowSipResponseBody(res *ingestviews.SIPView) *ShowSipResponseBody {
 		CreatedAt:   *res.CreatedAt,
 		StartedAt:   res.StartedAt,
 		CompletedAt: res.CompletedAt,
+		FailedAs:    res.FailedAs,
+		FailedKey:   res.FailedKey,
 	}
 	return body
 }

--- a/internal/api/gen/http/openapi.json
+++ b/internal/api/gen/http/openapi.json
@@ -734,6 +734,8 @@
             "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "completed_at": "1970-01-01T00:00:01Z",
             "created_at": "1970-01-01T00:00:01Z",
+            "failed_as": "PIP",
+            "failed_key": "abc123",
             "name": "abc123",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "failed",
@@ -871,14 +873,14 @@
       "example": {
         "event": {
           "Type": "sip_created_event",
-          "Value": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}"
+          "Value": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"failed_as\":\"PIP\",\"failed_key\":\"abc123\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}"
         }
       },
       "properties": {
         "event": {
           "example": {
             "Type": "sip_created_event",
-            "Value": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}"
+            "Value": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"failed_as\":\"PIP\",\"failed_key\":\"abc123\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}"
           },
           "properties": {
             "Type": {
@@ -898,7 +900,7 @@
             },
             "Value": {
               "description": "JSON encoded union value",
-              "example": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}",
+              "example": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"failed_as\":\"PIP\",\"failed_key\":\"abc123\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}",
               "type": "string"
             }
           },
@@ -1129,6 +1131,8 @@
         "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
         "completed_at": "1970-01-01T00:00:01Z",
         "created_at": "1970-01-01T00:00:01Z",
+        "failed_as": "PIP",
+        "failed_key": "abc123",
         "name": "abc123",
         "started_at": "1970-01-01T00:00:01Z",
         "status": "failed",
@@ -1151,6 +1155,20 @@
           "description": "Creation datetime",
           "example": "1970-01-01T00:00:01Z",
           "format": "date-time",
+          "type": "string"
+        },
+        "failed_as": {
+          "description": "Package type in case of failure (SIP or PIP)",
+          "enum": [
+            "SIP",
+            "PIP"
+          ],
+          "example": "PIP",
+          "type": "string"
+        },
+        "failed_key": {
+          "description": "Object key of the failed package in the internal bucket",
+          "example": "abc123",
           "type": "string"
         },
         "name": {
@@ -1438,6 +1456,8 @@
         "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
         "completed_at": "1970-01-01T00:00:01Z",
         "created_at": "1970-01-01T00:00:01Z",
+        "failed_as": "PIP",
+        "failed_key": "abc123",
         "name": "abc123",
         "started_at": "1970-01-01T00:00:01Z",
         "status": "failed",
@@ -1460,6 +1480,20 @@
           "description": "Creation datetime",
           "example": "1970-01-01T00:00:01Z",
           "format": "date-time",
+          "type": "string"
+        },
+        "failed_as": {
+          "description": "Package type in case of failure (SIP or PIP)",
+          "enum": [
+            "SIP",
+            "PIP"
+          ],
+          "example": "PIP",
+          "type": "string"
+        },
+        "failed_key": {
+          "description": "Object key of the failed package in the internal bucket",
+          "example": "abc123",
           "type": "string"
         },
         "name": {
@@ -1507,6 +1541,8 @@
           "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
           "completed_at": "1970-01-01T00:00:01Z",
           "created_at": "1970-01-01T00:00:01Z",
+          "failed_as": "PIP",
+          "failed_key": "abc123",
           "name": "abc123",
           "started_at": "1970-01-01T00:00:01Z",
           "status": "failed",

--- a/internal/api/gen/http/openapi.yaml
+++ b/internal/api/gen/http/openapi.yaml
@@ -1895,6 +1895,8 @@ definitions:
                 - aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                   completed_at: "1970-01-01T00:00:01Z"
                   created_at: "1970-01-01T00:00:01Z"
+                  failed_as: PIP
+                  failed_key: abc123
                   name: abc123
                   started_at: "1970-01-01T00:00:01Z"
                   status: failed
@@ -2024,17 +2026,17 @@ definitions:
                     Value:
                         type: string
                         description: JSON encoded union value
-                        example: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
+                        example: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","failed_as":"PIP","failed_key":"abc123","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
                 example:
                     Type: sip_created_event
-                    Value: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
+                    Value: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","failed_as":"PIP","failed_key":"abc123","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
                 required:
                     - Type
                     - Value
         example:
             event:
                 Type: sip_created_event
-                Value: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
+                Value: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","failed_as":"PIP","failed_key":"abc123","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
     IngestRejectSipNotAvailableResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object
@@ -2223,6 +2225,17 @@ definitions:
                 description: Creation datetime
                 example: "1970-01-01T00:00:01Z"
                 format: date-time
+            failed_as:
+                type: string
+                description: Package type in case of failure (SIP or PIP)
+                example: PIP
+                enum:
+                    - SIP
+                    - PIP
+            failed_key:
+                type: string
+                description: Object key of the failed package in the internal bucket
+                example: abc123
             name:
                 type: string
                 description: Name of the SIP
@@ -2252,6 +2265,8 @@ definitions:
             aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             completed_at: "1970-01-01T00:00:01Z"
             created_at: "1970-01-01T00:00:01Z"
+            failed_as: PIP
+            failed_key: abc123
             name: abc123
             started_at: "1970-01-01T00:00:01Z"
             status: failed
@@ -2473,6 +2488,17 @@ definitions:
                 description: Creation datetime
                 example: "1970-01-01T00:00:01Z"
                 format: date-time
+            failed_as:
+                type: string
+                description: Package type in case of failure (SIP or PIP)
+                example: PIP
+                enum:
+                    - SIP
+                    - PIP
+            failed_key:
+                type: string
+                description: Object key of the failed package in the internal bucket
+                example: abc123
             name:
                 type: string
                 description: Name of the SIP
@@ -2502,6 +2528,8 @@ definitions:
             aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             completed_at: "1970-01-01T00:00:01Z"
             created_at: "1970-01-01T00:00:01Z"
+            failed_as: PIP
+            failed_key: abc123
             name: abc123
             started_at: "1970-01-01T00:00:01Z"
             status: failed
@@ -2520,6 +2548,8 @@ definitions:
             - aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
               completed_at: "1970-01-01T00:00:01Z"
               created_at: "1970-01-01T00:00:01Z"
+              failed_as: PIP
+              failed_key: abc123
               name: abc123
               started_at: "1970-01-01T00:00:01Z"
               status: failed

--- a/internal/api/gen/http/openapi3.json
+++ b/internal/api/gen/http/openapi3.json
@@ -405,6 +405,8 @@
           "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
           "completed_at": "1970-01-01T00:00:01Z",
           "created_at": "1970-01-01T00:00:01Z",
+          "failed_as": "PIP",
+          "failed_key": "abc123",
           "name": "abc123",
           "started_at": "1970-01-01T00:00:01Z",
           "status": "failed",
@@ -427,6 +429,20 @@
             "description": "Creation datetime",
             "example": "1970-01-01T00:00:01Z",
             "format": "date-time",
+            "type": "string"
+          },
+          "failed_as": {
+            "description": "Package type in case of failure (SIP or PIP)",
+            "enum": [
+              "SIP",
+              "PIP"
+            ],
+            "example": "PIP",
+            "type": "string"
+          },
+          "failed_key": {
+            "description": "Object key of the failed package in the internal bucket",
+            "example": "abc123",
             "type": "string"
           },
           "name": {
@@ -1126,14 +1142,14 @@
         "example": {
           "event": {
             "Type": "sip_created_event",
-            "Value": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}"
+            "Value": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"failed_as\":\"PIP\",\"failed_key\":\"abc123\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}"
           }
         },
         "properties": {
           "event": {
             "example": {
               "Type": "sip_created_event",
-              "Value": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}"
+              "Value": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"failed_as\":\"PIP\",\"failed_key\":\"abc123\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}"
             },
             "properties": {
               "Type": {
@@ -1153,7 +1169,7 @@
               },
               "Value": {
                 "description": "JSON encoded union value",
-                "example": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}",
+                "example": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"failed_as\":\"PIP\",\"failed_key\":\"abc123\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}",
                 "type": "string"
               }
             },
@@ -1229,6 +1245,8 @@
             "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "completed_at": "1970-01-01T00:00:01Z",
             "created_at": "1970-01-01T00:00:01Z",
+            "failed_as": "PIP",
+            "failed_key": "abc123",
             "name": "abc123",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "failed",
@@ -1246,6 +1264,8 @@
             "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "completed_at": "1970-01-01T00:00:01Z",
             "created_at": "1970-01-01T00:00:01Z",
+            "failed_as": "PIP",
+            "failed_key": "abc123",
             "name": "abc123",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "failed",
@@ -1410,6 +1430,8 @@
             "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "completed_at": "1970-01-01T00:00:01Z",
             "created_at": "1970-01-01T00:00:01Z",
+            "failed_as": "PIP",
+            "failed_key": "abc123",
             "name": "abc123",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "failed",
@@ -1586,6 +1608,8 @@
               "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
               "completed_at": "1970-01-01T00:00:01Z",
               "created_at": "1970-01-01T00:00:01Z",
+              "failed_as": "PIP",
+              "failed_key": "abc123",
               "name": "abc123",
               "started_at": "1970-01-01T00:00:01Z",
               "status": "failed",
@@ -1752,7 +1776,7 @@
                 "example": {
                   "event": {
                     "Type": "sip_created_event",
-                    "Value": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}"
+                    "Value": "{\"item\":{\"aip_id\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\",\"completed_at\":\"1970-01-01T00:00:01Z\",\"created_at\":\"1970-01-01T00:00:01Z\",\"failed_as\":\"PIP\",\"failed_key\":\"abc123\",\"name\":\"abc123\",\"started_at\":\"1970-01-01T00:00:01Z\",\"status\":\"failed\",\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"},\"uuid\":\"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5\"}"
                   }
                 },
                 "schema": {
@@ -1975,6 +1999,8 @@
                       "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
                       "completed_at": "1970-01-01T00:00:01Z",
                       "created_at": "1970-01-01T00:00:01Z",
+                      "failed_as": "PIP",
+                      "failed_key": "abc123",
                       "name": "abc123",
                       "started_at": "1970-01-01T00:00:01Z",
                       "status": "failed",
@@ -2161,6 +2187,8 @@
                   "aip_id": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
                   "completed_at": "1970-01-01T00:00:01Z",
                   "created_at": "1970-01-01T00:00:01Z",
+                  "failed_as": "PIP",
+                  "failed_key": "abc123",
                   "name": "abc123",
                   "started_at": "1970-01-01T00:00:01Z",
                   "status": "failed",

--- a/internal/api/gen/http/openapi3.yaml
+++ b/internal/api/gen/http/openapi3.yaml
@@ -65,7 +65,7 @@ paths:
                             example:
                                 event:
                                     Type: sip_created_event
-                                    Value: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
+                                    Value: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","failed_as":"PIP","failed_key":"abc123","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
                 "401":
                     description: 'unauthorized: Unauthorized response.'
                     content:
@@ -219,6 +219,8 @@ paths:
                                     - aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                                       completed_at: "1970-01-01T00:00:01Z"
                                       created_at: "1970-01-01T00:00:01Z"
+                                      failed_as: PIP
+                                      failed_key: abc123
                                       name: abc123
                                       started_at: "1970-01-01T00:00:01Z"
                                       status: failed
@@ -281,6 +283,8 @@ paths:
                                 aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                                 completed_at: "1970-01-01T00:00:01Z"
                                 created_at: "1970-01-01T00:00:01Z"
+                                failed_as: PIP
+                                failed_key: abc123
                                 name: abc123
                                 started_at: "1970-01-01T00:00:01Z"
                                 status: failed
@@ -2007,6 +2011,17 @@ components:
                     description: Creation datetime
                     example: "1970-01-01T00:00:01Z"
                     format: date-time
+                failed_as:
+                    type: string
+                    description: Package type in case of failure (SIP or PIP)
+                    example: PIP
+                    enum:
+                        - SIP
+                        - PIP
+                failed_key:
+                    type: string
+                    description: Object key of the failed package in the internal bucket
+                    example: abc123
                 name:
                     type: string
                     description: Name of the SIP
@@ -2036,6 +2051,8 @@ components:
                 aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                 completed_at: "1970-01-01T00:00:01Z"
                 created_at: "1970-01-01T00:00:01Z"
+                failed_as: PIP
+                failed_key: abc123
                 name: abc123
                 started_at: "1970-01-01T00:00:01Z"
                 status: failed
@@ -2596,17 +2613,17 @@ components:
                         Value:
                             type: string
                             description: JSON encoded union value
-                            example: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
+                            example: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","failed_as":"PIP","failed_key":"abc123","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
                     example:
                         Type: sip_created_event
-                        Value: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
+                        Value: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","failed_as":"PIP","failed_key":"abc123","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
                     required:
                         - Type
                         - Value
             example:
                 event:
                     Type: sip_created_event
-                    Value: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
+                    Value: '{"item":{"aip_id":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5","completed_at":"1970-01-01T00:00:01Z","created_at":"1970-01-01T00:00:01Z","failed_as":"PIP","failed_key":"abc123","name":"abc123","started_at":"1970-01-01T00:00:01Z","status":"failed","uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"},"uuid":"d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"}'
         MonitorPingEvent:
             type: object
             properties:
@@ -2653,6 +2670,8 @@ components:
                 - aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                   completed_at: "1970-01-01T00:00:01Z"
                   created_at: "1970-01-01T00:00:01Z"
+                  failed_as: PIP
+                  failed_key: abc123
                   name: abc123
                   started_at: "1970-01-01T00:00:01Z"
                   status: failed
@@ -2671,6 +2690,8 @@ components:
                     aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                     completed_at: "1970-01-01T00:00:01Z"
                     created_at: "1970-01-01T00:00:01Z"
+                    failed_as: PIP
+                    failed_key: abc123
                     name: abc123
                     started_at: "1970-01-01T00:00:01Z"
                     status: failed
@@ -2796,6 +2817,8 @@ components:
                     aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                     completed_at: "1970-01-01T00:00:01Z"
                     created_at: "1970-01-01T00:00:01Z"
+                    failed_as: PIP
+                    failed_key: abc123
                     name: abc123
                     started_at: "1970-01-01T00:00:01Z"
                     status: failed
@@ -2924,6 +2947,8 @@ components:
                     - aip_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                       completed_at: "1970-01-01T00:00:01Z"
                       created_at: "1970-01-01T00:00:01Z"
+                      failed_as: PIP
+                      failed_key: abc123
                       name: abc123
                       started_at: "1970-01-01T00:00:01Z"
                       status: failed

--- a/internal/api/gen/ingest/service.go
+++ b/internal/api/gen/ingest/service.go
@@ -170,6 +170,10 @@ type SIP struct {
 	StartedAt *string
 	// Completion datetime
 	CompletedAt *string
+	// Package type in case of failure (SIP or PIP)
+	FailedAs *string
+	// Object key of the failed package in the internal bucket
+	FailedKey *string
 }
 
 type SIPCollection []*SIP
@@ -464,6 +468,8 @@ func newSIP(vres *ingestviews.SIPView) *SIP {
 		AipID:       vres.AipID,
 		StartedAt:   vres.StartedAt,
 		CompletedAt: vres.CompletedAt,
+		FailedAs:    vres.FailedAs,
+		FailedKey:   vres.FailedKey,
 	}
 	if vres.UUID != nil {
 		res.UUID = *vres.UUID
@@ -488,6 +494,8 @@ func newSIPView(res *SIP) *ingestviews.SIPView {
 		CreatedAt:   &res.CreatedAt,
 		StartedAt:   res.StartedAt,
 		CompletedAt: res.CompletedAt,
+		FailedAs:    res.FailedAs,
+		FailedKey:   res.FailedKey,
 	}
 	return vres
 }

--- a/internal/api/gen/ingest/views/view.go
+++ b/internal/api/gen/ingest/views/view.go
@@ -62,6 +62,10 @@ type SIPView struct {
 	StartedAt *string
 	// Completion datetime
 	CompletedAt *string
+	// Package type in case of failure (SIP or PIP)
+	FailedAs *string
+	// Object key of the failed package in the internal bucket
+	FailedKey *string
 }
 
 // EnduroPageView is a type that runs validations on a projected type.
@@ -129,6 +133,8 @@ var (
 			"created_at",
 			"started_at",
 			"completed_at",
+			"failed_as",
+			"failed_key",
 		},
 	}
 	// SIPWorkflowsMap is a map indexing the attribute names of SIPWorkflows by
@@ -149,6 +155,8 @@ var (
 			"created_at",
 			"started_at",
 			"completed_at",
+			"failed_as",
+			"failed_key",
 		},
 	}
 	// EnduroPageMap is a map indexing the attribute names of EnduroPage by view
@@ -325,6 +333,11 @@ func ValidateSIPView(result *SIPView) (err error) {
 	}
 	if result.CompletedAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("result.completed_at", *result.CompletedAt, goa.FormatDateTime))
+	}
+	if result.FailedAs != nil {
+		if !(*result.FailedAs == "SIP" || *result.FailedAs == "PIP") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("result.failed_as", *result.FailedAs, []any{"SIP", "PIP"}))
+		}
 	}
 	return
 }

--- a/internal/api/gen/storage/service.go
+++ b/internal/api/gen/storage/service.go
@@ -362,6 +362,10 @@ type SIP struct {
 	StartedAt *string
 	// Completion datetime
 	CompletedAt *string
+	// Package type in case of failure (SIP or PIP)
+	FailedAs *string
+	// Object key of the failed package in the internal bucket
+	FailedKey *string
 }
 
 type SIPCreatedEvent struct {

--- a/internal/api/gen/swagger/service.go
+++ b/internal/api/gen/swagger/service.go
@@ -52,6 +52,10 @@ type SIP struct {
 	StartedAt *string
 	// Completion datetime
 	CompletedAt *string
+	// Package type in case of failure (SIP or PIP)
+	FailedAs *string
+	// Object key of the failed package in the internal bucket
+	FailedKey *string
 }
 
 type SIPCreatedEvent struct {

--- a/internal/datatypes/sip.go
+++ b/internal/datatypes/sip.go
@@ -28,6 +28,12 @@ type SIP struct {
 
 	// Nullable, populated as soon as ingest completes.
 	CompletedAt sql.NullTime `db:"completed_at"`
+
+	// Set if there is a failure in workflow, it can be empty.
+	FailedAs enums.SIPFailedAs `db:"failed_as"`
+
+	// Object key from the failed SIP/PIP in the internal bucket.
+	FailedKey string `db:"failed_key"`
 }
 
 // Goa returns the API representation of the SIP.
@@ -46,6 +52,12 @@ func (s *SIP) Goa() *goaingest.SIP {
 	}
 	if s.AIPID.Valid {
 		col.AipID = ref.New(s.AIPID.UUID.String())
+	}
+	if s.FailedAs != "" {
+		col.FailedAs = ref.New(s.FailedAs.String())
+	}
+	if s.FailedKey != "" {
+		col.FailedKey = ref.New(s.FailedKey)
 	}
 
 	return &col

--- a/internal/db/migrations/20250528183140_add_failed_columns_to_sip_table.up.sql
+++ b/internal/db/migrations/20250528183140_add_failed_columns_to_sip_table.up.sql
@@ -1,0 +1,2 @@
+-- Modify "sip" table
+ALTER TABLE `sip` ADD COLUMN `failed_as` enum('SIP','PIP') NULL, ADD COLUMN `failed_key` varchar(1024) NULL;

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:5+ImJWovscl2gKZmnPcxYDZ9XRSpCmkaQ41OZYXvmMI=
+h1:InQx0l4FUJC4qGP5vF6Q2CSLsQeFK9EQC3/6spvhamc=
 1570659451_init.up.sql h1:zyiKKl39RqMxuEhop5jeeiPTxPiSSq00Tn6u06gyNmk=
 1710442322_nullable_aip_id.up.sql h1:vL4eG5YELXr3k4ymhHuRD/R7KpNt3/DNRhH26t83x3A=
 20250207193001_rename_package_table.up.sql h1:d2RjfIturPoFYMMtFocrMvvjEXEqDXDdxQRttcknX/0=
@@ -11,3 +11,4 @@ h1:5+ImJWovscl2gKZmnPcxYDZ9XRSpCmkaQ41OZYXvmMI=
 20250509030046_restore_sip_status_index.up.sql h1:8iKBW+nC9mgEs6PqQJ4Frq1IGJOjedAyhm3dO27yVZw=
 20250509030521_add_sip_uuid_column.up.sql h1:rtcC2HuAOJZI+/7ZkWrlrTn+wkrZ34BRqLK5bJRo3h8=
 20250519181224_update_workflow_types.up.sql h1:E17yEe45fUHXiQpU/cKINtqUZbEkN3jYNJd+SwcysC0=
+20250528183140_add_failed_columns_to_sip_table.up.sql h1:ggwXsUY9uWeE8B26fPClG/Ll1fj2UTZyT8RBV7AmUz0=

--- a/internal/ingest/goa_test.go
+++ b/internal/ingest/goa_test.go
@@ -128,6 +128,7 @@ func nullUUID(s string) uuid.NullUUID {
 var (
 	sipUUID1 = uuid.New()
 	sipUUID2 = uuid.New()
+	sipUUID3 = uuid.New()
 	testSIPs = []*datatypes.SIP{
 		{
 			ID:        1,
@@ -161,6 +162,23 @@ var (
 				Valid: true,
 			},
 		},
+		{
+			ID:        3,
+			UUID:      sipUUID3,
+			Name:      "Test SIP 3",
+			Status:    enums.SIPStatusError,
+			CreatedAt: time.Date(2024, 10, 1, 17, 13, 26, 0, time.UTC),
+			StartedAt: sql.NullTime{
+				Time:  time.Date(2024, 10, 1, 17, 13, 27, 0, time.UTC),
+				Valid: true,
+			},
+			CompletedAt: sql.NullTime{
+				Time:  time.Date(2024, 10, 1, 17, 13, 28, 0, time.UTC),
+				Valid: true,
+			},
+			FailedAs:  enums.SIPFailedAsSIP,
+			FailedKey: "failed-key",
+		},
 	}
 )
 
@@ -185,7 +203,7 @@ func TestList(t *testing.T) {
 					},
 				).Return(
 					testSIPs,
-					&persistence.Page{Limit: 20, Total: 2},
+					&persistence.Page{Limit: 20, Total: 3},
 					nil,
 				)
 			},
@@ -209,10 +227,20 @@ func TestList(t *testing.T) {
 						StartedAt:   ref.New("2024-10-01T17:13:27Z"),
 						CompletedAt: ref.New("2024-10-01T17:13:28Z"),
 					},
+					{
+						UUID:        sipUUID3,
+						Name:        ref.New("Test SIP 3"),
+						Status:      enums.SIPStatusError.String(),
+						CreatedAt:   "2024-10-01T17:13:26Z",
+						StartedAt:   ref.New("2024-10-01T17:13:27Z"),
+						CompletedAt: ref.New("2024-10-01T17:13:28Z"),
+						FailedAs:    ref.New(enums.SIPFailedAsSIP.String()),
+						FailedKey:   ref.New("failed-key"),
+					},
 				},
 				Page: &goaingest.EnduroPage{
 					Limit: 20,
-					Total: 2,
+					Total: 3,
 				},
 			},
 		},
@@ -328,7 +356,7 @@ func TestList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			svc := persistence_fake.NewMockService(ctrl)
 

--- a/internal/persistence/ent/client/convert.go
+++ b/internal/persistence/ent/client/convert.go
@@ -35,6 +35,8 @@ func convertSIP(sip *db.SIP) *datatypes.SIP {
 		CreatedAt:   sip.CreatedAt,
 		StartedAt:   started,
 		CompletedAt: completed,
+		FailedAs:    sip.FailedAs,
+		FailedKey:   sip.FailedKey,
 	}
 }
 

--- a/internal/persistence/ent/client/sip.go
+++ b/internal/persistence/ent/client/sip.go
@@ -105,6 +105,12 @@ func (c *client) UpdateSIP(
 	if up.CompletedAt.Valid {
 		q.SetCompletedAt(up.CompletedAt.Time)
 	}
+	if up.FailedAs.IsValid() {
+		q.SetFailedAs(up.FailedAs)
+	}
+	if up.FailedKey != "" {
+		q.SetFailedKey(up.FailedKey)
+	}
 
 	// Save changes.
 	s, err = q.Save(ctx)

--- a/internal/persistence/ent/db/migrate/schema.go
+++ b/internal/persistence/ent/db/migrate/schema.go
@@ -19,6 +19,8 @@ var (
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "started_at", Type: field.TypeTime, Nullable: true},
 		{Name: "completed_at", Type: field.TypeTime, Nullable: true},
+		{Name: "failed_as", Type: field.TypeEnum, Nullable: true, Enums: []string{"SIP", "PIP"}},
+		{Name: "failed_key", Type: field.TypeString, Nullable: true, Size: 1024},
 	}
 	// SipTable holds the schema information for the "sip" table.
 	SipTable = &schema.Table{

--- a/internal/persistence/ent/db/mutation.go
+++ b/internal/persistence/ent/db/mutation.go
@@ -46,6 +46,8 @@ type SIPMutation struct {
 	created_at       *time.Time
 	started_at       *time.Time
 	completed_at     *time.Time
+	failed_as        *enums.SIPFailedAs
+	failed_key       *string
 	clearedFields    map[string]struct{}
 	workflows        map[int]struct{}
 	removedworkflows map[int]struct{}
@@ -444,6 +446,104 @@ func (m *SIPMutation) ResetCompletedAt() {
 	delete(m.clearedFields, sip.FieldCompletedAt)
 }
 
+// SetFailedAs sets the "failed_as" field.
+func (m *SIPMutation) SetFailedAs(efa enums.SIPFailedAs) {
+	m.failed_as = &efa
+}
+
+// FailedAs returns the value of the "failed_as" field in the mutation.
+func (m *SIPMutation) FailedAs() (r enums.SIPFailedAs, exists bool) {
+	v := m.failed_as
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldFailedAs returns the old "failed_as" field's value of the SIP entity.
+// If the SIP object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SIPMutation) OldFailedAs(ctx context.Context) (v enums.SIPFailedAs, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldFailedAs is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldFailedAs requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldFailedAs: %w", err)
+	}
+	return oldValue.FailedAs, nil
+}
+
+// ClearFailedAs clears the value of the "failed_as" field.
+func (m *SIPMutation) ClearFailedAs() {
+	m.failed_as = nil
+	m.clearedFields[sip.FieldFailedAs] = struct{}{}
+}
+
+// FailedAsCleared returns if the "failed_as" field was cleared in this mutation.
+func (m *SIPMutation) FailedAsCleared() bool {
+	_, ok := m.clearedFields[sip.FieldFailedAs]
+	return ok
+}
+
+// ResetFailedAs resets all changes to the "failed_as" field.
+func (m *SIPMutation) ResetFailedAs() {
+	m.failed_as = nil
+	delete(m.clearedFields, sip.FieldFailedAs)
+}
+
+// SetFailedKey sets the "failed_key" field.
+func (m *SIPMutation) SetFailedKey(s string) {
+	m.failed_key = &s
+}
+
+// FailedKey returns the value of the "failed_key" field in the mutation.
+func (m *SIPMutation) FailedKey() (r string, exists bool) {
+	v := m.failed_key
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldFailedKey returns the old "failed_key" field's value of the SIP entity.
+// If the SIP object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SIPMutation) OldFailedKey(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldFailedKey is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldFailedKey requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldFailedKey: %w", err)
+	}
+	return oldValue.FailedKey, nil
+}
+
+// ClearFailedKey clears the value of the "failed_key" field.
+func (m *SIPMutation) ClearFailedKey() {
+	m.failed_key = nil
+	m.clearedFields[sip.FieldFailedKey] = struct{}{}
+}
+
+// FailedKeyCleared returns if the "failed_key" field was cleared in this mutation.
+func (m *SIPMutation) FailedKeyCleared() bool {
+	_, ok := m.clearedFields[sip.FieldFailedKey]
+	return ok
+}
+
+// ResetFailedKey resets all changes to the "failed_key" field.
+func (m *SIPMutation) ResetFailedKey() {
+	m.failed_key = nil
+	delete(m.clearedFields, sip.FieldFailedKey)
+}
+
 // AddWorkflowIDs adds the "workflows" edge to the Workflow entity by ids.
 func (m *SIPMutation) AddWorkflowIDs(ids ...int) {
 	if m.workflows == nil {
@@ -532,7 +632,7 @@ func (m *SIPMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SIPMutation) Fields() []string {
-	fields := make([]string, 0, 7)
+	fields := make([]string, 0, 9)
 	if m.uuid != nil {
 		fields = append(fields, sip.FieldUUID)
 	}
@@ -553,6 +653,12 @@ func (m *SIPMutation) Fields() []string {
 	}
 	if m.completed_at != nil {
 		fields = append(fields, sip.FieldCompletedAt)
+	}
+	if m.failed_as != nil {
+		fields = append(fields, sip.FieldFailedAs)
+	}
+	if m.failed_key != nil {
+		fields = append(fields, sip.FieldFailedKey)
 	}
 	return fields
 }
@@ -576,6 +682,10 @@ func (m *SIPMutation) Field(name string) (ent.Value, bool) {
 		return m.StartedAt()
 	case sip.FieldCompletedAt:
 		return m.CompletedAt()
+	case sip.FieldFailedAs:
+		return m.FailedAs()
+	case sip.FieldFailedKey:
+		return m.FailedKey()
 	}
 	return nil, false
 }
@@ -599,6 +709,10 @@ func (m *SIPMutation) OldField(ctx context.Context, name string) (ent.Value, err
 		return m.OldStartedAt(ctx)
 	case sip.FieldCompletedAt:
 		return m.OldCompletedAt(ctx)
+	case sip.FieldFailedAs:
+		return m.OldFailedAs(ctx)
+	case sip.FieldFailedKey:
+		return m.OldFailedKey(ctx)
 	}
 	return nil, fmt.Errorf("unknown SIP field %s", name)
 }
@@ -657,6 +771,20 @@ func (m *SIPMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetCompletedAt(v)
 		return nil
+	case sip.FieldFailedAs:
+		v, ok := value.(enums.SIPFailedAs)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetFailedAs(v)
+		return nil
+	case sip.FieldFailedKey:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetFailedKey(v)
+		return nil
 	}
 	return fmt.Errorf("unknown SIP field %s", name)
 }
@@ -696,6 +824,12 @@ func (m *SIPMutation) ClearedFields() []string {
 	if m.FieldCleared(sip.FieldCompletedAt) {
 		fields = append(fields, sip.FieldCompletedAt)
 	}
+	if m.FieldCleared(sip.FieldFailedAs) {
+		fields = append(fields, sip.FieldFailedAs)
+	}
+	if m.FieldCleared(sip.FieldFailedKey) {
+		fields = append(fields, sip.FieldFailedKey)
+	}
 	return fields
 }
 
@@ -718,6 +852,12 @@ func (m *SIPMutation) ClearField(name string) error {
 		return nil
 	case sip.FieldCompletedAt:
 		m.ClearCompletedAt()
+		return nil
+	case sip.FieldFailedAs:
+		m.ClearFailedAs()
+		return nil
+	case sip.FieldFailedKey:
+		m.ClearFailedKey()
 		return nil
 	}
 	return fmt.Errorf("unknown SIP nullable field %s", name)
@@ -747,6 +887,12 @@ func (m *SIPMutation) ResetField(name string) error {
 		return nil
 	case sip.FieldCompletedAt:
 		m.ResetCompletedAt()
+		return nil
+	case sip.FieldFailedAs:
+		m.ResetFailedAs()
+		return nil
+	case sip.FieldFailedKey:
+		m.ResetFailedKey()
 		return nil
 	}
 	return fmt.Errorf("unknown SIP field %s", name)

--- a/internal/persistence/ent/db/sip.go
+++ b/internal/persistence/ent/db/sip.go
@@ -33,6 +33,10 @@ type SIP struct {
 	StartedAt time.Time `json:"started_at,omitempty"`
 	// CompletedAt holds the value of the "completed_at" field.
 	CompletedAt time.Time `json:"completed_at,omitempty"`
+	// FailedAs holds the value of the "failed_as" field.
+	FailedAs enums.SIPFailedAs `json:"failed_as,omitempty"`
+	// FailedKey holds the value of the "failed_key" field.
+	FailedKey string `json:"failed_key,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the SIPQuery when eager-loading is set.
 	Edges        SIPEdges `json:"edges"`
@@ -64,7 +68,7 @@ func (*SIP) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case sip.FieldID:
 			values[i] = new(sql.NullInt64)
-		case sip.FieldName, sip.FieldStatus:
+		case sip.FieldName, sip.FieldStatus, sip.FieldFailedAs, sip.FieldFailedKey:
 			values[i] = new(sql.NullString)
 		case sip.FieldCreatedAt, sip.FieldStartedAt, sip.FieldCompletedAt:
 			values[i] = new(sql.NullTime)
@@ -133,6 +137,18 @@ func (s *SIP) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				s.CompletedAt = value.Time
 			}
+		case sip.FieldFailedAs:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field failed_as", values[i])
+			} else if value.Valid {
+				s.FailedAs = enums.SIPFailedAs(value.String)
+			}
+		case sip.FieldFailedKey:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field failed_key", values[i])
+			} else if value.Valid {
+				s.FailedKey = value.String
+			}
 		default:
 			s.selectValues.Set(columns[i], values[i])
 		}
@@ -194,6 +210,12 @@ func (s *SIP) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("completed_at=")
 	builder.WriteString(s.CompletedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("failed_as=")
+	builder.WriteString(fmt.Sprintf("%v", s.FailedAs))
+	builder.WriteString(", ")
+	builder.WriteString("failed_key=")
+	builder.WriteString(s.FailedKey)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/internal/persistence/ent/db/sip/sip.go
+++ b/internal/persistence/ent/db/sip/sip.go
@@ -30,6 +30,10 @@ const (
 	FieldStartedAt = "started_at"
 	// FieldCompletedAt holds the string denoting the completed_at field in the database.
 	FieldCompletedAt = "completed_at"
+	// FieldFailedAs holds the string denoting the failed_as field in the database.
+	FieldFailedAs = "failed_as"
+	// FieldFailedKey holds the string denoting the failed_key field in the database.
+	FieldFailedKey = "failed_key"
 	// EdgeWorkflows holds the string denoting the workflows edge name in mutations.
 	EdgeWorkflows = "workflows"
 	// Table holds the table name of the sip in the database.
@@ -53,6 +57,8 @@ var Columns = []string{
 	FieldCreatedAt,
 	FieldStartedAt,
 	FieldCompletedAt,
+	FieldFailedAs,
+	FieldFailedKey,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -77,6 +83,16 @@ func StatusValidator(s enums.SIPStatus) error {
 		return nil
 	default:
 		return fmt.Errorf("sip: invalid enum value for status field: %q", s)
+	}
+}
+
+// FailedAsValidator is a validator for the "failed_as" field enum values. It is called by the builders before save.
+func FailedAsValidator(fa enums.SIPFailedAs) error {
+	switch fa.String() {
+	case "SIP", "PIP":
+		return nil
+	default:
+		return fmt.Errorf("sip: invalid enum value for failed_as field: %q", fa)
 	}
 }
 
@@ -121,6 +137,16 @@ func ByStartedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByCompletedAt orders the results by the completed_at field.
 func ByCompletedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCompletedAt, opts...).ToFunc()
+}
+
+// ByFailedAs orders the results by the failed_as field.
+func ByFailedAs(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFailedAs, opts...).ToFunc()
+}
+
+// ByFailedKey orders the results by the failed_key field.
+func ByFailedKey(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFailedKey, opts...).ToFunc()
 }
 
 // ByWorkflowsCount orders the results by workflows count.

--- a/internal/persistence/ent/db/sip/where.go
+++ b/internal/persistence/ent/db/sip/where.go
@@ -87,6 +87,11 @@ func CompletedAt(v time.Time) predicate.SIP {
 	return predicate.SIP(sql.FieldEQ(FieldCompletedAt, v))
 }
 
+// FailedKey applies equality check predicate on the "failed_key" field. It's identical to FailedKeyEQ.
+func FailedKey(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldEQ(FieldFailedKey, v))
+}
+
 // UUIDEQ applies the EQ predicate on the "uuid" field.
 func UUIDEQ(v uuid.UUID) predicate.SIP {
 	return predicate.SIP(sql.FieldEQ(FieldUUID, v))
@@ -410,6 +415,121 @@ func CompletedAtIsNil() predicate.SIP {
 // CompletedAtNotNil applies the NotNil predicate on the "completed_at" field.
 func CompletedAtNotNil() predicate.SIP {
 	return predicate.SIP(sql.FieldNotNull(FieldCompletedAt))
+}
+
+// FailedAsEQ applies the EQ predicate on the "failed_as" field.
+func FailedAsEQ(v enums.SIPFailedAs) predicate.SIP {
+	vc := v
+	return predicate.SIP(sql.FieldEQ(FieldFailedAs, vc))
+}
+
+// FailedAsNEQ applies the NEQ predicate on the "failed_as" field.
+func FailedAsNEQ(v enums.SIPFailedAs) predicate.SIP {
+	vc := v
+	return predicate.SIP(sql.FieldNEQ(FieldFailedAs, vc))
+}
+
+// FailedAsIn applies the In predicate on the "failed_as" field.
+func FailedAsIn(vs ...enums.SIPFailedAs) predicate.SIP {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.SIP(sql.FieldIn(FieldFailedAs, v...))
+}
+
+// FailedAsNotIn applies the NotIn predicate on the "failed_as" field.
+func FailedAsNotIn(vs ...enums.SIPFailedAs) predicate.SIP {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.SIP(sql.FieldNotIn(FieldFailedAs, v...))
+}
+
+// FailedAsIsNil applies the IsNil predicate on the "failed_as" field.
+func FailedAsIsNil() predicate.SIP {
+	return predicate.SIP(sql.FieldIsNull(FieldFailedAs))
+}
+
+// FailedAsNotNil applies the NotNil predicate on the "failed_as" field.
+func FailedAsNotNil() predicate.SIP {
+	return predicate.SIP(sql.FieldNotNull(FieldFailedAs))
+}
+
+// FailedKeyEQ applies the EQ predicate on the "failed_key" field.
+func FailedKeyEQ(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldEQ(FieldFailedKey, v))
+}
+
+// FailedKeyNEQ applies the NEQ predicate on the "failed_key" field.
+func FailedKeyNEQ(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldNEQ(FieldFailedKey, v))
+}
+
+// FailedKeyIn applies the In predicate on the "failed_key" field.
+func FailedKeyIn(vs ...string) predicate.SIP {
+	return predicate.SIP(sql.FieldIn(FieldFailedKey, vs...))
+}
+
+// FailedKeyNotIn applies the NotIn predicate on the "failed_key" field.
+func FailedKeyNotIn(vs ...string) predicate.SIP {
+	return predicate.SIP(sql.FieldNotIn(FieldFailedKey, vs...))
+}
+
+// FailedKeyGT applies the GT predicate on the "failed_key" field.
+func FailedKeyGT(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldGT(FieldFailedKey, v))
+}
+
+// FailedKeyGTE applies the GTE predicate on the "failed_key" field.
+func FailedKeyGTE(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldGTE(FieldFailedKey, v))
+}
+
+// FailedKeyLT applies the LT predicate on the "failed_key" field.
+func FailedKeyLT(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldLT(FieldFailedKey, v))
+}
+
+// FailedKeyLTE applies the LTE predicate on the "failed_key" field.
+func FailedKeyLTE(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldLTE(FieldFailedKey, v))
+}
+
+// FailedKeyContains applies the Contains predicate on the "failed_key" field.
+func FailedKeyContains(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldContains(FieldFailedKey, v))
+}
+
+// FailedKeyHasPrefix applies the HasPrefix predicate on the "failed_key" field.
+func FailedKeyHasPrefix(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldHasPrefix(FieldFailedKey, v))
+}
+
+// FailedKeyHasSuffix applies the HasSuffix predicate on the "failed_key" field.
+func FailedKeyHasSuffix(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldHasSuffix(FieldFailedKey, v))
+}
+
+// FailedKeyIsNil applies the IsNil predicate on the "failed_key" field.
+func FailedKeyIsNil() predicate.SIP {
+	return predicate.SIP(sql.FieldIsNull(FieldFailedKey))
+}
+
+// FailedKeyNotNil applies the NotNil predicate on the "failed_key" field.
+func FailedKeyNotNil() predicate.SIP {
+	return predicate.SIP(sql.FieldNotNull(FieldFailedKey))
+}
+
+// FailedKeyEqualFold applies the EqualFold predicate on the "failed_key" field.
+func FailedKeyEqualFold(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldEqualFold(FieldFailedKey, v))
+}
+
+// FailedKeyContainsFold applies the ContainsFold predicate on the "failed_key" field.
+func FailedKeyContainsFold(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldContainsFold(FieldFailedKey, v))
 }
 
 // HasWorkflows applies the HasEdge predicate on the "workflows" edge.

--- a/internal/persistence/ent/db/sip_create.go
+++ b/internal/persistence/ent/db/sip_create.go
@@ -97,6 +97,34 @@ func (sc *SIPCreate) SetNillableCompletedAt(t *time.Time) *SIPCreate {
 	return sc
 }
 
+// SetFailedAs sets the "failed_as" field.
+func (sc *SIPCreate) SetFailedAs(efa enums.SIPFailedAs) *SIPCreate {
+	sc.mutation.SetFailedAs(efa)
+	return sc
+}
+
+// SetNillableFailedAs sets the "failed_as" field if the given value is not nil.
+func (sc *SIPCreate) SetNillableFailedAs(efa *enums.SIPFailedAs) *SIPCreate {
+	if efa != nil {
+		sc.SetFailedAs(*efa)
+	}
+	return sc
+}
+
+// SetFailedKey sets the "failed_key" field.
+func (sc *SIPCreate) SetFailedKey(s string) *SIPCreate {
+	sc.mutation.SetFailedKey(s)
+	return sc
+}
+
+// SetNillableFailedKey sets the "failed_key" field if the given value is not nil.
+func (sc *SIPCreate) SetNillableFailedKey(s *string) *SIPCreate {
+	if s != nil {
+		sc.SetFailedKey(*s)
+	}
+	return sc
+}
+
 // AddWorkflowIDs adds the "workflows" edge to the Workflow entity by IDs.
 func (sc *SIPCreate) AddWorkflowIDs(ids ...int) *SIPCreate {
 	sc.mutation.AddWorkflowIDs(ids...)
@@ -172,6 +200,11 @@ func (sc *SIPCreate) check() error {
 	if _, ok := sc.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`db: missing required field "SIP.created_at"`)}
 	}
+	if v, ok := sc.mutation.FailedAs(); ok {
+		if err := sip.FailedAsValidator(v); err != nil {
+			return &ValidationError{Name: "failed_as", err: fmt.Errorf(`db: validator failed for field "SIP.failed_as": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -225,6 +258,14 @@ func (sc *SIPCreate) createSpec() (*SIP, *sqlgraph.CreateSpec) {
 	if value, ok := sc.mutation.CompletedAt(); ok {
 		_spec.SetField(sip.FieldCompletedAt, field.TypeTime, value)
 		_node.CompletedAt = value
+	}
+	if value, ok := sc.mutation.FailedAs(); ok {
+		_spec.SetField(sip.FieldFailedAs, field.TypeEnum, value)
+		_node.FailedAs = value
+	}
+	if value, ok := sc.mutation.FailedKey(); ok {
+		_spec.SetField(sip.FieldFailedKey, field.TypeString, value)
+		_node.FailedKey = value
 	}
 	if nodes := sc.mutation.WorkflowsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/persistence/ent/db/sip_update.go
+++ b/internal/persistence/ent/db/sip_update.go
@@ -119,6 +119,46 @@ func (su *SIPUpdate) ClearCompletedAt() *SIPUpdate {
 	return su
 }
 
+// SetFailedAs sets the "failed_as" field.
+func (su *SIPUpdate) SetFailedAs(efa enums.SIPFailedAs) *SIPUpdate {
+	su.mutation.SetFailedAs(efa)
+	return su
+}
+
+// SetNillableFailedAs sets the "failed_as" field if the given value is not nil.
+func (su *SIPUpdate) SetNillableFailedAs(efa *enums.SIPFailedAs) *SIPUpdate {
+	if efa != nil {
+		su.SetFailedAs(*efa)
+	}
+	return su
+}
+
+// ClearFailedAs clears the value of the "failed_as" field.
+func (su *SIPUpdate) ClearFailedAs() *SIPUpdate {
+	su.mutation.ClearFailedAs()
+	return su
+}
+
+// SetFailedKey sets the "failed_key" field.
+func (su *SIPUpdate) SetFailedKey(s string) *SIPUpdate {
+	su.mutation.SetFailedKey(s)
+	return su
+}
+
+// SetNillableFailedKey sets the "failed_key" field if the given value is not nil.
+func (su *SIPUpdate) SetNillableFailedKey(s *string) *SIPUpdate {
+	if s != nil {
+		su.SetFailedKey(*s)
+	}
+	return su
+}
+
+// ClearFailedKey clears the value of the "failed_key" field.
+func (su *SIPUpdate) ClearFailedKey() *SIPUpdate {
+	su.mutation.ClearFailedKey()
+	return su
+}
+
 // AddWorkflowIDs adds the "workflows" edge to the Workflow entity by IDs.
 func (su *SIPUpdate) AddWorkflowIDs(ids ...int) *SIPUpdate {
 	su.mutation.AddWorkflowIDs(ids...)
@@ -194,6 +234,11 @@ func (su *SIPUpdate) check() error {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`db: validator failed for field "SIP.status": %w`, err)}
 		}
 	}
+	if v, ok := su.mutation.FailedAs(); ok {
+		if err := sip.FailedAsValidator(v); err != nil {
+			return &ValidationError{Name: "failed_as", err: fmt.Errorf(`db: validator failed for field "SIP.failed_as": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -232,6 +277,18 @@ func (su *SIPUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if su.mutation.CompletedAtCleared() {
 		_spec.ClearField(sip.FieldCompletedAt, field.TypeTime)
+	}
+	if value, ok := su.mutation.FailedAs(); ok {
+		_spec.SetField(sip.FieldFailedAs, field.TypeEnum, value)
+	}
+	if su.mutation.FailedAsCleared() {
+		_spec.ClearField(sip.FieldFailedAs, field.TypeEnum)
+	}
+	if value, ok := su.mutation.FailedKey(); ok {
+		_spec.SetField(sip.FieldFailedKey, field.TypeString, value)
+	}
+	if su.mutation.FailedKeyCleared() {
+		_spec.ClearField(sip.FieldFailedKey, field.TypeString)
 	}
 	if su.mutation.WorkflowsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -386,6 +443,46 @@ func (suo *SIPUpdateOne) ClearCompletedAt() *SIPUpdateOne {
 	return suo
 }
 
+// SetFailedAs sets the "failed_as" field.
+func (suo *SIPUpdateOne) SetFailedAs(efa enums.SIPFailedAs) *SIPUpdateOne {
+	suo.mutation.SetFailedAs(efa)
+	return suo
+}
+
+// SetNillableFailedAs sets the "failed_as" field if the given value is not nil.
+func (suo *SIPUpdateOne) SetNillableFailedAs(efa *enums.SIPFailedAs) *SIPUpdateOne {
+	if efa != nil {
+		suo.SetFailedAs(*efa)
+	}
+	return suo
+}
+
+// ClearFailedAs clears the value of the "failed_as" field.
+func (suo *SIPUpdateOne) ClearFailedAs() *SIPUpdateOne {
+	suo.mutation.ClearFailedAs()
+	return suo
+}
+
+// SetFailedKey sets the "failed_key" field.
+func (suo *SIPUpdateOne) SetFailedKey(s string) *SIPUpdateOne {
+	suo.mutation.SetFailedKey(s)
+	return suo
+}
+
+// SetNillableFailedKey sets the "failed_key" field if the given value is not nil.
+func (suo *SIPUpdateOne) SetNillableFailedKey(s *string) *SIPUpdateOne {
+	if s != nil {
+		suo.SetFailedKey(*s)
+	}
+	return suo
+}
+
+// ClearFailedKey clears the value of the "failed_key" field.
+func (suo *SIPUpdateOne) ClearFailedKey() *SIPUpdateOne {
+	suo.mutation.ClearFailedKey()
+	return suo
+}
+
 // AddWorkflowIDs adds the "workflows" edge to the Workflow entity by IDs.
 func (suo *SIPUpdateOne) AddWorkflowIDs(ids ...int) *SIPUpdateOne {
 	suo.mutation.AddWorkflowIDs(ids...)
@@ -474,6 +571,11 @@ func (suo *SIPUpdateOne) check() error {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`db: validator failed for field "SIP.status": %w`, err)}
 		}
 	}
+	if v, ok := suo.mutation.FailedAs(); ok {
+		if err := sip.FailedAsValidator(v); err != nil {
+			return &ValidationError{Name: "failed_as", err: fmt.Errorf(`db: validator failed for field "SIP.failed_as": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -529,6 +631,18 @@ func (suo *SIPUpdateOne) sqlSave(ctx context.Context) (_node *SIP, err error) {
 	}
 	if suo.mutation.CompletedAtCleared() {
 		_spec.ClearField(sip.FieldCompletedAt, field.TypeTime)
+	}
+	if value, ok := suo.mutation.FailedAs(); ok {
+		_spec.SetField(sip.FieldFailedAs, field.TypeEnum, value)
+	}
+	if suo.mutation.FailedAsCleared() {
+		_spec.ClearField(sip.FieldFailedAs, field.TypeEnum)
+	}
+	if value, ok := suo.mutation.FailedKey(); ok {
+		_spec.SetField(sip.FieldFailedKey, field.TypeString, value)
+	}
+	if suo.mutation.FailedKeyCleared() {
+		_spec.ClearField(sip.FieldFailedKey, field.TypeString)
 	}
 	if suo.mutation.WorkflowsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/persistence/ent/schema/sip.go
+++ b/internal/persistence/ent/schema/sip.go
@@ -47,6 +47,14 @@ func (SIP) Fields() []ent.Field {
 			Optional(),
 		field.Time("completed_at").
 			Optional(),
+		field.Enum("failed_as").
+			GoType(enums.SIPFailedAsSIP).
+			Optional(),
+		field.String("failed_key").
+			Annotations(entsql.Annotation{
+				Size: 1024,
+			}).
+			Optional(),
 	}
 }
 

--- a/internal/workflow/local_activities.go
+++ b/internal/workflow/local_activities.go
@@ -44,6 +44,8 @@ type updateSIPLocalActivityParams struct {
 	AIPUUID     string
 	CompletedAt time.Time
 	Status      enums.SIPStatus
+	FailedAs    enums.SIPFailedAs
+	FailedKey   string
 }
 
 type updateSIPLocalActivityResult struct{}
@@ -59,9 +61,15 @@ func updateSIPLocalActivity(
 		func(s *datatypes.SIP) (*datatypes.SIP, error) {
 			s.Name = params.Name
 			s.Status = params.Status
+			s.FailedAs = params.FailedAs
+			s.FailedKey = params.FailedKey
 
 			if !params.Status.IsValid() {
 				return nil, fmt.Errorf("invalid status: %s", params.Status)
+			}
+
+			if params.FailedAs != "" && !params.FailedAs.IsValid() {
+				return nil, fmt.Errorf("invalid failed as: %s", params.FailedAs)
 			}
 
 			if params.AIPUUID != "" {

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -452,6 +452,8 @@ func (s *ProcessingWorkflowTestSuite) TestConfirmation() {
 				params.Name == sipName &&
 				params.AIPUUID == aipUUID.String() &&
 				params.Status == enums.SIPStatusIngested &&
+				params.FailedAs == "" &&
+				params.FailedKey == "" &&
 				!params.CompletedAt.IsZero()
 		}),
 	).Return(nil, nil).Once()
@@ -672,6 +674,8 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 				params.Name == sipName &&
 				params.AIPUUID == aipUUID.String() &&
 				params.Status == enums.SIPStatusIngested &&
+				params.FailedAs == "" &&
+				params.FailedKey == "" &&
 				!params.CompletedAt.IsZero()
 		}),
 	).Return(nil, nil).Once()
@@ -888,6 +892,8 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 				params.Name == sipName &&
 				params.AIPUUID == aipUUID.String() &&
 				params.Status == enums.SIPStatusIngested &&
+				params.FailedAs == "" &&
+				params.FailedKey == "" &&
 				!params.CompletedAt.IsZero()
 		}),
 	).Return(nil, nil).Once()
@@ -1045,6 +1051,8 @@ func (s *ProcessingWorkflowTestSuite) TestRejection() {
 				params.Name == sipName &&
 				params.AIPUUID == aipUUID.String() &&
 				params.Status == enums.SIPStatusIngested &&
+				params.FailedAs == "" &&
+				params.FailedKey == "" &&
 				!params.CompletedAt.IsZero()
 		}),
 	).Return(nil, nil).Once()
@@ -1336,6 +1344,8 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 				params.Name == sipName &&
 				params.AIPUUID == aipUUID &&
 				params.Status == enums.SIPStatusIngested &&
+				params.FailedAs == "" &&
+				params.FailedKey == "" &&
 				!params.CompletedAt.IsZero()
 		}),
 	).Return(nil, nil).Once()
@@ -1497,6 +1507,8 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 				params.Name == sipName &&
 				params.AIPUUID == "" &&
 				params.Status == enums.SIPStatusFailed &&
+				params.FailedAs == enums.SIPFailedAsSIP &&
+				params.FailedKey == failedKey &&
 				!params.CompletedAt.IsZero()
 		}),
 	).Return(nil, nil)
@@ -1683,6 +1695,8 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPA3m() {
 				params.Name == sipName &&
 				params.AIPUUID == "" &&
 				params.Status == enums.SIPStatusError &&
+				params.FailedAs == enums.SIPFailedAsPIP &&
+				params.FailedKey == failedKey &&
 				!params.CompletedAt.IsZero()
 		}),
 	).Return(nil, nil)
@@ -1819,6 +1833,8 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPAM() {
 				params.Name == sipName &&
 				params.AIPUUID == "" &&
 				params.Status == enums.SIPStatusError &&
+				params.FailedAs == enums.SIPFailedAsPIP &&
+				params.FailedKey == failedKey &&
 				!params.CompletedAt.IsZero()
 		}),
 	).Return(nil, nil)
@@ -1935,6 +1951,8 @@ func (s *ProcessingWorkflowTestSuite) TestInternalUpload() {
 				params.Name == sipName &&
 				params.AIPUUID == "" &&
 				params.Status == enums.SIPStatusError &&
+				params.FailedAs == enums.SIPFailedAsSIP &&
+				params.FailedKey == failedKey &&
 				!params.CompletedAt.IsZero()
 		}),
 	).Return(nil, nil)

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -90,6 +90,9 @@ type sipInfo struct {
 
 	// transformed indicates if the SIP should be considered a PIP.
 	transformed bool
+
+	// failed_key is the object key of the failed SIP/PIP in the internal bucket.
+	failed_key string
 }
 
 // aipInfo represents the AIP.


### PR DESCRIPTION
Review after #1250.

- Add new fields to datatypes SIP.
- Add new nullable columns to the SIP table.
- Add new optional attributes to the SIP Goa design.
- Consider new fields in persistence SIP update and reads.
- Consider new fields in conversions.
- Add new parameters to the update SIP activity and
  consider them in the update.
- Add failed key to workflow state, populate it when
  the failed SIP/PIP is sent to the internal bucket.
- Generate Goa, Ent and dashboard client code.

Refs #1202.