### PR TITLE
Tweaks for SIP upload

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -30,6 +30,7 @@ server {
     listen 80;
     root /usr/share/nginx/html;
     absolute_redirect off;
+    client_max_body_size 4096M
     location /api/ingest/monitor {
         proxy_pass http://backend/ingest/monitor;
         proxy_http_version 1.1;

--- a/dashboard/src/pages/ingest/upload/index.vue
+++ b/dashboard/src/pages/ingest/upload/index.vue
@@ -18,7 +18,7 @@ const authStore = useAuthStore();
 const layoutStore = useLayoutStore();
 
 const GiB = 1024 ** 3; // 1 GiB in bytes
-const maxFileSize = 500 * GiB;
+const maxFileSize = 4 * GiB;
 
 layoutStore.updateBreadcrumb([{ text: "Ingest" }, { text: "Upload SIPs" }]);
 

--- a/enduro.toml
+++ b/enduro.toml
@@ -207,8 +207,8 @@ passphrase = "" # Secret: set (if required) with env var ENDURO_AM_SFTP_PRIVATEK
 
 [upload]
 # maxSize is the maximum upload size allowed by the server in bytes.
-# Default: 102400000.
-maxSize = 102400000
+# Default: 4294967296 (4 GiB).
+maxSize = 4294967296
 
 # internalBucket section configures a bucket where Enduro will place uploaded
 # SIPs. Make sure it doesn't match any of the watched buckets.

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/jonboulle/clockwork v0.4.0
 	github.com/mattn/go-sqlite3 v1.14.22
+	github.com/mholt/archiver/v4 v4.0.0-alpha.8
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nyudlts/go-bagit v0.3.0-alpha.0.20240515212815-8dab411c23af
 	github.com/oklog/run v1.1.0
@@ -138,7 +139,6 @@ require (
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d // indirect
-	github.com/mholt/archiver/v4 v4.0.0-alpha.8 // indirect
 	github.com/mholt/archives v0.1.1 // indirect
 	github.com/minio/minlz v1.0.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,7 +112,7 @@ func Read(config *Configuration, configFile string) (found bool, configFileUsed 
 	v.SetDefault("preservation.taskqueue", temporal.A3mWorkerTaskQueue)
 	v.SetDefault("storage.taskqueue", temporal.GlobalTaskQueue)
 	v.SetDefault("temporal.taskqueue", temporal.GlobalTaskQueue)
-	v.SetDefault("upload.maxSize", 102400000)
+	v.SetDefault("upload.maxSize", 4294967296)
 	v.SetEnvPrefix("enduro")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -96,6 +96,7 @@ func TestConfig(t *testing.T) {
 		assert.Equal(t, c.Temporal.TaskQueue, temporal.GlobalTaskQueue)
 		assert.Equal(t, c.ValidatePREMIS.Enabled, false)
 		assert.Equal(t, c.ValidatePREMIS.XSDPath, "")
+		assert.Equal(t, c.Upload.MaxSize, int64(4294967296))
 	})
 }
 


### PR DESCRIPTION
- Change object key for uploaded SIPs
  Include the prefix, the file name without extension, the SIP UUID
  and the original extension.
- Update upload max size 
  Use 4 GiB as default in the configuration and the dashboard. Add
  `client_max_body_size 4096M` to the dashboard Dockerfile nginx config.

Refs #1210.