### PR TITLE
Set uploader max filesize from config (#1237)

### DIFF
--- a/dashboard/src/components/AboutDialog.vue
+++ b/dashboard/src/components/AboutDialog.vue
@@ -3,23 +3,23 @@ import Modal from "bootstrap/js/dist/modal";
 import { onMounted, ref } from "vue";
 import { closeDialog } from "vue3-promise-dialog";
 
-import { api, client } from "@/client";
 import useEventListener from "@/composables/useEventListener";
+import { useAboutStore } from "@/stores/about";
 import IconDocumentation from "~icons/lucide/book-text";
 import IconLicense from "~icons/lucide/file-text";
 import IconContributing from "~icons/lucide/git-merge";
 
+const aboutStore = useAboutStore();
+
 const el = ref<HTMLElement | null>(null);
 const modal = ref<Modal | null>(null);
-const about = ref<api.EnduroAbout | null>(null);
 
 onMounted(() => {
-  client.about.aboutAbout().then((resp) => {
-    about.value = resp;
-    if (!el.value) return;
-    modal.value = new Modal(el.value);
-    modal.value.show();
-  });
+  if (!el.value) return;
+  modal.value = new Modal(el.value);
+  modal.value.show();
+
+  aboutStore.load();
 });
 
 useEventListener(el, "hidden.bs.modal", () => closeDialog(null));
@@ -41,7 +41,7 @@ useEventListener(el, "hidden.bs.modal", () => closeDialog(null));
           ></button>
         </div>
         <div class="modal-body">
-          <div class="mb-3" v-if="about">
+          <div class="mb-3">
             <div class="row">
               <div
                 class="col-12 col-sm-6 text-primary fw-bold text-sm-end text-truncate"
@@ -49,7 +49,7 @@ useEventListener(el, "hidden.bs.modal", () => closeDialog(null));
                 Application version:
               </div>
               <div class="col-12 col-sm-6 text-truncate">
-                v{{ about.version }}
+                {{ aboutStore.formattedVersion }}
               </div>
             </div>
             <div class="row">
@@ -59,22 +59,22 @@ useEventListener(el, "hidden.bs.modal", () => closeDialog(null));
                 Preservation system:
               </div>
               <div class="col-12 col-sm-6 text-truncate">
-                {{ about.preservationSystem }}
+                {{ aboutStore.preservationSystem }}
               </div>
             </div>
-            <div class="row" v-if="about.preprocessing.enabled">
+            <div class="row" v-if="aboutStore.preprocessing.enabled">
               <div
                 class="col-12 col-sm-6 text-primary fw-bold text-sm-end text-truncate"
               >
                 Preprocessing workflow:
               </div>
               <div class="col-12 col-sm-6 text-truncate">
-                {{ about.preprocessing.workflowName }}
+                {{ aboutStore.preprocessing.workflowName }}
               </div>
             </div>
             <div
               class="row"
-              v-if="about.poststorage && about.poststorage.length > 0"
+              v-if="aboutStore.poststorage && aboutStore.poststorage.length > 0"
             >
               <div
                 class="col-12 col-sm-6 text-primary fw-bold text-sm-end text-truncate"
@@ -83,7 +83,7 @@ useEventListener(el, "hidden.bs.modal", () => closeDialog(null));
               </div>
               <div class="col-12 col-sm-6 d-flex flex-column text-truncate">
                 <span
-                  v-for="ps in about.poststorage"
+                  v-for="ps in aboutStore.poststorage"
                   :key="ps.taskQueue + '-' + ps.workflowName"
                   >{{ ps.workflowName }}</span
                 >

--- a/dashboard/src/stores/__tests__/about.test.ts
+++ b/dashboard/src/stores/__tests__/about.test.ts
@@ -1,0 +1,248 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api, client } from "@/client";
+import { useAboutStore } from "@/stores/about";
+
+vi.mock("@/client");
+
+describe("useAboutStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  describe("state", () => {
+    it("initializes with correct default values", () => {
+      const aboutStore = useAboutStore();
+
+      expect(aboutStore.loaded).toBe(false);
+      expect(aboutStore.poststorage).toEqual([]);
+      expect(aboutStore.preprocessing).toEqual({
+        enabled: false,
+        taskQueue: "",
+        workflowName: "",
+      });
+      expect(aboutStore.preservationSystem).toBe("a3m");
+      expect(aboutStore.uploadMaxSize).toBe(0);
+      expect(aboutStore.version).toBe("");
+    });
+  });
+
+  describe("getters", () => {
+    describe("formattedUploadMaxSize", () => {
+      it("formats bytes correctly", () => {
+        const aboutStore = useAboutStore();
+        aboutStore.uploadMaxSize = 512;
+        expect(aboutStore.formattedUploadMaxSize).toBe("512 bytes");
+      });
+
+      it("formats KiB correctly", () => {
+        const aboutStore = useAboutStore();
+        aboutStore.uploadMaxSize = 1536; // 1.5 KiB
+        expect(aboutStore.formattedUploadMaxSize).toBe("1.50 KiB");
+      });
+
+      it("formats MiB correctly", () => {
+        const aboutStore = useAboutStore();
+        aboutStore.uploadMaxSize = 1572864; // 1.5 MiB
+        expect(aboutStore.formattedUploadMaxSize).toBe("1.50 MiB");
+      });
+
+      it("formats GiB correctly", () => {
+        const aboutStore = useAboutStore();
+        aboutStore.uploadMaxSize = 1610612736; // 1.5 GiB
+        expect(aboutStore.formattedUploadMaxSize).toBe("1.50 GiB");
+      });
+
+      it("formats TiB correctly", () => {
+        const aboutStore = useAboutStore();
+        aboutStore.uploadMaxSize = 1.5 * 1024 ** 4; // 1.5 TiB
+        expect(aboutStore.formattedUploadMaxSize).toBe("1.50 TiB");
+      });
+
+      it("handles edge case at 1024 bytes", () => {
+        const aboutStore = useAboutStore();
+        aboutStore.uploadMaxSize = 1024;
+        expect(aboutStore.formattedUploadMaxSize).toBe("1.00 KiB");
+      });
+
+      it("handles edge case at 1 MiB", () => {
+        const aboutStore = useAboutStore();
+        aboutStore.uploadMaxSize = 1024 * 1024;
+        expect(aboutStore.formattedUploadMaxSize).toBe("1.00 MiB");
+      });
+
+      it("handles edge case at 1 GiB", () => {
+        const aboutStore = useAboutStore();
+        aboutStore.uploadMaxSize = 1024 ** 3;
+        expect(aboutStore.formattedUploadMaxSize).toBe("1.00 GiB");
+      });
+
+      it("handles edge case at 1 TiB", () => {
+        const aboutStore = useAboutStore();
+        aboutStore.uploadMaxSize = 1024 ** 4;
+        expect(aboutStore.formattedUploadMaxSize).toBe("1.00 TiB");
+      });
+    });
+
+    describe("formattedVersion", () => {
+      it("formats version with v prefix", () => {
+        const aboutStore = useAboutStore();
+        aboutStore.version = "1.2.3";
+        expect(aboutStore.formattedVersion).toBe("v1.2.3");
+      });
+
+      it("handles empty version", () => {
+        const aboutStore = useAboutStore();
+        aboutStore.version = "";
+        expect(aboutStore.formattedVersion).toBe("unknown");
+      });
+    });
+  });
+
+  describe("actions", () => {
+    describe("fetch", () => {
+      it("fetches and updates state successfully", async () => {
+        const mockResponse: api.EnduroAbout = {
+          poststorage: [
+            {
+              taskQueue: "test-queue",
+              workflowName: "test-workflow",
+            },
+          ],
+          preprocessing: {
+            enabled: true,
+            taskQueue: "preprocessing-queue",
+            workflowName: "preprocessing-workflow",
+          },
+          preservationSystem: "archivematica",
+          uploadMaxSize: 1073741824, // 1 GiB
+          version: "1.0.0",
+        };
+
+        client.about.aboutAbout = vi.fn().mockResolvedValue(mockResponse);
+
+        const aboutStore = useAboutStore();
+        await aboutStore.fetch();
+
+        expect(aboutStore.loaded).toBe(true);
+        expect(aboutStore.poststorage).toEqual(mockResponse.poststorage);
+        expect(aboutStore.preprocessing).toEqual(mockResponse.preprocessing);
+        expect(aboutStore.preservationSystem).toBe(
+          mockResponse.preservationSystem,
+        );
+        expect(aboutStore.uploadMaxSize).toBe(mockResponse.uploadMaxSize);
+        expect(aboutStore.version).toBe(mockResponse.version);
+      });
+
+      it("handles undefined poststorage in response", async () => {
+        const mockResponse: api.EnduroAbout = {
+          poststorage: undefined,
+          preprocessing: {
+            enabled: false,
+            taskQueue: "",
+            workflowName: "",
+          },
+          preservationSystem: "a3m",
+          uploadMaxSize: 0,
+          version: "1.0.0",
+        };
+
+        client.about.aboutAbout = vi.fn().mockResolvedValue(mockResponse);
+
+        const aboutStore = useAboutStore();
+        await aboutStore.fetch();
+
+        expect(aboutStore.poststorage).toEqual([]);
+      });
+
+      it("handles fetch errors", async () => {
+        const consoleErrorSpy = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        const error = new Error("Network error");
+
+        client.about.aboutAbout = vi.fn().mockRejectedValue(error);
+
+        const aboutStore = useAboutStore();
+        await aboutStore.fetch();
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          "Error fetching about data:",
+          "Network error",
+        );
+        expect(aboutStore.loaded).toBe(false);
+
+        consoleErrorSpy.mockRestore();
+      });
+    });
+
+    describe("load", () => {
+      it("calls fetch when not loaded", async () => {
+        const aboutStore = useAboutStore();
+        const fetchSpy = vi.spyOn(aboutStore, "fetch").mockResolvedValue();
+
+        await aboutStore.load();
+
+        expect(fetchSpy).toHaveBeenCalledOnce();
+      });
+
+      it("does not call fetch when already loaded", async () => {
+        const aboutStore = useAboutStore();
+        aboutStore.loaded = true;
+        const fetchSpy = vi.spyOn(aboutStore, "fetch").mockResolvedValue();
+
+        await aboutStore.load();
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+      });
+
+      it("returns fetch promise when not loaded", async () => {
+        const mockResponse: api.EnduroAbout = {
+          poststorage: [],
+          preprocessing: {
+            enabled: false,
+            taskQueue: "",
+            workflowName: "",
+          },
+          preservationSystem: "a3m",
+          uploadMaxSize: 0,
+          version: "1.0.0",
+        };
+
+        client.about.aboutAbout = vi.fn().mockResolvedValue(mockResponse);
+
+        const aboutStore = useAboutStore();
+        const result = await aboutStore.load();
+
+        expect(aboutStore.loaded).toBe(true);
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe("integration", () => {
+    it("formats upload max size and version after successful fetch", async () => {
+      const mockResponse: api.EnduroAbout = {
+        poststorage: [],
+        preprocessing: {
+          enabled: false,
+          taskQueue: "",
+          workflowName: "",
+        },
+        preservationSystem: "a3m",
+        uploadMaxSize: 2147483648, // 2 GiB
+        version: "2.0.0",
+      };
+
+      client.about.aboutAbout = vi.fn().mockResolvedValue(mockResponse);
+
+      const aboutStore = useAboutStore();
+      await aboutStore.fetch();
+
+      expect(aboutStore.formattedUploadMaxSize).toBe("2.00 GiB");
+      expect(aboutStore.formattedVersion).toBe("v2.0.0");
+    });
+  });
+});

--- a/dashboard/src/stores/about.ts
+++ b/dashboard/src/stores/about.ts
@@ -1,0 +1,72 @@
+import { acceptHMRUpdate, defineStore } from "pinia";
+
+import { api, client } from "@/client";
+
+export const useAboutStore = defineStore("about", {
+  state: () => ({
+    loaded: false,
+    poststorage: [] as Array<api.EnduroPoststorage>,
+    preprocessing: {
+      enabled: false,
+      taskQueue: "",
+      workflowName: "",
+    },
+    preservationSystem: "a3m",
+    uploadMaxSize: 0,
+    version: "",
+  }),
+  getters: {
+    // formattedUploadMaxSize returns the upload max size formatted as a string
+    // with appropriate units (bytes, KiB, MiB, GiB).
+    formattedUploadMaxSize: (state) => {
+      const size = state.uploadMaxSize;
+      if (size >= 1024 ** 4) {
+        return `${(size / 1024 ** 4).toFixed(2)} TiB`;
+      } else if (size >= 1024 ** 3) {
+        return `${(size / 1024 ** 3).toFixed(2)} GiB`;
+      } else if (size >= 1024 ** 2) {
+        return `${(size / 1024 ** 2).toFixed(2)} MiB`;
+      } else if (size >= 1024) {
+        return `${(size / 1024).toFixed(2)} KiB`;
+      } else {
+        return `${size} bytes`;
+      }
+    },
+    // formattedVersion returns the version prefixed with "v" or "unknown"
+    // if not set.
+    formattedVersion: (state) => {
+      if (!state.version) {
+        return "unknown";
+      }
+      return "v" + state.version;
+    },
+  },
+  actions: {
+    // fetch retrieves the about data from the API and updates the store state.
+    async fetch() {
+      return client.about
+        .aboutAbout()
+        .then((resp) => {
+          this.loaded = true;
+          this.poststorage = resp.poststorage || [];
+          this.preprocessing = resp.preprocessing;
+          this.preservationSystem = resp.preservationSystem;
+          this.uploadMaxSize = resp.uploadMaxSize;
+          this.version = resp.version;
+        })
+        .catch((e) => {
+          console.error("Error fetching about data:", e.message);
+        });
+    },
+    // Load fetches the about data from the API if it hasn't been loaded yet.
+    async load() {
+      if (!this.loaded) {
+        return this.fetch();
+      }
+    },
+  },
+});
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useAboutStore, import.meta.hot));
+}


### PR DESCRIPTION
- Set uploader max filesize from the AIP `/about` endpoint "upload_max_size".
- Define a default max upload size of 4 GiB
- Add an "about" store