### PR TITLE
Support macOS/Apple Silicon in dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ CMD ["/home/enduro/bin/enduro", "--config", "/home/enduro/.config/enduro.toml"]
 FROM base AS enduro-a3m-worker
 COPY --link --from=build-libxml /usr/bin/xmllint /usr/bin/xmllint
 COPY --link --from=build-libxml /usr/lib/libxml2.so.2 /usr/lib/libxml2.so.2
-COPY --link --from=build-libxml /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --link --from=build-libxml /lib/ld-musl-*.so.1 /lib/
 COPY --link --from=build-libxml /lib/libz.so.1 /lib/libz.so.1
 COPY --link --from=build-libxml /usr/lib/liblzma.so.5 /usr/lib/liblzma.so.5
 COPY --link --from=build-enduro-a3m-worker /out/enduro-a3m-worker /home/enduro/bin/enduro-a3m-worker
@@ -75,7 +75,7 @@ CMD ["/home/enduro/bin/enduro-a3m-worker", "--config", "/home/enduro/.config/end
 FROM base AS enduro-am-worker
 COPY --link --from=build-libxml /usr/bin/xmllint /usr/bin/xmllint
 COPY --link --from=build-libxml /usr/lib/libxml2.so.2 /usr/lib/libxml2.so.2
-COPY --link --from=build-libxml /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --link --from=build-libxml /lib/ld-musl-*.so.1 /lib/
 COPY --link --from=build-libxml /lib/libz.so.1 /lib/libz.so.1
 COPY --link --from=build-libxml /usr/lib/liblzma.so.5 /usr/lib/liblzma.so.5
 COPY --link --from=build-enduro-am-worker /out/enduro-am-worker /home/enduro/bin/enduro-am-worker

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     Icons({ compiler: "vue3" }),
   ],
   server: {
+    host: "127.0.0.1",
     port: 80,
     strictPort: true,
     proxy: {

--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -17,9 +17,10 @@ A local Kubernetes cluster:
 - [Minikube] _(tested)_
 - [Kind] _(tested)_
 
-It can run with other solutions like Microk8s or Docker for Desktop/Mac and
-even against remote clusters, check Tilt's [Choosing a Local Dev Cluster] and
-[Install] documentation for more information to install these requirements.
+It can run with other solutions like Microk8s, Docker for Desktop/Mac, or
+Lima/Colima (tested on macOS including Apple Silicon), and even against remote
+clusters. Check Tilt's [Choosing a Local Dev Cluster] and [Install]
+documentation for more information to install these requirements.
 
 Additionally, follow the [Manage Docker as a non-root user] post-install guide
 so that you don’t have to run Tilt with `sudo`. _Note that managing Docker as a


### PR DESCRIPTION
I recently started using a Mac with an M4 chip as my primary driver. To run enduro-sdps, I've had to make a few changes to improve compatibility with macOS and Apple Silicon. These updates also help with broader architecture support, like ARM on major cloud providers.

It's really fast btw. Partly because the virtual machine that hosts Linux and k3s runs natively on the aarch64 cores, i.e. no CPU emulation is required. The setup process is also very easy - using [Colima](https://github.com/abiosoft/colima), which is an open-source, lightweight alternative to Docker Desktop for Mac and is managed from the CLI.