### PR TITLE
Use ent client for SIP updates

### DIFF
--- a/internal/ingest/fake/mock_ingest.go
+++ b/internal/ingest/fake/mock_ingest.go
@@ -17,6 +17,7 @@ import (
 	ingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
 	datatypes "github.com/artefactual-sdps/enduro/internal/datatypes"
 	enums "github.com/artefactual-sdps/enduro/internal/enums"
+	persistence "github.com/artefactual-sdps/enduro/internal/persistence"
 	uuid "github.com/google/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -387,17 +388,18 @@ func (c *MockServiceSetWorkflowStatusCall) DoAndReturn(f func(context.Context, i
 }
 
 // UpdateSIP mocks base method.
-func (m *MockService) UpdateSIP(arg0 context.Context, arg1 uuid.UUID, arg2, arg3 string, arg4 enums.SIPStatus, arg5 time.Time) error {
+func (m *MockService) UpdateSIP(arg0 context.Context, arg1 uuid.UUID, arg2 persistence.SIPUpdater) (*datatypes.SIP, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSIP", arg0, arg1, arg2, arg3, arg4, arg5)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "UpdateSIP", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*datatypes.SIP)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // UpdateSIP indicates an expected call of UpdateSIP.
-func (mr *MockServiceMockRecorder) UpdateSIP(arg0, arg1, arg2, arg3, arg4, arg5 any) *MockServiceUpdateSIPCall {
+func (mr *MockServiceMockRecorder) UpdateSIP(arg0, arg1, arg2 any) *MockServiceUpdateSIPCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSIP", reflect.TypeOf((*MockService)(nil).UpdateSIP), arg0, arg1, arg2, arg3, arg4, arg5)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSIP", reflect.TypeOf((*MockService)(nil).UpdateSIP), arg0, arg1, arg2)
 	return &MockServiceUpdateSIPCall{Call: call}
 }
 
@@ -407,19 +409,19 @@ type MockServiceUpdateSIPCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockServiceUpdateSIPCall) Return(arg0 error) *MockServiceUpdateSIPCall {
-	c.Call = c.Call.Return(arg0)
+func (c *MockServiceUpdateSIPCall) Return(arg0 *datatypes.SIP, arg1 error) *MockServiceUpdateSIPCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceUpdateSIPCall) Do(f func(context.Context, uuid.UUID, string, string, enums.SIPStatus, time.Time) error) *MockServiceUpdateSIPCall {
+func (c *MockServiceUpdateSIPCall) Do(f func(context.Context, uuid.UUID, persistence.SIPUpdater) (*datatypes.SIP, error)) *MockServiceUpdateSIPCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceUpdateSIPCall) DoAndReturn(f func(context.Context, uuid.UUID, string, string, enums.SIPStatus, time.Time) error) *MockServiceUpdateSIPCall {
+func (c *MockServiceUpdateSIPCall) DoAndReturn(f func(context.Context, uuid.UUID, persistence.SIPUpdater) (*datatypes.SIP, error)) *MockServiceUpdateSIPCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/persistence/fake/mock_persistence.go
+++ b/internal/persistence/fake/mock_persistence.go
@@ -15,6 +15,7 @@ import (
 
 	datatypes "github.com/artefactual-sdps/enduro/internal/datatypes"
 	persistence "github.com/artefactual-sdps/enduro/internal/persistence"
+	uuid "github.com/google/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -234,7 +235,7 @@ func (c *MockServiceListSIPsCall) DoAndReturn(f func(context.Context, *persisten
 }
 
 // UpdateSIP mocks base method.
-func (m *MockService) UpdateSIP(arg0 context.Context, arg1 int, arg2 persistence.SIPUpdater) (*datatypes.SIP, error) {
+func (m *MockService) UpdateSIP(arg0 context.Context, arg1 uuid.UUID, arg2 persistence.SIPUpdater) (*datatypes.SIP, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSIP", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*datatypes.SIP)
@@ -261,13 +262,13 @@ func (c *MockServiceUpdateSIPCall) Return(arg0 *datatypes.SIP, arg1 error) *Mock
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceUpdateSIPCall) Do(f func(context.Context, int, persistence.SIPUpdater) (*datatypes.SIP, error)) *MockServiceUpdateSIPCall {
+func (c *MockServiceUpdateSIPCall) Do(f func(context.Context, uuid.UUID, persistence.SIPUpdater) (*datatypes.SIP, error)) *MockServiceUpdateSIPCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceUpdateSIPCall) DoAndReturn(f func(context.Context, int, persistence.SIPUpdater) (*datatypes.SIP, error)) *MockServiceUpdateSIPCall {
+func (c *MockServiceUpdateSIPCall) DoAndReturn(f func(context.Context, uuid.UUID, persistence.SIPUpdater) (*datatypes.SIP, error)) *MockServiceUpdateSIPCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/google/uuid"
+
 	"github.com/artefactual-sdps/enduro/internal/datatypes"
 )
 
@@ -28,7 +30,7 @@ type Service interface {
 	// the SIP from the data store, adding auto-generated data
 	// (e.g. ID, CreatedAt).
 	CreateSIP(context.Context, *datatypes.SIP) error
-	UpdateSIP(context.Context, int, SIPUpdater) (*datatypes.SIP, error)
+	UpdateSIP(context.Context, uuid.UUID, SIPUpdater) (*datatypes.SIP, error)
 	DeleteSIP(context.Context, int) error
 	ListSIPs(context.Context, *SIPFilter) ([]*datatypes.SIP, *Page, error)
 

--- a/internal/persistence/telemetry.go
+++ b/internal/persistence/telemetry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -44,10 +45,10 @@ func (w *wrapper) CreateSIP(ctx context.Context, p *datatypes.SIP) error {
 	return nil
 }
 
-func (w *wrapper) UpdateSIP(ctx context.Context, id int, updater SIPUpdater) (*datatypes.SIP, error) {
+func (w *wrapper) UpdateSIP(ctx context.Context, id uuid.UUID, updater SIPUpdater) (*datatypes.SIP, error) {
 	ctx, span := w.tracer.Start(ctx, "UpdateSIP")
 	defer span.End()
-	span.SetAttributes(attribute.Int("id", id))
+	span.SetAttributes(attribute.String("id", id.String()))
 
 	r, err := w.wrapped.UpdateSIP(ctx, id, updater)
 	if err != nil {

--- a/internal/workflow/local_activities_test.go
+++ b/internal/workflow/local_activities_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -13,9 +14,10 @@ import (
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 
-	w "github.com/artefactual-sdps/enduro/internal/datatypes"
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
 	"github.com/artefactual-sdps/enduro/internal/enums"
 	ingest_fake "github.com/artefactual-sdps/enduro/internal/ingest/fake"
+	"github.com/artefactual-sdps/enduro/internal/persistence"
 )
 
 func TestCreateWorkflowLocalActivity(t *testing.T) {
@@ -44,14 +46,14 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 				SIPUUID:     sipUUID,
 			},
 			mockCalls: func(m *ingest_fake.MockServiceMockRecorder) {
-				m.CreateWorkflow(mockutil.Context(), &w.Workflow{
+				m.CreateWorkflow(mockutil.Context(), &datatypes.Workflow{
 					TemporalID:  "workflow-id",
 					Type:        enums.WorkflowTypeCreateAip,
 					Status:      enums.WorkflowStatusDone,
 					StartedAt:   sql.NullTime{Time: startedAt, Valid: true},
 					CompletedAt: sql.NullTime{Time: completedAt, Valid: true},
 					SIPUUID:     sipUUID,
-				}).DoAndReturn(func(ctx context.Context, w *w.Workflow) error {
+				}).DoAndReturn(func(ctx context.Context, w *datatypes.Workflow) error {
 					w.ID = 1
 					return nil
 				})
@@ -67,12 +69,12 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 				SIPUUID:    sipUUID,
 			},
 			mockCalls: func(m *ingest_fake.MockServiceMockRecorder) {
-				m.CreateWorkflow(mockutil.Context(), &w.Workflow{
+				m.CreateWorkflow(mockutil.Context(), &datatypes.Workflow{
 					TemporalID: "workflow-id",
 					Type:       enums.WorkflowTypeCreateAip,
 					Status:     enums.WorkflowStatusDone,
 					SIPUUID:    sipUUID,
-				}).DoAndReturn(func(ctx context.Context, w *w.Workflow) error {
+				}).DoAndReturn(func(ctx context.Context, w *datatypes.Workflow) error {
 					w.ID = 1
 					return nil
 				})
@@ -88,7 +90,7 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 				SIPUUID:    sipUUID,
 			},
 			mockCalls: func(m *ingest_fake.MockServiceMockRecorder) {
-				m.CreateWorkflow(mockutil.Context(), &w.Workflow{
+				m.CreateWorkflow(mockutil.Context(), &datatypes.Workflow{
 					TemporalID: "workflow-id",
 					Type:       enums.WorkflowTypeCreateAip,
 					Status:     enums.WorkflowStatusDone,
@@ -122,6 +124,125 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 			var res uint
 			_ = enc.Get(&res)
 			assert.DeepEqual(t, res, tt.want)
+		})
+	}
+}
+
+func TestUpdateSIPLocalActivity(t *testing.T) {
+	t.Parallel()
+
+	sipUUID := uuid.New()
+	aipUUID := uuid.New()
+	name := "Test SIP"
+	completedAt := time.Now()
+
+	for _, tt := range []struct {
+		name      string
+		params    *updateSIPLocalActivityParams
+		mockCalls func(context.Context, *ingest_fake.MockService)
+		wantErr   string
+	}{
+		{
+			name: "Updates a SIP",
+			params: &updateSIPLocalActivityParams{
+				UUID:        sipUUID,
+				Name:        name,
+				Status:      enums.SIPStatusIngested,
+				CompletedAt: completedAt,
+				AIPUUID:     aipUUID.String(),
+			},
+			mockCalls: func(ctx context.Context, svc *ingest_fake.MockService) {
+				svc.EXPECT().
+					UpdateSIP(
+						ctx,
+						sipUUID,
+						mockutil.Func(
+							"should update sip",
+							func(updater persistence.SIPUpdater) error {
+								s, err := updater(&datatypes.SIP{})
+								assert.NilError(t, err)
+								assert.DeepEqual(t, s.Name, name)
+								assert.DeepEqual(t, s.Status, enums.SIPStatusIngested)
+								assert.DeepEqual(t, s.CompletedAt, sql.NullTime{Valid: true, Time: completedAt})
+								assert.DeepEqual(t, s.AIPID, uuid.NullUUID{Valid: true, UUID: aipUUID})
+								return nil
+							},
+						),
+					).
+					Return(nil, nil)
+			},
+		},
+		{
+			name: "Fails to update a SIP (invalid status)",
+			params: &updateSIPLocalActivityParams{
+				UUID:        sipUUID,
+				Name:        name,
+				Status:      "",
+				CompletedAt: completedAt,
+				AIPUUID:     aipUUID.String(),
+			},
+			mockCalls: func(ctx context.Context, svc *ingest_fake.MockService) {
+				svc.EXPECT().
+					UpdateSIP(
+						ctx,
+						sipUUID,
+						mockutil.Func(
+							"should fail to update sip",
+							func(updater persistence.SIPUpdater) error {
+								_, err := updater(&datatypes.SIP{})
+								assert.ErrorContains(t, err, "invalid status: ")
+								return nil
+							},
+						),
+					).
+					Return(nil, errors.New("invalid status: "))
+			},
+			wantErr: "invalid status: ",
+		},
+		{
+			name: "Fails to update a SIP (invalid AIP UUID)",
+			params: &updateSIPLocalActivityParams{
+				UUID:        sipUUID,
+				Name:        name,
+				Status:      enums.SIPStatusIngested,
+				CompletedAt: completedAt,
+				AIPUUID:     "invalid-uuid",
+			},
+			mockCalls: func(ctx context.Context, svc *ingest_fake.MockService) {
+				svc.EXPECT().
+					UpdateSIP(
+						ctx,
+						sipUUID,
+						mockutil.Func(
+							"should fail to update sip",
+							func(updater persistence.SIPUpdater) error {
+								_, err := updater(&datatypes.SIP{})
+								assert.ErrorContains(t, err, "invalid AIP UUID: invalid-uuid")
+								return nil
+							},
+						),
+					).
+					Return(nil, errors.New("invalid AIP UUID: invalid-uuid"))
+			},
+			wantErr: "invalid AIP UUID: invalid-uuid",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			svc := ingest_fake.NewMockService(gomock.NewController(t))
+			if tt.mockCalls != nil {
+				tt.mockCalls(ctx, svc)
+			}
+
+			re, err := updateSIPLocalActivity(ctx, svc, tt.params)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, re, &updateSIPLocalActivityResult{})
 		})
 	}
 }


### PR DESCRIPTION
Slowly moving towards the goal of using Ent in the ingest service. This is related to #1202, where I plan to add new columns to the SIP table to reflect the failure type (SIP or PIP) and the failed object key.