### PR TITLE
Test parameters sent to SIP update activity

### DIFF
--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"slices"
-	"time"
 
 	"github.com/google/uuid"
 
@@ -108,10 +107,4 @@ type aipInfo struct {
 	// path is left blank when using AM as the preservation system because
 	// storage of the AIP is handled by AM and the AMSS.
 	path string
-
-	// storedAt is the time when the AIP is stored.
-	//
-	// storedAt is set when the preservation system reports the AIP has been
-	// created and stored successfully.
-	storedAt time.Time
 }


### PR DESCRIPTION
- Make sure the CompletedAt time is not set while processing.
- Use argument matchers to check that CompletedAt is set.
- Remove `storedAt` from the `state.aip`.

As #1249, this is related to #1202, where I plan to add new columns to the SIP table to add failure details, and I want to test those values are properly set in workflow.