### PR TITLE
Add download SIP API endpoints

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 dashboard/src/openapi-generator/** linguist-generated
+docs/src/dev-manual/api/openapi3.json linguist-generated
 internal/api/gen/** linguist-generated

--- a/dashboard/src/openapi-generator/apis/IngestApi.ts
+++ b/dashboard/src/openapi-generator/apis/IngestApi.ts
@@ -45,6 +45,15 @@ export interface IngestConfirmSipRequest {
     confirmSipRequestBody: ConfirmSipRequestBody;
 }
 
+export interface IngestDownloadSipRequest {
+    uuid: string;
+    enduroSipDownloadTicket?: string;
+}
+
+export interface IngestDownloadSipRequestRequest {
+    uuid: string;
+}
+
 export interface IngestListSipWorkflowsRequest {
     uuid: string;
 }
@@ -98,6 +107,39 @@ export interface IngestApiInterface {
      * confirm_sip ingest
      */
     ingestConfirmSip(requestParameters: IngestConfirmSipRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void>;
+
+    /**
+     * Download the failed package related to a SIP. It will be the original SIP or the transformed PIP, based on the SIP\'s `failed_as` value.
+     * @summary download_sip ingest
+     * @param {string} uuid Identifier of the SIP to download
+     * @param {string} [enduroSipDownloadTicket] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof IngestApiInterface
+     */
+    ingestDownloadSipRaw(requestParameters: IngestDownloadSipRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Blob>>;
+
+    /**
+     * Download the failed package related to a SIP. It will be the original SIP or the transformed PIP, based on the SIP\'s `failed_as` value.
+     * download_sip ingest
+     */
+    ingestDownloadSip(requestParameters: IngestDownloadSipRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Blob>;
+
+    /**
+     * Request access to SIP download
+     * @summary download_sip_request ingest
+     * @param {string} uuid Identifier of the SIP to download
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof IngestApiInterface
+     */
+    ingestDownloadSipRequestRaw(requestParameters: IngestDownloadSipRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>>;
+
+    /**
+     * Request access to SIP download
+     * download_sip_request ingest
+     */
+    ingestDownloadSipRequest(requestParameters: IngestDownloadSipRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void>;
 
     /**
      * List all workflows for a SIP
@@ -267,6 +309,77 @@ export class IngestApi extends runtime.BaseAPI implements IngestApiInterface {
      */
     async ingestConfirmSip(requestParameters: IngestConfirmSipRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
         await this.ingestConfirmSipRaw(requestParameters, initOverrides);
+    }
+
+    /**
+     * Download the failed package related to a SIP. It will be the original SIP or the transformed PIP, based on the SIP\'s `failed_as` value.
+     * download_sip ingest
+     */
+    async ingestDownloadSipRaw(requestParameters: IngestDownloadSipRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Blob>> {
+        if (requestParameters.uuid === null || requestParameters.uuid === undefined) {
+            throw new runtime.RequiredError('uuid','Required parameter requestParameters.uuid was null or undefined when calling ingestDownloadSip.');
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/ingest/sips/{uuid}/download`.replace(`{${"uuid"}}`, encodeURIComponent(String(requestParameters.uuid))),
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.BlobApiResponse(response);
+    }
+
+    /**
+     * Download the failed package related to a SIP. It will be the original SIP or the transformed PIP, based on the SIP\'s `failed_as` value.
+     * download_sip ingest
+     */
+    async ingestDownloadSip(requestParameters: IngestDownloadSipRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Blob> {
+        const response = await this.ingestDownloadSipRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * Request access to SIP download
+     * download_sip_request ingest
+     */
+    async ingestDownloadSipRequestRaw(requestParameters: IngestDownloadSipRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
+        if (requestParameters.uuid === null || requestParameters.uuid === undefined) {
+            throw new runtime.RequiredError('uuid','Required parameter requestParameters.uuid was null or undefined when calling ingestDownloadSipRequest.');
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.accessToken) {
+            const token = this.configuration.accessToken;
+            const tokenString = await token("jwt_header_Authorization", []);
+
+            if (tokenString) {
+                headerParameters["Authorization"] = `Bearer ${tokenString}`;
+            }
+        }
+        const response = await this.request({
+            path: `/ingest/sips/{uuid}/download`.replace(`{${"uuid"}}`, encodeURIComponent(String(requestParameters.uuid))),
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.VoidApiResponse(response);
+    }
+
+    /**
+     * Request access to SIP download
+     * download_sip_request ingest
+     */
+    async ingestDownloadSipRequest(requestParameters: IngestDownloadSipRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
+        await this.ingestDownloadSipRequestRaw(requestParameters, initOverrides);
     }
 
     /**

--- a/docs/src/admin-manual/iac.md
+++ b/docs/src/admin-manual/iac.md
@@ -153,21 +153,32 @@ rm -rf $TMP_DIR
 ## Required attributes
 
 The following table shows the attributes required for each API endpoint. The
-attributes allow a wildcard hierarchical declaration. For example, `ingest:sips:*`
-will give access to endpoints requiring `ingest:sips:list`, `ingest:sips:read`, etc.
-The `*` attribute will provide full access to the API.
+attributes allow a wildcard hierarchical declaration. For example,
+`ingest:sips:*` will give access to endpoints requiring `ingest:sips:list`,
+`ingest:sips:read`, etc. The `*` attribute will provide full access to the API.
+
+In order to stablish a Websocket connection from the browser, the
+`GET /ingest/monitor` endpoint requires a cookie obtained from the
+`POST /ingest/monitor` endpoint. Similarly, to be able to stream a SIP download
+from the browser, the `GET /ingest/sips/{id}/download` endpoint requires a
+cookie obtained from the `POST /ingest/sips/{id}/download` endpoint.
 
 | Method | Endpoint                              | Attributes                      |
 | ------ | ------------------------------------- | ------------------------------- |
+| POST   | /ingest/monitor                       | `All ingest attributes`         |
+| GET    | /ingest/monitor                       | `-`                             |
 | GET    | /ingest/sips                          | `ingest:sips:list`              |
 | GET    | /ingest/sips/{id}                     | `ingest:sips:read`              |
 | POST   | /ingest/sips/{id}/confirm             | `ingest:sips:review`            |
+| POST   | /ingest/sips/{id}/download            | `ingest:sips:download`          |
+| GET    | /ingest/sips/{id}/download            | `-`                             |
 | POST   | /ingest/sips/{id}/reject              | `ingest:sips:review`            |
 | GET    | /ingest/sips/{id}/workflows           | `ingest:sips:workflows:list`    |
 | POST   | /ingest/sips/upload                   | `ingest:sips:upload`            |
 | GET    | /storage/aips                         | `storage:aips:list`             |
 | POST   | /storage/aips                         | `storage:aips:create`           |
 | GET    | /storage/aips/{uuid}                  | `storage:aips:read`             |
+| POST   | /storage/aips/{uuid}/deletion-cancel  | `storage:aips:deletion:request` |
 | POST   | /storage/aips/{uuid}/deletion-request | `storage:aips:deletion:request` |
 | POST   | /storage/aips/{uuid}/deletion-review  | `storage:aips:deletion:review`  |
 | GET    | /storage/aips/{uuid}/download         | `storage:aips:download`         |

--- a/docs/src/dev-manual/api/openapi3.json
+++ b/docs/src/dev-manual/api/openapi3.json
@@ -1910,6 +1910,7 @@
         "security": [
           {
             "jwt_header_Authorization": [
+              "ingest:sips:download",
               "ingest:sips:list",
               "ingest:sips:read",
               "ingest:sips:review",
@@ -2402,6 +2403,238 @@
           }
         ],
         "summary": "confirm_sip ingest",
+        "tags": [
+          "ingest"
+        ]
+      }
+    },
+    "/ingest/sips/{uuid}/download": {
+      "get": {
+        "description": "Download the failed package related to a SIP. It will be the original SIP or the transformed PIP, based on the SIP's `failed_as` value.",
+        "operationId": "ingest#download_sip",
+        "parameters": [
+          {
+            "description": "Identifier of the SIP to download",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "description": "Identifier of the SIP to download",
+              "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "example": "abc123",
+            "in": "cookie",
+            "name": "enduro-sip-download-ticket",
+            "schema": {
+              "example": "abc123",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK response.",
+            "headers": {
+              "Content-Disposition": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "example": 1,
+                "schema": {
+                  "example": 1,
+                  "format": "int64",
+                  "type": "integer"
+                }
+              },
+              "Content-Type": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "not_valid: Bad Request response."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized: Unauthorized response."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "forbidden: Forbidden response."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "abc123",
+                  "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SIPNotFound"
+                }
+              }
+            },
+            "description": "not_found: SIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
+          }
+        },
+        "summary": "download_sip ingest",
+        "tags": [
+          "ingest"
+        ]
+      },
+      "post": {
+        "description": "Request access to SIP download",
+        "operationId": "ingest#download_sip_request",
+        "parameters": [
+          {
+            "description": "Identifier of the SIP to download",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "description": "Identifier of the SIP to download",
+              "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "headers": {
+              "Set-Cookie": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "not_valid: Bad Request response."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized: Unauthorized response."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "forbidden: Forbidden response."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "abc123",
+                  "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SIPNotFound"
+                }
+              }
+            },
+            "description": "not_found: SIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
+          }
+        },
+        "security": [
+          {
+            "jwt_header_Authorization": [
+              "ingest:sips:download"
+            ]
+          }
+        ],
+        "summary": "download_sip_request ingest",
         "tags": [
           "ingest"
         ]

--- a/enduro.toml
+++ b/enduro.toml
@@ -211,11 +211,11 @@ passphrase = "" # Secret: set (if required) with env var ENDURO_AM_SFTP_PRIVATEK
 maxSize = 4294967296
 
 # internalStorage section configures a bucket where Enduro will place uploaded
-# SIPs. Make sure it doesn't match any of the watched buckets.
+# SIPs and failed SIPs/PIPs. Make sure it doesn't match any of the watched buckets.
 [internalStorage.bucket]
 # Example for an Azure URL connection where the bucket/container is called "sips".
 # See [internalStorage.azure] below to set credentials.
-# URL = "azblob://sips"
+# url = "azblob://sips"
 endpoint = "http://minio.enduro-sdps:9000"
 pathStyle = true
 accessKey = "minio"

--- a/hack/kube/components/dev/keycloak.yaml
+++ b/hack/kube/components/dev/keycloak.yaml
@@ -115,6 +115,7 @@ data:
           ],
           "attributes": {
             "enduro": [
+              "ingest:sips:download",
               "ingest:sips:list",
               "ingest:sips:read",
               "ingest:sips:upload",

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -56,6 +56,7 @@ func HTTPServer(
 	ingestEndpoints := ingest.NewEndpoints(ingestsvc.Goa())
 	ingestErrorHandler := errorHandler(logger, "Ingest error.")
 	ingestServer := ingestsvr.New(ingestEndpoints, mux, dec, enc, ingestErrorHandler, nil, websocketUpgrader, nil)
+	ingestServer.DownloadSip = writeTimeout(ingestServer.DownloadSip, 0)
 	ingestsvr.Mount(mux, ingestServer)
 
 	// Storage service.

--- a/internal/api/design/design.go
+++ b/internal/api/design/design.go
@@ -16,6 +16,7 @@ import (
 
 var JWTAuth = JWTSecurity("jwt", func() {
 	Description("Secures endpoint by requiring a valid JWT token.")
+	Scope("ingest:sips:download")
 	Scope("ingest:sips:list")
 	Scope("ingest:sips:read")
 	Scope("ingest:sips:review")

--- a/internal/api/gen/about/endpoints.go
+++ b/internal/api/gen/about/endpoints.go
@@ -42,7 +42,7 @@ func NewAboutEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.Endpoint {
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{},
 		}
 		var token string

--- a/internal/api/gen/http/ingest/client/cli.go
+++ b/internal/api/gen/http/ingest/client/cli.go
@@ -277,3 +277,53 @@ func BuildUploadSipPayload(ingestUploadSipContentType string, ingestUploadSipTok
 
 	return v, nil
 }
+
+// BuildDownloadSipRequestPayload builds the payload for the ingest
+// download_sip_request endpoint from CLI flags.
+func BuildDownloadSipRequestPayload(ingestDownloadSipRequestUUID string, ingestDownloadSipRequestToken string) (*ingest.DownloadSipRequestPayload, error) {
+	var err error
+	var uuid string
+	{
+		uuid = ingestDownloadSipRequestUUID
+		err = goa.MergeErrors(err, goa.ValidateFormat("uuid", uuid, goa.FormatUUID))
+		if err != nil {
+			return nil, err
+		}
+	}
+	var token *string
+	{
+		if ingestDownloadSipRequestToken != "" {
+			token = &ingestDownloadSipRequestToken
+		}
+	}
+	v := &ingest.DownloadSipRequestPayload{}
+	v.UUID = uuid
+	v.Token = token
+
+	return v, nil
+}
+
+// BuildDownloadSipPayload builds the payload for the ingest download_sip
+// endpoint from CLI flags.
+func BuildDownloadSipPayload(ingestDownloadSipUUID string, ingestDownloadSipTicket string) (*ingest.DownloadSipPayload, error) {
+	var err error
+	var uuid string
+	{
+		uuid = ingestDownloadSipUUID
+		err = goa.MergeErrors(err, goa.ValidateFormat("uuid", uuid, goa.FormatUUID))
+		if err != nil {
+			return nil, err
+		}
+	}
+	var ticket *string
+	{
+		if ingestDownloadSipTicket != "" {
+			ticket = &ingestDownloadSipTicket
+		}
+	}
+	v := &ingest.DownloadSipPayload{}
+	v.UUID = uuid
+	v.Ticket = ticket
+
+	return v, nil
+}

--- a/internal/api/gen/http/ingest/client/paths.go
+++ b/internal/api/gen/http/ingest/client/paths.go
@@ -51,3 +51,13 @@ func RejectSipIngestPath(uuid string) string {
 func UploadSipIngestPath() string {
 	return "/ingest/sips/upload"
 }
+
+// DownloadSipRequestIngestPath returns the URL path to the ingest service download_sip_request HTTP endpoint.
+func DownloadSipRequestIngestPath(uuid string) string {
+	return fmt.Sprintf("/ingest/sips/%v/download", uuid)
+}
+
+// DownloadSipIngestPath returns the URL path to the ingest service download_sip HTTP endpoint.
+func DownloadSipIngestPath(uuid string) string {
+	return fmt.Sprintf("/ingest/sips/%v/download", uuid)
+}

--- a/internal/api/gen/http/ingest/client/types.go
+++ b/internal/api/gen/http/ingest/client/types.go
@@ -327,6 +327,97 @@ type UploadSipInternalErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// DownloadSipRequestNotValidResponseBody is the type of the "ingest" service
+// "download_sip_request" endpoint HTTP response body for the "not_valid" error.
+type DownloadSipRequestNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DownloadSipRequestInternalErrorResponseBody is the type of the "ingest"
+// service "download_sip_request" endpoint HTTP response body for the
+// "internal_error" error.
+type DownloadSipRequestInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DownloadSipRequestNotFoundResponseBody is the type of the "ingest" service
+// "download_sip_request" endpoint HTTP response body for the "not_found" error.
+type DownloadSipRequestNotFoundResponseBody struct {
+	// Message of error
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Identifier of missing SIP
+	UUID *string `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
+}
+
+// DownloadSipNotValidResponseBody is the type of the "ingest" service
+// "download_sip" endpoint HTTP response body for the "not_valid" error.
+type DownloadSipNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DownloadSipInternalErrorResponseBody is the type of the "ingest" service
+// "download_sip" endpoint HTTP response body for the "internal_error" error.
+type DownloadSipInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DownloadSipNotFoundResponseBody is the type of the "ingest" service
+// "download_sip" endpoint HTTP response body for the "not_found" error.
+type DownloadSipNotFoundResponseBody struct {
+	// Message of error
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Identifier of missing SIP
+	UUID *string `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
+}
+
 // SIPCollectionResponseBody is used to define fields on response body types.
 type SIPCollectionResponseBody []*SIPResponseBody
 
@@ -856,6 +947,140 @@ func NewUploadSipUnauthorized(body string) ingest.Unauthorized {
 	return v
 }
 
+// NewDownloadSipRequestResultOK builds a "ingest" service
+// "download_sip_request" endpoint result from a HTTP "OK" response.
+func NewDownloadSipRequestResultOK(ticket *string) *ingest.DownloadSipRequestResult {
+	v := &ingest.DownloadSipRequestResult{}
+	v.Ticket = ticket
+
+	return v
+}
+
+// NewDownloadSipRequestNotValid builds a ingest service download_sip_request
+// endpoint not_valid error.
+func NewDownloadSipRequestNotValid(body *DownloadSipRequestNotValidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDownloadSipRequestInternalError builds a ingest service
+// download_sip_request endpoint internal_error error.
+func NewDownloadSipRequestInternalError(body *DownloadSipRequestInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDownloadSipRequestNotFound builds a ingest service download_sip_request
+// endpoint not_found error.
+func NewDownloadSipRequestNotFound(body *DownloadSipRequestNotFoundResponseBody) *ingest.SIPNotFound {
+	v := &ingest.SIPNotFound{
+		Message: *body.Message,
+		UUID:    *body.UUID,
+	}
+
+	return v
+}
+
+// NewDownloadSipRequestForbidden builds a ingest service download_sip_request
+// endpoint forbidden error.
+func NewDownloadSipRequestForbidden(body string) ingest.Forbidden {
+	v := ingest.Forbidden(body)
+
+	return v
+}
+
+// NewDownloadSipRequestUnauthorized builds a ingest service
+// download_sip_request endpoint unauthorized error.
+func NewDownloadSipRequestUnauthorized(body string) ingest.Unauthorized {
+	v := ingest.Unauthorized(body)
+
+	return v
+}
+
+// NewDownloadSipResultOK builds a "ingest" service "download_sip" endpoint
+// result from a HTTP "OK" response.
+func NewDownloadSipResultOK(contentType string, contentLength int64, contentDisposition string) *ingest.DownloadSipResult {
+	v := &ingest.DownloadSipResult{}
+	v.ContentType = contentType
+	v.ContentLength = contentLength
+	v.ContentDisposition = contentDisposition
+
+	return v
+}
+
+// NewDownloadSipNotValid builds a ingest service download_sip endpoint
+// not_valid error.
+func NewDownloadSipNotValid(body *DownloadSipNotValidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDownloadSipInternalError builds a ingest service download_sip endpoint
+// internal_error error.
+func NewDownloadSipInternalError(body *DownloadSipInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDownloadSipNotFound builds a ingest service download_sip endpoint
+// not_found error.
+func NewDownloadSipNotFound(body *DownloadSipNotFoundResponseBody) *ingest.SIPNotFound {
+	v := &ingest.SIPNotFound{
+		Message: *body.Message,
+		UUID:    *body.UUID,
+	}
+
+	return v
+}
+
+// NewDownloadSipForbidden builds a ingest service download_sip endpoint
+// forbidden error.
+func NewDownloadSipForbidden(body string) ingest.Forbidden {
+	v := ingest.Forbidden(body)
+
+	return v
+}
+
+// NewDownloadSipUnauthorized builds a ingest service download_sip endpoint
+// unauthorized error.
+func NewDownloadSipUnauthorized(body string) ingest.Unauthorized {
+	v := ingest.Unauthorized(body)
+
+	return v
+}
+
 // ValidateMonitorResponseBody runs the validations defined on
 // MonitorResponseBody
 func ValidateMonitorResponseBody(body *MonitorResponseBody) (err error) {
@@ -1207,6 +1432,132 @@ func ValidateUploadSipInternalErrorResponseBody(body *UploadSipInternalErrorResp
 	}
 	if body.Fault == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDownloadSipRequestNotValidResponseBody runs the validations defined
+// on download_sip_request_not_valid_response_body
+func ValidateDownloadSipRequestNotValidResponseBody(body *DownloadSipRequestNotValidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDownloadSipRequestInternalErrorResponseBody runs the validations
+// defined on download_sip_request_internal_error_response_body
+func ValidateDownloadSipRequestInternalErrorResponseBody(body *DownloadSipRequestInternalErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDownloadSipRequestNotFoundResponseBody runs the validations defined
+// on download_sip_request_not_found_response_body
+func ValidateDownloadSipRequestNotFoundResponseBody(body *DownloadSipRequestNotFoundResponseBody) (err error) {
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.UUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "body"))
+	}
+	if body.UUID != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.uuid", *body.UUID, goa.FormatUUID))
+	}
+	return
+}
+
+// ValidateDownloadSipNotValidResponseBody runs the validations defined on
+// download_sip_not_valid_response_body
+func ValidateDownloadSipNotValidResponseBody(body *DownloadSipNotValidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDownloadSipInternalErrorResponseBody runs the validations defined on
+// download_sip_internal_error_response_body
+func ValidateDownloadSipInternalErrorResponseBody(body *DownloadSipInternalErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDownloadSipNotFoundResponseBody runs the validations defined on
+// download_sip_not_found_response_body
+func ValidateDownloadSipNotFoundResponseBody(body *DownloadSipNotFoundResponseBody) (err error) {
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.UUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "body"))
+	}
+	if body.UUID != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.uuid", *body.UUID, goa.FormatUUID))
 	}
 	return
 }

--- a/internal/api/gen/http/ingest/server/encode_decode.go
+++ b/internal/api/gen/http/ingest/server/encode_decode.go
@@ -879,6 +879,249 @@ func EncodeUploadSipError(encoder func(context.Context, http.ResponseWriter) goa
 	}
 }
 
+// EncodeDownloadSipRequestResponse returns an encoder for responses returned
+// by the ingest download_sip_request endpoint.
+func EncodeDownloadSipRequestResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(*ingest.DownloadSipRequestResult)
+		if res.Ticket != nil {
+			ticket := *res.Ticket
+			http.SetCookie(w, &http.Cookie{
+				Name:     "enduro-sip-download-ticket",
+				Value:    ticket,
+				MaxAge:   5,
+				Secure:   true,
+				HttpOnly: true,
+			})
+		}
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+}
+
+// DecodeDownloadSipRequestRequest returns a decoder for requests sent to the
+// ingest download_sip_request endpoint.
+func DecodeDownloadSipRequestRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
+		var (
+			uuid  string
+			token *string
+			err   error
+
+			params = mux.Vars(r)
+		)
+		uuid = params["uuid"]
+		err = goa.MergeErrors(err, goa.ValidateFormat("uuid", uuid, goa.FormatUUID))
+		tokenRaw := r.Header.Get("Authorization")
+		if tokenRaw != "" {
+			token = &tokenRaw
+		}
+		if err != nil {
+			return nil, err
+		}
+		payload := NewDownloadSipRequestPayload(uuid, token)
+		if payload.Token != nil {
+			if strings.Contains(*payload.Token, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.Token, " ", 2)[1]
+				payload.Token = &cred
+			}
+		}
+
+		return payload, nil
+	}
+}
+
+// EncodeDownloadSipRequestError returns an encoder for errors returned by the
+// download_sip_request ingest endpoint.
+func EncodeDownloadSipRequestError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "not_valid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDownloadSipRequestNotValidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDownloadSipRequestInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "not_found":
+			var res *ingest.SIPNotFound
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDownloadSipRequestNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "forbidden":
+			var res ingest.Forbidden
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			body := res
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "unauthorized":
+			var res ingest.Unauthorized
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			body := res
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
+// EncodeDownloadSipResponse returns an encoder for responses returned by the
+// ingest download_sip endpoint.
+func EncodeDownloadSipResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(*ingest.DownloadSipResult)
+		w.Header().Set("Content-Type", res.ContentType)
+		{
+			val := res.ContentLength
+			contentLengths := strconv.FormatInt(val, 10)
+			w.Header().Set("Content-Length", contentLengths)
+		}
+		w.Header().Set("Content-Disposition", res.ContentDisposition)
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+}
+
+// DecodeDownloadSipRequest returns a decoder for requests sent to the ingest
+// download_sip endpoint.
+func DecodeDownloadSipRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
+		var (
+			uuid   string
+			ticket *string
+			err    error
+			c      *http.Cookie
+
+			params = mux.Vars(r)
+		)
+		uuid = params["uuid"]
+		err = goa.MergeErrors(err, goa.ValidateFormat("uuid", uuid, goa.FormatUUID))
+		c, _ = r.Cookie("enduro-sip-download-ticket")
+		var ticketRaw string
+		if c != nil {
+			ticketRaw = c.Value
+		}
+		if ticketRaw != "" {
+			ticket = &ticketRaw
+		}
+		if err != nil {
+			return nil, err
+		}
+		payload := NewDownloadSipPayload(uuid, ticket)
+
+		return payload, nil
+	}
+}
+
+// EncodeDownloadSipError returns an encoder for errors returned by the
+// download_sip ingest endpoint.
+func EncodeDownloadSipError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "not_valid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDownloadSipNotValidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDownloadSipInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "not_found":
+			var res *ingest.SIPNotFound
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDownloadSipNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "forbidden":
+			var res ingest.Forbidden
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			body := res
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "unauthorized":
+			var res ingest.Unauthorized
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			body := res
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
 // marshalIngestviewsSIPViewToSIPResponseBody builds a value of type
 // *SIPResponseBody from a value of type *ingestviews.SIPView.
 func marshalIngestviewsSIPViewToSIPResponseBody(v *ingestviews.SIPView) *SIPResponseBody {

--- a/internal/api/gen/http/ingest/server/paths.go
+++ b/internal/api/gen/http/ingest/server/paths.go
@@ -51,3 +51,13 @@ func RejectSipIngestPath(uuid string) string {
 func UploadSipIngestPath() string {
 	return "/ingest/sips/upload"
 }
+
+// DownloadSipRequestIngestPath returns the URL path to the ingest service download_sip_request HTTP endpoint.
+func DownloadSipRequestIngestPath(uuid string) string {
+	return fmt.Sprintf("/ingest/sips/%v/download", uuid)
+}
+
+// DownloadSipIngestPath returns the URL path to the ingest service download_sip HTTP endpoint.
+func DownloadSipIngestPath(uuid string) string {
+	return fmt.Sprintf("/ingest/sips/%v/download", uuid)
+}

--- a/internal/api/gen/http/ingest/server/types.go
+++ b/internal/api/gen/http/ingest/server/types.go
@@ -327,6 +327,97 @@ type UploadSipInternalErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// DownloadSipRequestNotValidResponseBody is the type of the "ingest" service
+// "download_sip_request" endpoint HTTP response body for the "not_valid" error.
+type DownloadSipRequestNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DownloadSipRequestInternalErrorResponseBody is the type of the "ingest"
+// service "download_sip_request" endpoint HTTP response body for the
+// "internal_error" error.
+type DownloadSipRequestInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DownloadSipRequestNotFoundResponseBody is the type of the "ingest" service
+// "download_sip_request" endpoint HTTP response body for the "not_found" error.
+type DownloadSipRequestNotFoundResponseBody struct {
+	// Message of error
+	Message string `form:"message" json:"message" xml:"message"`
+	// Identifier of missing SIP
+	UUID string `form:"uuid" json:"uuid" xml:"uuid"`
+}
+
+// DownloadSipNotValidResponseBody is the type of the "ingest" service
+// "download_sip" endpoint HTTP response body for the "not_valid" error.
+type DownloadSipNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DownloadSipInternalErrorResponseBody is the type of the "ingest" service
+// "download_sip" endpoint HTTP response body for the "internal_error" error.
+type DownloadSipInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DownloadSipNotFoundResponseBody is the type of the "ingest" service
+// "download_sip" endpoint HTTP response body for the "not_found" error.
+type DownloadSipNotFoundResponseBody struct {
+	// Message of error
+	Message string `form:"message" json:"message" xml:"message"`
+	// Identifier of missing SIP
+	UUID string `form:"uuid" json:"uuid" xml:"uuid"`
+}
+
 // SIPResponseBodyCollection is used to define fields on response body types.
 type SIPResponseBodyCollection []*SIPResponseBody
 
@@ -701,6 +792,83 @@ func NewUploadSipInternalErrorResponseBody(res *goa.ServiceError) *UploadSipInte
 	return body
 }
 
+// NewDownloadSipRequestNotValidResponseBody builds the HTTP response body from
+// the result of the "download_sip_request" endpoint of the "ingest" service.
+func NewDownloadSipRequestNotValidResponseBody(res *goa.ServiceError) *DownloadSipRequestNotValidResponseBody {
+	body := &DownloadSipRequestNotValidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDownloadSipRequestInternalErrorResponseBody builds the HTTP response body
+// from the result of the "download_sip_request" endpoint of the "ingest"
+// service.
+func NewDownloadSipRequestInternalErrorResponseBody(res *goa.ServiceError) *DownloadSipRequestInternalErrorResponseBody {
+	body := &DownloadSipRequestInternalErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDownloadSipRequestNotFoundResponseBody builds the HTTP response body from
+// the result of the "download_sip_request" endpoint of the "ingest" service.
+func NewDownloadSipRequestNotFoundResponseBody(res *ingest.SIPNotFound) *DownloadSipRequestNotFoundResponseBody {
+	body := &DownloadSipRequestNotFoundResponseBody{
+		Message: res.Message,
+		UUID:    res.UUID,
+	}
+	return body
+}
+
+// NewDownloadSipNotValidResponseBody builds the HTTP response body from the
+// result of the "download_sip" endpoint of the "ingest" service.
+func NewDownloadSipNotValidResponseBody(res *goa.ServiceError) *DownloadSipNotValidResponseBody {
+	body := &DownloadSipNotValidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDownloadSipInternalErrorResponseBody builds the HTTP response body from
+// the result of the "download_sip" endpoint of the "ingest" service.
+func NewDownloadSipInternalErrorResponseBody(res *goa.ServiceError) *DownloadSipInternalErrorResponseBody {
+	body := &DownloadSipInternalErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDownloadSipNotFoundResponseBody builds the HTTP response body from the
+// result of the "download_sip" endpoint of the "ingest" service.
+func NewDownloadSipNotFoundResponseBody(res *ingest.SIPNotFound) *DownloadSipNotFoundResponseBody {
+	body := &DownloadSipNotFoundResponseBody{
+		Message: res.Message,
+		UUID:    res.UUID,
+	}
+	return body
+}
+
 // NewMonitorRequestPayload builds a ingest service monitor_request endpoint
 // payload.
 func NewMonitorRequestPayload(token *string) *ingest.MonitorRequestPayload {
@@ -777,6 +945,25 @@ func NewUploadSipPayload(contentType string, token *string) *ingest.UploadSipPay
 	v := &ingest.UploadSipPayload{}
 	v.ContentType = contentType
 	v.Token = token
+
+	return v
+}
+
+// NewDownloadSipRequestPayload builds a ingest service download_sip_request
+// endpoint payload.
+func NewDownloadSipRequestPayload(uuid string, token *string) *ingest.DownloadSipRequestPayload {
+	v := &ingest.DownloadSipRequestPayload{}
+	v.UUID = uuid
+	v.Token = token
+
+	return v
+}
+
+// NewDownloadSipPayload builds a ingest service download_sip endpoint payload.
+func NewDownloadSipPayload(uuid string, ticket *string) *ingest.DownloadSipPayload {
+	v := &ingest.DownloadSipPayload{}
+	v.UUID = uuid
+	v.Ticket = ticket
 
 	return v
 }

--- a/internal/api/gen/http/openapi.json
+++ b/internal/api/gen/http/openapi.json
@@ -612,6 +612,270 @@
       "title": "IngestConfirmSipRequestBody",
       "type": "object"
     },
+    "IngestDownloadSipInternalErrorResponseBody": {
+      "description": "download_sip_internal_error_response_body result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
+    "IngestDownloadSipNotFoundResponseBody": {
+      "description": "SIP not found",
+      "example": {
+        "message": "abc123",
+        "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+      },
+      "properties": {
+        "message": {
+          "description": "Message of error",
+          "example": "abc123",
+          "type": "string"
+        },
+        "uuid": {
+          "description": "Identifier of missing SIP",
+          "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+          "format": "uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "uuid"
+      ],
+      "title": "IngestDownloadSipNotFoundResponseBody",
+      "type": "object"
+    },
+    "IngestDownloadSipNotValidResponseBody": {
+      "description": "download_sip_not_valid_response_body result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
+    "IngestDownloadSipRequestInternalErrorResponseBody": {
+      "description": "download_sip_request_internal_error_response_body result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
+    "IngestDownloadSipRequestNotFoundResponseBody": {
+      "description": "SIP not found",
+      "example": {
+        "message": "abc123",
+        "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+      },
+      "properties": {
+        "message": {
+          "description": "Message of error",
+          "example": "abc123",
+          "type": "string"
+        },
+        "uuid": {
+          "description": "Identifier of missing SIP",
+          "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+          "format": "uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "uuid"
+      ],
+      "title": "IngestDownloadSipRequestNotFoundResponseBody",
+      "type": "object"
+    },
+    "IngestDownloadSipRequestNotValidResponseBody": {
+      "description": "download_sip_request_not_valid_response_body result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
     "IngestListSipWorkflowsNotFoundResponseBody": {
       "description": "SIP not found",
       "example": {
@@ -3443,7 +3707,7 @@
         ]
       },
       "post": {
-        "description": "Request access to the /monitor WebSocket\n\n**Required security scopes for jwt**:\n  * `ingest:sips:list`\n  * `ingest:sips:read`\n  * `ingest:sips:review`\n  * `ingest:sips:upload`\n  * `ingest:sips:workflows:list`",
+        "description": "Request access to the /monitor WebSocket\n\n**Required security scopes for jwt**:\n  * `ingest:sips:download`\n  * `ingest:sips:list`\n  * `ingest:sips:read`\n  * `ingest:sips:review`\n  * `ingest:sips:upload`\n  * `ingest:sips:workflows:list`",
         "operationId": "ingest#monitor_request",
         "parameters": [
           {
@@ -3817,6 +4081,150 @@
           }
         ],
         "summary": "confirm_sip ingest",
+        "tags": [
+          "ingest"
+        ]
+      }
+    },
+    "/ingest/sips/{uuid}/download": {
+      "get": {
+        "description": "Download the failed package related to a SIP. It will be the original SIP or the transformed PIP, based on the SIP's `failed_as` value.",
+        "operationId": "ingest#download_sip",
+        "parameters": [
+          {
+            "description": "Identifier of the SIP to download",
+            "format": "uuid",
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "headers": {
+              "Content-Disposition": {
+                "type": "string"
+              },
+              "Content-Length": {
+                "type": "int64"
+              },
+              "Content-Type": {
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request response.",
+            "schema": {
+              "$ref": "#/definitions/IngestDownloadSipNotValidResponseBody"
+            }
+          },
+          "401": {
+            "description": "Unauthorized response.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "403": {
+            "description": "Forbidden response.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found response.",
+            "schema": {
+              "$ref": "#/definitions/IngestDownloadSipNotFoundResponseBody",
+              "required": [
+                "message",
+                "uuid"
+              ]
+            }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/IngestDownloadSipInternalErrorResponseBody"
+            }
+          }
+        },
+        "schemes": [
+          "http"
+        ],
+        "summary": "download_sip ingest",
+        "tags": [
+          "ingest"
+        ]
+      },
+      "post": {
+        "description": "Request access to SIP download\n\n**Required security scopes for jwt**:\n  * `ingest:sips:download`",
+        "operationId": "ingest#download_sip_request",
+        "parameters": [
+          {
+            "description": "Identifier of the SIP to download",
+            "format": "uuid",
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response."
+          },
+          "400": {
+            "description": "Bad Request response.",
+            "schema": {
+              "$ref": "#/definitions/IngestDownloadSipRequestNotValidResponseBody"
+            }
+          },
+          "401": {
+            "description": "Unauthorized response.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "403": {
+            "description": "Forbidden response.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found response.",
+            "schema": {
+              "$ref": "#/definitions/IngestDownloadSipRequestNotFoundResponseBody",
+              "required": [
+                "message",
+                "uuid"
+              ]
+            }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/IngestDownloadSipRequestInternalErrorResponseBody"
+            }
+          }
+        },
+        "schemes": [
+          "http"
+        ],
+        "security": [
+          {
+            "jwt_header_Authorization": []
+          }
+        ],
+        "summary": "download_sip_request ingest",
         "tags": [
           "ingest"
         ]
@@ -5186,7 +5594,7 @@
   ],
   "securityDefinitions": {
     "jwt_header_Authorization": {
-      "description": "Secures endpoint by requiring a valid JWT token.\n\n**Security Scopes**:\n  * `ingest:sips:list`: no description\n  * `ingest:sips:read`: no description\n  * `ingest:sips:review`: no description\n  * `ingest:sips:upload`: no description\n  * `ingest:sips:workflows:list`: no description\n  * `storage:aips:create`: no description\n  * `storage:aips:deletion:request`: no description\n  * `storage:aips:deletion:review`: no description\n  * `storage:aips:download`: no description\n  * `storage:aips:list`: no description\n  * `storage:aips:move`: no description\n  * `storage:aips:read`: no description\n  * `storage:aips:review`: no description\n  * `storage:aips:submit`: no description\n  * `storage:aips:workflows:list`: no description\n  * `storage:locations:aips:list`: no description\n  * `storage:locations:create`: no description\n  * `storage:locations:list`: no description\n  * `storage:locations:read`: no description",
+      "description": "Secures endpoint by requiring a valid JWT token.\n\n**Security Scopes**:\n  * `ingest:sips:download`: no description\n  * `ingest:sips:list`: no description\n  * `ingest:sips:read`: no description\n  * `ingest:sips:review`: no description\n  * `ingest:sips:upload`: no description\n  * `ingest:sips:workflows:list`: no description\n  * `storage:aips:create`: no description\n  * `storage:aips:deletion:request`: no description\n  * `storage:aips:deletion:review`: no description\n  * `storage:aips:download`: no description\n  * `storage:aips:list`: no description\n  * `storage:aips:move`: no description\n  * `storage:aips:read`: no description\n  * `storage:aips:review`: no description\n  * `storage:aips:submit`: no description\n  * `storage:aips:workflows:list`: no description\n  * `storage:locations:aips:list`: no description\n  * `storage:locations:create`: no description\n  * `storage:locations:list`: no description\n  * `storage:locations:read`: no description",
       "in": "header",
       "name": "Authorization",
       "type": "apiKey"

--- a/internal/api/gen/http/openapi.yaml
+++ b/internal/api/gen/http/openapi.yaml
@@ -69,6 +69,7 @@ paths:
                 Request access to the /monitor WebSocket
 
                 **Required security scopes for jwt**:
+                  * `ingest:sips:download`
                   * `ingest:sips:list`
                   * `ingest:sips:read`
                   * `ingest:sips:review`
@@ -282,6 +283,106 @@ paths:
                     description: Conflict response.
                     schema:
                         $ref: '#/definitions/IngestConfirmSipNotAvailableResponseBody'
+            schemes:
+                - http
+            security:
+                - jwt_header_Authorization: []
+    /ingest/sips/{uuid}/download:
+        get:
+            tags:
+                - ingest
+            summary: download_sip ingest
+            description: Download the failed package related to a SIP. It will be the original SIP or the transformed PIP, based on the SIP's `failed_as` value.
+            operationId: ingest#download_sip
+            parameters:
+                - name: uuid
+                  in: path
+                  description: Identifier of the SIP to download
+                  required: true
+                  type: string
+                  format: uuid
+            responses:
+                "200":
+                    description: OK response.
+                    headers:
+                        Content-Disposition:
+                            type: string
+                        Content-Length:
+                            type: int64
+                        Content-Type:
+                            type: string
+                "400":
+                    description: Bad Request response.
+                    schema:
+                        $ref: '#/definitions/IngestDownloadSipNotValidResponseBody'
+                "401":
+                    description: Unauthorized response.
+                    schema:
+                        type: string
+                "403":
+                    description: Forbidden response.
+                    schema:
+                        type: string
+                "404":
+                    description: Not Found response.
+                    schema:
+                        $ref: '#/definitions/IngestDownloadSipNotFoundResponseBody'
+                        required:
+                            - message
+                            - uuid
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/IngestDownloadSipInternalErrorResponseBody'
+            schemes:
+                - http
+        post:
+            tags:
+                - ingest
+            summary: download_sip_request ingest
+            description: |-
+                Request access to SIP download
+
+                **Required security scopes for jwt**:
+                  * `ingest:sips:download`
+            operationId: ingest#download_sip_request
+            parameters:
+                - name: uuid
+                  in: path
+                  description: Identifier of the SIP to download
+                  required: true
+                  type: string
+                  format: uuid
+                - name: Authorization
+                  in: header
+                  required: false
+                  type: string
+            responses:
+                "200":
+                    description: OK response.
+                "400":
+                    description: Bad Request response.
+                    schema:
+                        $ref: '#/definitions/IngestDownloadSipRequestNotValidResponseBody'
+                "401":
+                    description: Unauthorized response.
+                    schema:
+                        type: string
+                "403":
+                    description: Forbidden response.
+                    schema:
+                        type: string
+                "404":
+                    description: Not Found response.
+                    schema:
+                        $ref: '#/definitions/IngestDownloadSipRequestNotFoundResponseBody'
+                        required:
+                            - message
+                            - uuid
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/IngestDownloadSipRequestInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1779,6 +1880,218 @@ definitions:
             location_id: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
         required:
             - location_id
+    IngestDownloadSipInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: download_sip_internal_error_response_body result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
+    IngestDownloadSipNotFoundResponseBody:
+        title: IngestDownloadSipNotFoundResponseBody
+        type: object
+        properties:
+            message:
+                type: string
+                description: Message of error
+                example: abc123
+            uuid:
+                type: string
+                description: Identifier of missing SIP
+                example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                format: uuid
+        description: SIP not found
+        example:
+            message: abc123
+            uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+        required:
+            - message
+            - uuid
+    IngestDownloadSipNotValidResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: download_sip_not_valid_response_body result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
+    IngestDownloadSipRequestInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: download_sip_request_internal_error_response_body result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
+    IngestDownloadSipRequestNotFoundResponseBody:
+        title: IngestDownloadSipRequestNotFoundResponseBody
+        type: object
+        properties:
+            message:
+                type: string
+                description: Message of error
+                example: abc123
+            uuid:
+                type: string
+                description: Identifier of missing SIP
+                example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                format: uuid
+        description: SIP not found
+        example:
+            message: abc123
+            uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+        required:
+            - message
+            - uuid
+    IngestDownloadSipRequestNotValidResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: download_sip_request_not_valid_response_body result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
     IngestListSipWorkflowsNotFoundResponseBody:
         title: IngestListSipWorkflowsNotFoundResponseBody
         type: object
@@ -3968,6 +4281,7 @@ securityDefinitions:
             Secures endpoint by requiring a valid JWT token.
 
             **Security Scopes**:
+              * `ingest:sips:download`: no description
               * `ingest:sips:list`: no description
               * `ingest:sips:read`: no description
               * `ingest:sips:review`: no description

--- a/internal/api/gen/http/openapi3.json
+++ b/internal/api/gen/http/openapi3.json
@@ -1910,6 +1910,7 @@
         "security": [
           {
             "jwt_header_Authorization": [
+              "ingest:sips:download",
               "ingest:sips:list",
               "ingest:sips:read",
               "ingest:sips:review",
@@ -2402,6 +2403,238 @@
           }
         ],
         "summary": "confirm_sip ingest",
+        "tags": [
+          "ingest"
+        ]
+      }
+    },
+    "/ingest/sips/{uuid}/download": {
+      "get": {
+        "description": "Download the failed package related to a SIP. It will be the original SIP or the transformed PIP, based on the SIP's `failed_as` value.",
+        "operationId": "ingest#download_sip",
+        "parameters": [
+          {
+            "description": "Identifier of the SIP to download",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "description": "Identifier of the SIP to download",
+              "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "example": "abc123",
+            "in": "cookie",
+            "name": "enduro-sip-download-ticket",
+            "schema": {
+              "example": "abc123",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK response.",
+            "headers": {
+              "Content-Disposition": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "example": 1,
+                "schema": {
+                  "example": 1,
+                  "format": "int64",
+                  "type": "integer"
+                }
+              },
+              "Content-Type": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "not_valid: Bad Request response."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized: Unauthorized response."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "forbidden: Forbidden response."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "abc123",
+                  "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SIPNotFound"
+                }
+              }
+            },
+            "description": "not_found: SIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
+          }
+        },
+        "summary": "download_sip ingest",
+        "tags": [
+          "ingest"
+        ]
+      },
+      "post": {
+        "description": "Request access to SIP download",
+        "operationId": "ingest#download_sip_request",
+        "parameters": [
+          {
+            "description": "Identifier of the SIP to download",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "description": "Identifier of the SIP to download",
+              "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "headers": {
+              "Set-Cookie": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "not_valid: Bad Request response."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized: Unauthorized response."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "forbidden: Forbidden response."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "abc123",
+                  "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SIPNotFound"
+                }
+              }
+            },
+            "description": "not_found: SIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
+          }
+        },
+        "security": [
+          {
+            "jwt_header_Authorization": [
+              "ingest:sips:download"
+            ]
+          }
+        ],
+        "summary": "download_sip_request ingest",
         "tags": [
           "ingest"
         ]

--- a/internal/api/gen/http/openapi3.yaml
+++ b/internal/api/gen/http/openapi3.yaml
@@ -127,6 +127,7 @@ paths:
                                 $ref: '#/components/schemas/Error'
             security:
                 - jwt_header_Authorization:
+                    - ingest:sips:download
                     - ingest:sips:list
                     - ingest:sips:read
                     - ingest:sips:review
@@ -398,6 +399,159 @@ paths:
             security:
                 - jwt_header_Authorization:
                     - ingest:sips:review
+    /ingest/sips/{uuid}/download:
+        get:
+            tags:
+                - ingest
+            summary: download_sip ingest
+            description: Download the failed package related to a SIP. It will be the original SIP or the transformed PIP, based on the SIP's `failed_as` value.
+            operationId: ingest#download_sip
+            parameters:
+                - name: uuid
+                  in: path
+                  description: Identifier of the SIP to download
+                  required: true
+                  schema:
+                    type: string
+                    description: Identifier of the SIP to download
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                    format: uuid
+                  example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                - name: enduro-sip-download-ticket
+                  in: cookie
+                  allowEmptyValue: true
+                  schema:
+                    type: string
+                    example: abc123
+                  example: abc123
+            responses:
+                "200":
+                    description: OK response.
+                    headers:
+                        Content-Disposition:
+                            schema:
+                                type: string
+                                example: abc123
+                            example: abc123
+                        Content-Length:
+                            schema:
+                                type: integer
+                                example: 1
+                                format: int64
+                            example: 1
+                        Content-Type:
+                            schema:
+                                type: string
+                                example: abc123
+                            example: abc123
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+                                format: binary
+                "400":
+                    description: 'not_valid: Bad Request response.'
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: Unauthorized response.'
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+                                example: abc123
+                            example: abc123
+                "403":
+                    description: 'forbidden: Forbidden response.'
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+                                example: abc123
+                            example: abc123
+                "404":
+                    description: 'not_found: SIP not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SIPNotFound'
+                            example:
+                                message: abc123
+                                uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                "500":
+                    description: 'internal_error: Internal Server Error response.'
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+        post:
+            tags:
+                - ingest
+            summary: download_sip_request ingest
+            description: Request access to SIP download
+            operationId: ingest#download_sip_request
+            parameters:
+                - name: uuid
+                  in: path
+                  description: Identifier of the SIP to download
+                  required: true
+                  schema:
+                    type: string
+                    description: Identifier of the SIP to download
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                    format: uuid
+                  example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+            responses:
+                "200":
+                    description: OK response.
+                    headers:
+                        Set-Cookie:
+                            schema:
+                                type: string
+                                example: abc123
+                            example: abc123
+                "400":
+                    description: 'not_valid: Bad Request response.'
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: Unauthorized response.'
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+                                example: abc123
+                            example: abc123
+                "403":
+                    description: 'forbidden: Forbidden response.'
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+                                example: abc123
+                            example: abc123
+                "404":
+                    description: 'not_found: SIP not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SIPNotFound'
+                            example:
+                                message: abc123
+                                uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                "500":
+                    description: 'internal_error: Internal Server Error response.'
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+            security:
+                - jwt_header_Authorization:
+                    - ingest:sips:download
     /ingest/sips/{uuid}/reject:
         post:
             tags:

--- a/internal/api/gen/ingest/client.go
+++ b/internal/api/gen/ingest/client.go
@@ -17,27 +17,31 @@ import (
 
 // Client is the "ingest" service client.
 type Client struct {
-	MonitorRequestEndpoint   goa.Endpoint
-	MonitorEndpoint          goa.Endpoint
-	ListSipsEndpoint         goa.Endpoint
-	ShowSipEndpoint          goa.Endpoint
-	ListSipWorkflowsEndpoint goa.Endpoint
-	ConfirmSipEndpoint       goa.Endpoint
-	RejectSipEndpoint        goa.Endpoint
-	UploadSipEndpoint        goa.Endpoint
+	MonitorRequestEndpoint     goa.Endpoint
+	MonitorEndpoint            goa.Endpoint
+	ListSipsEndpoint           goa.Endpoint
+	ShowSipEndpoint            goa.Endpoint
+	ListSipWorkflowsEndpoint   goa.Endpoint
+	ConfirmSipEndpoint         goa.Endpoint
+	RejectSipEndpoint          goa.Endpoint
+	UploadSipEndpoint          goa.Endpoint
+	DownloadSipRequestEndpoint goa.Endpoint
+	DownloadSipEndpoint        goa.Endpoint
 }
 
 // NewClient initializes a "ingest" service client given the endpoints.
-func NewClient(monitorRequest, monitor, listSips, showSip, listSipWorkflows, confirmSip, rejectSip, uploadSip goa.Endpoint) *Client {
+func NewClient(monitorRequest, monitor, listSips, showSip, listSipWorkflows, confirmSip, rejectSip, uploadSip, downloadSipRequest, downloadSip goa.Endpoint) *Client {
 	return &Client{
-		MonitorRequestEndpoint:   monitorRequest,
-		MonitorEndpoint:          monitor,
-		ListSipsEndpoint:         listSips,
-		ShowSipEndpoint:          showSip,
-		ListSipWorkflowsEndpoint: listSipWorkflows,
-		ConfirmSipEndpoint:       confirmSip,
-		RejectSipEndpoint:        rejectSip,
-		UploadSipEndpoint:        uploadSip,
+		MonitorRequestEndpoint:     monitorRequest,
+		MonitorEndpoint:            monitor,
+		ListSipsEndpoint:           listSips,
+		ShowSipEndpoint:            showSip,
+		ListSipWorkflowsEndpoint:   listSipWorkflows,
+		ConfirmSipEndpoint:         confirmSip,
+		RejectSipEndpoint:          rejectSip,
+		UploadSipEndpoint:          uploadSip,
+		DownloadSipRequestEndpoint: downloadSipRequest,
+		DownloadSipEndpoint:        downloadSip,
 	}
 }
 
@@ -159,4 +163,40 @@ func (c *Client) UploadSip(ctx context.Context, p *UploadSipPayload, req io.Read
 		return
 	}
 	return ires.(*UploadSipResult), nil
+}
+
+// DownloadSipRequest calls the "download_sip_request" endpoint of the "ingest"
+// service.
+// DownloadSipRequest may return the following errors:
+//   - "not_found" (type *SIPNotFound): SIP not found
+//   - "not_valid" (type *goa.ServiceError)
+//   - "internal_error" (type *goa.ServiceError)
+//   - "unauthorized" (type Unauthorized)
+//   - "forbidden" (type Forbidden)
+//   - error: internal error
+func (c *Client) DownloadSipRequest(ctx context.Context, p *DownloadSipRequestPayload) (res *DownloadSipRequestResult, err error) {
+	var ires any
+	ires, err = c.DownloadSipRequestEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(*DownloadSipRequestResult), nil
+}
+
+// DownloadSip calls the "download_sip" endpoint of the "ingest" service.
+// DownloadSip may return the following errors:
+//   - "not_found" (type *SIPNotFound): SIP not found
+//   - "not_valid" (type *goa.ServiceError)
+//   - "internal_error" (type *goa.ServiceError)
+//   - "unauthorized" (type Unauthorized)
+//   - "forbidden" (type Forbidden)
+//   - error: internal error
+func (c *Client) DownloadSip(ctx context.Context, p *DownloadSipPayload) (res *DownloadSipResult, resp io.ReadCloser, err error) {
+	var ires any
+	ires, err = c.DownloadSipEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	o := ires.(*DownloadSipResponseData)
+	return o.Result, o.Body, nil
 }

--- a/internal/api/gen/ingest/service.go
+++ b/internal/api/gen/ingest/service.go
@@ -36,6 +36,11 @@ type Service interface {
 	RejectSip(context.Context, *RejectSipPayload) (err error)
 	// Upload a SIP to trigger an ingest workflow
 	UploadSip(context.Context, *UploadSipPayload, io.ReadCloser) (res *UploadSipResult, err error)
+	// Request access to SIP download
+	DownloadSipRequest(context.Context, *DownloadSipRequestPayload) (res *DownloadSipRequestResult, err error)
+	// Download the failed package related to a SIP. It will be the original SIP or
+	// the transformed PIP, based on the SIP's `failed_as` value.
+	DownloadSip(context.Context, *DownloadSipPayload) (res *DownloadSipResult, body io.ReadCloser, err error)
 }
 
 // Auther defines the authorization functions to be implemented by the service.
@@ -58,7 +63,7 @@ const ServiceName = "ingest"
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
-var MethodNames = [8]string{"monitor_request", "monitor", "list_sips", "show_sip", "list_sip_workflows", "confirm_sip", "reject_sip", "upload_sip"}
+var MethodNames = [10]string{"monitor_request", "monitor", "list_sips", "show_sip", "list_sip_workflows", "confirm_sip", "reject_sip", "upload_sip", "download_sip_request", "download_sip"}
 
 // MonitorServerStream is the interface a "monitor" endpoint server stream must
 // satisfy.
@@ -84,6 +89,36 @@ type ConfirmSipPayload struct {
 	// Identifier of storage location
 	LocationID uuid.UUID
 	Token      *string
+}
+
+// DownloadSipPayload is the payload type of the ingest service download_sip
+// method.
+type DownloadSipPayload struct {
+	// Identifier of the SIP to download
+	UUID   string
+	Ticket *string
+}
+
+// DownloadSipRequestPayload is the payload type of the ingest service
+// download_sip_request method.
+type DownloadSipRequestPayload struct {
+	// Identifier of the SIP to download
+	UUID  string
+	Token *string
+}
+
+// DownloadSipRequestResult is the result type of the ingest service
+// download_sip_request method.
+type DownloadSipRequestResult struct {
+	Ticket *string
+}
+
+// DownloadSipResult is the result type of the ingest service download_sip
+// method.
+type DownloadSipResult struct {
+	ContentType        string
+	ContentLength      int64
+	ContentDisposition string
 }
 
 // Page represents a subset of search results.

--- a/internal/api/gen/storage/endpoints.go
+++ b/internal/api/gen/storage/endpoints.go
@@ -90,7 +90,7 @@ func NewListAipsEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.Endpoint
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:list"},
 		}
 		var token string
@@ -118,7 +118,7 @@ func NewCreateAipEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.Endpoin
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:create"},
 		}
 		var token string
@@ -146,7 +146,7 @@ func NewSubmitAipEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.Endpoin
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:submit"},
 		}
 		var token string
@@ -169,7 +169,7 @@ func NewUpdateAipEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.Endpoin
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:submit"},
 		}
 		var token string
@@ -192,7 +192,7 @@ func NewDownloadAipEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.Endpo
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:download"},
 		}
 		var token string
@@ -215,7 +215,7 @@ func NewMoveAipEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.Endpoint 
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:move"},
 		}
 		var token string
@@ -238,7 +238,7 @@ func NewMoveAipStatusEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.End
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:move"},
 		}
 		var token string
@@ -261,7 +261,7 @@ func NewRejectAipEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.Endpoin
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:review"},
 		}
 		var token string
@@ -284,7 +284,7 @@ func NewShowAipEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.Endpoint 
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:read"},
 		}
 		var token string
@@ -312,7 +312,7 @@ func NewListAipWorkflowsEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:workflows:list"},
 		}
 		var token string
@@ -340,7 +340,7 @@ func NewRequestAipDeletionEndpoint(s Service, authJWTFn security.AuthJWTFunc) go
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:deletion:request"},
 		}
 		var token string
@@ -363,7 +363,7 @@ func NewReviewAipDeletionEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:deletion:review"},
 		}
 		var token string
@@ -386,7 +386,7 @@ func NewCancelAipDeletionEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:aips:deletion:request"},
 		}
 		var token string
@@ -409,7 +409,7 @@ func NewListLocationsEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.End
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:locations:list"},
 		}
 		var token string
@@ -437,7 +437,7 @@ func NewCreateLocationEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.En
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:locations:create"},
 		}
 		var token string
@@ -460,7 +460,7 @@ func NewShowLocationEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.Endp
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:locations:read"},
 		}
 		var token string
@@ -488,7 +488,7 @@ func NewListLocationAipsEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.
 		var err error
 		sc := security.JWTScheme{
 			Name:           "jwt",
-			Scopes:         []string{"ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
+			Scopes:         []string{"ingest:sips:download", "ingest:sips:list", "ingest:sips:read", "ingest:sips:review", "ingest:sips:upload", "ingest:sips:workflows:list", "storage:aips:create", "storage:aips:deletion:request", "storage:aips:deletion:review", "storage:aips:download", "storage:aips:list", "storage:aips:move", "storage:aips:read", "storage:aips:review", "storage:aips:submit", "storage:aips:workflows:list", "storage:locations:aips:list", "storage:locations:create", "storage:locations:list", "storage:locations:read"},
 			RequiredScopes: []string{"storage:locations:aips:list"},
 		}
 		var token string

--- a/internal/ingest/download_sip.go
+++ b/internal/ingest/download_sip.go
@@ -1,0 +1,117 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/google/uuid"
+	"gocloud.dev/gcerrors"
+
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
+	"github.com/artefactual-sdps/enduro/internal/persistence"
+)
+
+func (w *goaWrapper) readSIP(ctx context.Context, id string) (*datatypes.SIP, error) {
+	// Validate the payload UUID.
+	sipUUID, err := uuid.Parse(id)
+	if err != nil {
+		return nil, goaingest.MakeNotValid(errors.New("invalid UUID"))
+	}
+
+	// Read the persisted SIP.
+	sip, err := w.perSvc.ReadSIP(ctx, sipUUID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrNotFound) {
+			return nil, &goaingest.SIPNotFound{UUID: id, Message: "SIP not found"}
+		} else {
+			return nil, goaingest.MakeInternalError(errors.New("error reading SIP"))
+		}
+	}
+
+	return sip, nil
+}
+
+func (w *goaWrapper) DownloadSipRequest(
+	ctx context.Context,
+	payload *goaingest.DownloadSipRequestPayload,
+) (*goaingest.DownloadSipRequestResult, error) {
+	sip, err := w.readSIP(ctx, payload.UUID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check that failed as and failed key values are set.
+	if sip.FailedAs == "" || sip.FailedKey == "" {
+		return nil, goaingest.MakeNotValid(errors.New("SIP has no failed values"))
+	}
+
+	// Check if the failed SIP/PIP exists in the internal bucket.
+	exists, err := w.internalStorage.Exists(ctx, sip.FailedKey)
+	if err != nil {
+		return nil, goaingest.MakeInternalError(errors.New("error checking SIP/PIP file"))
+	}
+
+	if !exists {
+		return nil, &goaingest.SIPNotFound{
+			UUID:    payload.UUID,
+			Message: "Failed SIP/PIP file not found in the internal storage",
+		}
+	}
+
+	// Request a ticket.
+	ticket, err := w.ticketProvider.Request(ctx)
+	if err != nil {
+		return nil, goaingest.MakeInternalError(errors.New("ticket request failed"))
+	}
+
+	// A ticket is not provided when authentication is disabled.
+	// Do not set the ticket cookie in that case.
+	res := &goaingest.DownloadSipRequestResult{}
+	if ticket != "" {
+		res.Ticket = &ticket
+	}
+
+	return res, nil
+}
+
+func (w *goaWrapper) DownloadSip(
+	ctx context.Context,
+	payload *goaingest.DownloadSipPayload,
+) (*goaingest.DownloadSipResult, io.ReadCloser, error) {
+	// Verify the ticket.
+	if err := w.ticketProvider.Check(ctx, payload.Ticket); err != nil {
+		return nil, nil, ErrUnauthorized
+	}
+
+	sip, err := w.readSIP(ctx, payload.UUID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Check that failed as and failed key values are set.
+	if sip.FailedAs == "" || sip.FailedKey == "" {
+		return nil, nil, goaingest.MakeNotValid(errors.New("SIP has no failed values"))
+	}
+
+	// Get a reader from the internal storage for the SIP failed key.
+	reader, err := w.internalStorage.NewReader(ctx, sip.FailedKey, nil)
+	if err != nil {
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			return nil, nil, &goaingest.SIPNotFound{
+				UUID:    payload.UUID,
+				Message: "Failed SIP/PIP file not found in the internal storage",
+			}
+		} else {
+			return nil, nil, goaingest.MakeInternalError(errors.New("error reading SIP file"))
+		}
+	}
+
+	return &goaingest.DownloadSipResult{
+		ContentType:        reader.ContentType(),
+		ContentLength:      reader.Size(),
+		ContentDisposition: fmt.Sprintf("attachment; filename=\"%s\"", sip.FailedKey),
+	}, reader, nil
+}

--- a/internal/ingest/download_sip_test.go
+++ b/internal/ingest/download_sip_test.go
@@ -1,0 +1,313 @@
+package ingest_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"go.artefactual.dev/tools/ref"
+	"go.uber.org/mock/gomock"
+	"gocloud.dev/blob"
+	"gocloud.dev/blob/memblob"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/api/auth"
+	auth_fake "github.com/artefactual-sdps/enduro/internal/api/auth/fake"
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
+	"github.com/artefactual-sdps/enduro/internal/enums"
+	"github.com/artefactual-sdps/enduro/internal/ingest"
+	"github.com/artefactual-sdps/enduro/internal/persistence"
+	persistence_fake "github.com/artefactual-sdps/enduro/internal/persistence/fake"
+)
+
+const (
+	key         = "failed.zip"
+	contentType = "application/zip"
+)
+
+var (
+	sipUUID = uuid.New()
+	content = []byte("zipcontent")
+)
+
+func setupBucket(t *testing.T) *blob.Bucket {
+	bucket := memblob.OpenBucket(nil)
+	t.Cleanup(func() {
+		if err := bucket.Close(); err != nil {
+			t.Fatalf("close bucket: %v", err)
+		}
+	})
+
+	w, err := bucket.NewWriter(t.Context(), key, &blob.WriterOptions{ContentType: contentType})
+	assert.NilError(t, err)
+	_, err = w.Write(content)
+	assert.NilError(t, err)
+	assert.NilError(t, w.Close())
+
+	return bucket
+}
+
+func TestDownloadSipRequest(t *testing.T) {
+	t.Parallel()
+
+	bucket := setupBucket(t)
+
+	for _, tt := range []struct {
+		name    string
+		payload *goaingest.DownloadSipRequestPayload
+		mock    func(context.Context, *auth_fake.MockTicketStore, *persistence_fake.MockService)
+		wantErr string
+		wantRes *goaingest.DownloadSipRequestResult
+	}{
+		{
+			name:    "Fails to request a SIP download (invalid UUID)",
+			payload: &goaingest.DownloadSipRequestPayload{UUID: "invalid-uuid"},
+			wantErr: "invalid UUID",
+		},
+		{
+			name:    "Fails to request a SIP download (SIP not found)",
+			payload: &goaingest.DownloadSipRequestPayload{UUID: sipUUID.String()},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				psvc.EXPECT().ReadSIP(ctx, sipUUID).Return(nil, persistence.ErrNotFound)
+			},
+			wantErr: "SIP not found.",
+		},
+		{
+			name:    "Fails to request a SIP download (persistence error)",
+			payload: &goaingest.DownloadSipRequestPayload{UUID: sipUUID.String()},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				psvc.EXPECT().ReadSIP(ctx, sipUUID).Return(nil, persistence.ErrInternal)
+			},
+			wantErr: "error reading SIP",
+		},
+		{
+			name:    "Fails to request a SIP download (missing failed values)",
+			payload: &goaingest.DownloadSipRequestPayload{UUID: sipUUID.String()},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				psvc.EXPECT().ReadSIP(ctx, sipUUID).Return(&datatypes.SIP{UUID: sipUUID}, nil)
+			},
+			wantErr: "SIP has no failed values",
+		},
+		{
+			name:    "Fails to request a SIP download (SIP file not found)",
+			payload: &goaingest.DownloadSipRequestPayload{UUID: sipUUID.String()},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				psvc.EXPECT().
+					ReadSIP(ctx, sipUUID).
+					Return(
+						&datatypes.SIP{UUID: sipUUID, FailedAs: enums.SIPFailedAsSIP, FailedKey: "missing"},
+						nil,
+					)
+			},
+			wantErr: "SIP not found.",
+		},
+		{
+			name:    "Fails to request a SIP download (fails to create ticket)",
+			payload: &goaingest.DownloadSipRequestPayload{UUID: sipUUID.String()},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				psvc.EXPECT().
+					ReadSIP(ctx, sipUUID).
+					Return(
+						&datatypes.SIP{UUID: sipUUID, FailedAs: enums.SIPFailedAsSIP, FailedKey: key},
+						nil,
+					)
+				ts.EXPECT().
+					SetEx(ctx, "Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk", time.Second*5).
+					Return(errors.New("ticket error"))
+			},
+			wantErr: "ticket request failed",
+		},
+		{
+			name:    "Requests a SIP download",
+			payload: &goaingest.DownloadSipRequestPayload{UUID: sipUUID.String()},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				psvc.EXPECT().
+					ReadSIP(ctx, sipUUID).
+					Return(
+						&datatypes.SIP{UUID: sipUUID, FailedAs: enums.SIPFailedAsSIP, FailedKey: key},
+						nil,
+					)
+				ts.EXPECT().SetEx(ctx, "Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk", time.Second*5).Return(nil)
+			},
+			wantRes: &goaingest.DownloadSipRequestResult{
+				Ticket: ref.New("Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk"),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			ticketStoreMock := auth_fake.NewMockTicketStore(gomock.NewController(t))
+			psvcMock := persistence_fake.NewMockService(gomock.NewController(t))
+			if tt.mock != nil {
+				tt.mock(ctx, ticketStoreMock, psvcMock)
+			}
+
+			rander := rand.New(rand.NewSource(1)) // #nosec
+			ticketProvider := auth.NewTicketProvider(ctx, ticketStoreMock, rander)
+			svc := ingest.NewService(logr.Discard(), nil, nil, nil, psvcMock, nil, ticketProvider, "", bucket, 0, nil)
+
+			res, err := svc.Goa().DownloadSipRequest(ctx, tt.payload)
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.DeepEqual(t, res, tt.wantRes)
+		})
+	}
+}
+
+func TestDownloadSip(t *testing.T) {
+	t.Parallel()
+
+	bucket := setupBucket(t)
+
+	for _, tt := range []struct {
+		name     string
+		payload  *goaingest.DownloadSipPayload
+		mock     func(context.Context, *auth_fake.MockTicketStore, *persistence_fake.MockService)
+		wantErr  string
+		wantRes  *goaingest.DownloadSipResult
+		wantBody []byte
+	}{
+		{
+			name:    "Fails to download a SIP (missing ticket)",
+			payload: &goaingest.DownloadSipPayload{},
+			wantErr: "Unauthorized",
+		},
+		{
+			name:    "Fails to download a SIP (invalid ticket)",
+			payload: &goaingest.DownloadSipPayload{Ticket: ref.New("invalid-ticket")},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				ts.EXPECT().GetDel(ctx, "invalid-ticket").Return(auth.ErrKeyNotFound)
+			},
+			wantErr: "Unauthorized",
+		},
+		{
+			name: "Fails to download a SIP (invalid UUID)",
+			payload: &goaingest.DownloadSipPayload{
+				Ticket: ref.New("valid-ticket"),
+				UUID:   "invalid-uuid",
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket").Return(nil)
+			},
+			wantErr: "invalid UUID",
+		},
+		{
+			name: "Fails to download a SIP (SIP not found)",
+			payload: &goaingest.DownloadSipPayload{
+				Ticket: ref.New("valid-ticket"),
+				UUID:   sipUUID.String(),
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket").Return(nil)
+				psvc.EXPECT().ReadSIP(ctx, sipUUID).Return(nil, persistence.ErrNotFound)
+			},
+			wantErr: "SIP not found.",
+		},
+		{
+			name: "Fails to download a SIP (persistence error)",
+			payload: &goaingest.DownloadSipPayload{
+				Ticket: ref.New("valid-ticket"),
+				UUID:   sipUUID.String(),
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket").Return(nil)
+				psvc.EXPECT().ReadSIP(ctx, sipUUID).Return(nil, persistence.ErrInternal)
+			},
+			wantErr: "error reading SIP",
+		},
+		{
+			name: "Fails to download a SIP (missing failed values)",
+			payload: &goaingest.DownloadSipPayload{
+				Ticket: ref.New("valid-ticket"),
+				UUID:   sipUUID.String(),
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket").Return(nil)
+				psvc.EXPECT().ReadSIP(ctx, sipUUID).Return(&datatypes.SIP{UUID: sipUUID}, nil)
+			},
+			wantErr: "SIP has no failed values",
+		},
+		{
+			name: "Fails to download a SIP (SIP file not found)",
+			payload: &goaingest.DownloadSipPayload{
+				Ticket: ref.New("valid-ticket"),
+				UUID:   sipUUID.String(),
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket").Return(nil)
+				psvc.EXPECT().
+					ReadSIP(ctx, sipUUID).
+					Return(
+						&datatypes.SIP{UUID: sipUUID, FailedAs: enums.SIPFailedAsSIP, FailedKey: "missing"},
+						nil,
+					)
+			},
+			wantErr: "SIP not found.",
+		},
+		{
+			name: "Downloads a SIP",
+			payload: &goaingest.DownloadSipPayload{
+				Ticket: ref.New("valid-ticket"),
+				UUID:   sipUUID.String(),
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket").Return(nil)
+				psvc.EXPECT().
+					ReadSIP(ctx, sipUUID).
+					Return(
+						&datatypes.SIP{UUID: sipUUID, FailedAs: enums.SIPFailedAsSIP, FailedKey: key},
+						nil,
+					)
+			},
+			wantBody: content,
+			wantRes: &goaingest.DownloadSipResult{
+				ContentDisposition: fmt.Sprintf("attachment; filename=%q", key),
+				ContentType:        contentType,
+				ContentLength:      int64(len(content)),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			ticketStoreMock := auth_fake.NewMockTicketStore(gomock.NewController(t))
+			psvcMock := persistence_fake.NewMockService(gomock.NewController(t))
+			if tt.mock != nil {
+				tt.mock(ctx, ticketStoreMock, psvcMock)
+			}
+
+			ticketProvider := auth.NewTicketProvider(ctx, ticketStoreMock, nil)
+			svc := ingest.NewService(logr.Discard(), nil, nil, nil, psvcMock, nil, ticketProvider, "", bucket, 0, nil)
+
+			res, body, err := svc.Goa().DownloadSip(ctx, tt.payload)
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				return
+			}
+
+			t.Cleanup(func() {
+				err := body.Close()
+				assert.NilError(t, err)
+			})
+
+			assert.DeepEqual(t, res, tt.wantRes)
+			cont, err := io.ReadAll(body)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, cont, tt.wantBody)
+		})
+	}
+}

--- a/internal/ingest/goa.go
+++ b/internal/ingest/goa.go
@@ -64,7 +64,9 @@ func (w *goaWrapper) MonitorRequest(
 		w.logger.Error(err, "failed to request ticket")
 		return nil, goaingest.MakeNotAvailable(errors.New("cannot perform operation"))
 	}
-	// Do not set cookie unless a ticket is provided.
+
+	// A ticket is not provided when authentication is disabled.
+	// Do not set the ticket cookie in that case.
 	if ticket != "" {
 		res.Ticket = &ticket
 	}


### PR DESCRIPTION
Browsers don't allow to set custom headers (like Authorization) when
downloading files via `window.open()` or `<a href="...">`. Also, using
the fetch API with custom headers requires loading the entire file into
memory, which is not suitable for large files. To work around this, I
implemented a two-step download process, similar to what we do to
set up Websocket connections:

- Request SIP download endpoint:
  - The frontend will call this endpoint with the Authorization header.
  - The backend will validate the token and return a short-lived,
    single-use ticket (via a cookie).

- SIP download endpoint:
  - The frontend will open this endpoint in a new window.
  - The browser will automatically send the ticket cookie.
  - The backend will validate the ticket and stream the file.

Following iterations could allow to download the SIP in a single step
process for out of browser requests to the API.

Refs #1202.