### PR TITLE
Remove duplicate API request on SIPs page

### DIFF
--- a/dashboard/src/pages/ingest/sips/index.vue
+++ b/dashboard/src/pages/ingest/sips/index.vue
@@ -267,7 +267,6 @@ watch(
 
 onMounted(() => {
   if (el.value) tooltip = new Tooltip(el.value);
-  execute();
 });
 </script>
 


### PR DESCRIPTION
Remove a duplicate request to the `ingest/sips` endpoint when the SIPs page loads.