### PR TITLE
Add failed SIP/PIP download to dashboard

### DIFF
--- a/dashboard/src/components/SipRelatedPackages.vue
+++ b/dashboard/src/components/SipRelatedPackages.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import { api } from "@/client";
+import UUID from "@/components/UUID.vue";
+import { useAuthStore } from "@/stores/auth";
+import { useSipStore } from "@/stores/sip";
+
+const authStore = useAuthStore();
+const sipStore = useSipStore();
+</script>
+
+<template>
+  <div
+    class="card mb-3"
+    v-if="
+      sipStore.current?.aipId ||
+      (sipStore.current?.failedAs && sipStore.current?.failedKey)
+    "
+  >
+    <div class="card-body">
+      <h4 class="card-title">Related Packages</h4>
+      <template v-if="sipStore.current?.aipId">
+        <p class="card-text">
+          <strong>AIP</strong>
+          <UUID :id="sipStore.current.aipId" />
+        </p>
+        <router-link
+          v-if="authStore.checkAttributes(['storage:aips:read'])"
+          class="btn btn-primary btn-sm"
+          :to="{
+            name: '/storage/aips/[id]/',
+            params: { id: sipStore.current.aipId },
+          }"
+          >View</router-link
+        >
+      </template>
+      <p class="card-text">
+        <strong
+          v-if="
+            sipStore.current.failedAs == api.EnduroIngestSipFailedAsEnum.Sip
+          "
+          >Failed SIP</strong
+        >
+        <strong
+          v-if="
+            sipStore.current.failedAs == api.EnduroIngestSipFailedAsEnum.Pip
+          "
+          >Failed PIP</strong
+        >
+        <br />
+        {{ sipStore.current.failedKey }}
+      </p>
+      <Transition
+        mode="out-in"
+        v-if="authStore.checkAttributes(['ingest:sips:download'])"
+      >
+        <div
+          v-if="sipStore.downloadError"
+          class="alert alert-danger text-center mb-0"
+          role="alert"
+        >
+          {{ sipStore.downloadError }}
+        </div>
+        <button
+          v-else
+          type="button"
+          class="btn btn-primary btn-sm"
+          @click="sipStore.download()"
+        >
+          Download
+        </button>
+      </Transition>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 0.3s;
+}
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+.v-enter-to,
+.v-leave-from {
+  opacity: 1;
+}
+</style>

--- a/dashboard/src/components/__tests__/SipRelatedPackages.test.ts
+++ b/dashboard/src/components/__tests__/SipRelatedPackages.test.ts
@@ -1,0 +1,219 @@
+import { createTestingPinia } from "@pinia/testing";
+import { cleanup, fireEvent, render } from "@testing-library/vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRouter, createWebHistory } from "vue-router";
+
+import { api } from "@/client";
+import SipRelatedPackages from "@/components/SipRelatedPackages.vue";
+import { useSipStore } from "@/stores/sip";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { name: "/", path: "/", component: {} },
+    { name: "/storage/aips/[id]/", path: "/storage/aips/:id/", component: {} },
+  ],
+});
+
+describe("SipRelatedPackages.vue", () => {
+  afterEach(() => cleanup());
+
+  it("renders nothing", () => {
+    const { queryByText } = render(SipRelatedPackages, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              sip: { current: null },
+            },
+          }),
+          router,
+        ],
+      },
+    });
+
+    expect(queryByText("Related Packages")).toBeNull();
+  });
+
+  it("shows AIP and view button", () => {
+    const { getByText, getByRole } = render(SipRelatedPackages, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              sip: { current: { aipId: "aip-uuid" } },
+              auth: {
+                config: { enabled: true, abac: { enabled: true } },
+                attributes: ["storage:aips:read"],
+              },
+            },
+          }),
+          router,
+        ],
+      },
+    });
+
+    getByText("Related Packages");
+    getByText("AIP");
+    getByText("aip-uuid");
+    getByRole("link", { name: "View" });
+  });
+
+  it("shows AIP without view button", () => {
+    const { getByText, queryByRole } = render(SipRelatedPackages, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              sip: { current: { aipId: "aip-uuid" } },
+              auth: {
+                config: { enabled: true, abac: { enabled: true } },
+                attributes: [],
+              },
+            },
+          }),
+          router,
+        ],
+      },
+    });
+
+    getByText("Related Packages");
+    getByText("AIP");
+    getByText("aip-uuid");
+    expect(queryByRole("link", { name: "View" })).toBeNull();
+  });
+
+  it("shows failed SIP and download button", async () => {
+    const { getByText, getByRole } = render(SipRelatedPackages, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              sip: {
+                current: {
+                  failedAs: api.EnduroIngestSipFailedAsEnum.Sip,
+                  failedKey: "failed-sip.zip",
+                },
+              },
+              auth: {
+                config: { enabled: true, abac: { enabled: true } },
+                attributes: ["ingest:sips:download"],
+              },
+            },
+          }),
+          router,
+        ],
+      },
+    });
+
+    const sipStore = useSipStore();
+
+    getByText("Related Packages");
+    getByText("Failed SIP");
+    getByText("failed-sip.zip");
+    const btn = getByRole("button", { name: "Download" });
+    await fireEvent.click(btn);
+    expect(sipStore.download).toHaveBeenCalled();
+  });
+
+  it("shows failed PIP and download button", async () => {
+    const { getByText, getByRole } = render(SipRelatedPackages, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              sip: {
+                current: {
+                  failedAs: api.EnduroIngestSipFailedAsEnum.Pip,
+                  failedKey: "failed-pip.zip",
+                },
+              },
+              auth: {
+                config: { enabled: true, abac: { enabled: true } },
+                attributes: ["ingest:sips:download"],
+              },
+            },
+          }),
+          router,
+        ],
+      },
+    });
+
+    const sipStore = useSipStore();
+
+    getByText("Related Packages");
+    getByText("Failed PIP");
+    getByText("failed-pip.zip");
+    const btn = getByRole("button", { name: "Download" });
+    await fireEvent.click(btn);
+    expect(sipStore.download).toHaveBeenCalled();
+  });
+
+  it("shows failed PIP without download button", () => {
+    const { getByText, queryByRole } = render(SipRelatedPackages, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              sip: {
+                current: {
+                  failedAs: api.EnduroIngestSipFailedAsEnum.Pip,
+                  failedKey: "failed-pip.zip",
+                },
+              },
+              auth: {
+                config: { enabled: true, abac: { enabled: true } },
+                attributes: [],
+              },
+            },
+          }),
+          router,
+        ],
+      },
+    });
+
+    getByText("Related Packages");
+    getByText("Failed PIP");
+    getByText("failed-pip.zip");
+    expect(queryByRole("button", { name: "Download" })).toBeNull();
+  });
+
+  it("shows failed PIP with error message", () => {
+    const { getByText, getByRole, queryByRole } = render(SipRelatedPackages, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              sip: {
+                current: {
+                  failedAs: api.EnduroIngestSipFailedAsEnum.Pip,
+                  failedKey: "failed-pip.zip",
+                },
+                downloadError: "Download failed",
+              },
+              auth: {
+                config: { enabled: true, abac: { enabled: true } },
+                attributes: ["ingest:sips:download"],
+              },
+            },
+          }),
+          router,
+        ],
+      },
+    });
+
+    getByText("Related Packages");
+    getByText("Failed PIP");
+    getByText("failed-pip.zip");
+    getByRole("alert");
+    getByText("Download failed");
+    expect(queryByRole("button", { name: "Download" })).toBeNull();
+  });
+});

--- a/dashboard/src/pages/ingest/sips/[id]/index.vue
+++ b/dashboard/src/pages/ingest/sips/[id]/index.vue
@@ -2,6 +2,7 @@
 import Tooltip from "bootstrap/js/dist/tooltip";
 import { computed, onMounted, ref } from "vue";
 
+import SipRelatedPackages from "@/components/SipRelatedPackages.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import UUID from "@/components/UUID.vue";
 import WorkflowCollapse from "@/components/WorkflowCollapse.vue";
@@ -67,29 +68,8 @@ onMounted(() => {
           </dd>
         </dl>
       </div>
-      <div
-        class="col-md-6"
-        v-if="
-          sipStore.current?.aipId &&
-          authStore.checkAttributes(['storage:aips:read'])
-        "
-      >
-        <div class="card mb-3">
-          <div class="card-body">
-            <h4 class="card-title">Related AIP</h4>
-            <p class="card-text">
-              <UUID :id="sipStore.current.aipId" />
-            </p>
-            <router-link
-              class="btn btn-primary btn-sm"
-              :to="{
-                name: '/storage/aips/[id]/',
-                params: { id: sipStore.current.aipId },
-              }"
-              >View</router-link
-            >
-          </div>
-        </div>
+      <div class="col-md-6">
+        <SipRelatedPackages />
       </div>
     </div>
 


### PR DESCRIPTION
- Create a new component to show the related AIP or the failed SIP/PIP
  in the same related packages card, based on the current SIP status.
- Add download action to SIP store. Two steps process to get a cookie
  from the request SIP download endpoint and redirect to a new window
  with the API download URL.
- Collect errors and display them as an alert in the card, replacing
  the download button for 5 seconds.

Refs #1202, depends on #1253.