### PR TITLE
Fix SIP/PIP download button display

### DIFF
--- a/dashboard/src/components/SipRelatedPackages.vue
+++ b/dashboard/src/components/SipRelatedPackages.vue
@@ -33,42 +33,46 @@ const sipStore = useSipStore();
           >View</router-link
         >
       </template>
-      <p class="card-text">
-        <strong
-          v-if="
-            sipStore.current.failedAs == api.EnduroIngestSipFailedAsEnum.Sip
-          "
-          >Failed SIP</strong
-        >
-        <strong
-          v-if="
-            sipStore.current.failedAs == api.EnduroIngestSipFailedAsEnum.Pip
-          "
-          >Failed PIP</strong
-        >
-        <br />
-        {{ sipStore.current.failedKey }}
-      </p>
-      <Transition
-        mode="out-in"
-        v-if="authStore.checkAttributes(['ingest:sips:download'])"
+      <template
+        v-else-if="sipStore.current?.failedAs && sipStore.current?.failedKey"
       >
-        <div
-          v-if="sipStore.downloadError"
-          class="alert alert-danger text-center mb-0"
-          role="alert"
+        <p class="card-text">
+          <strong
+            v-if="
+              sipStore.current.failedAs == api.EnduroIngestSipFailedAsEnum.Sip
+            "
+            >Failed SIP</strong
+          >
+          <strong
+            v-if="
+              sipStore.current.failedAs == api.EnduroIngestSipFailedAsEnum.Pip
+            "
+            >Failed PIP</strong
+          >
+          <br />
+          {{ sipStore.current.failedKey }}
+        </p>
+        <Transition
+          mode="out-in"
+          v-if="authStore.checkAttributes(['ingest:sips:download'])"
         >
-          {{ sipStore.downloadError }}
-        </div>
-        <button
-          v-else
-          type="button"
-          class="btn btn-primary btn-sm"
-          @click="sipStore.download()"
-        >
-          Download
-        </button>
-      </Transition>
+          <div
+            v-if="sipStore.downloadError"
+            class="alert alert-danger text-center mb-0"
+            role="alert"
+          >
+            {{ sipStore.downloadError }}
+          </div>
+          <button
+            v-else
+            type="button"
+            class="btn btn-primary btn-sm"
+            @click="sipStore.download()"
+          >
+            Download
+          </button>
+        </Transition>
+      </template>
     </div>
   </div>
 </template>

--- a/dashboard/src/components/__tests__/SipRelatedPackages.test.ts
+++ b/dashboard/src/components/__tests__/SipRelatedPackages.test.ts
@@ -216,4 +216,42 @@ describe("SipRelatedPackages.vue", () => {
     getByText("Download failed");
     expect(queryByRole("button", { name: "Download" })).toBeNull();
   });
+
+  it("shows AIP and view button over failed SIP and download button", () => {
+    const { getByText, getByRole, queryByText, queryByRole } = render(
+      SipRelatedPackages,
+      {
+        global: {
+          plugins: [
+            createTestingPinia({
+              createSpy: vi.fn,
+              initialState: {
+                sip: {
+                  current: {
+                    aipId: "aip-uuid",
+                    failedAs: api.EnduroIngestSipFailedAsEnum.Sip,
+                    failedKey: "failed-sip.zip",
+                  },
+                },
+                auth: {
+                  config: { enabled: true, abac: { enabled: true } },
+                  attributes: ["storage:aips:read", "ingest:sips:download"],
+                },
+              },
+            }),
+            router,
+          ],
+        },
+      },
+    );
+
+    getByText("Related Packages");
+    getByText("AIP");
+    getByText("aip-uuid");
+    getByRole("link", { name: "View" });
+    expect(queryByText("Failed SIP")).toBeNull();
+    expect(queryByText("failed-sip.zip")).toBeNull();
+    expect(queryByText("Failed SIP")).toBeNull();
+    expect(queryByRole("button", { name: "Download" })).toBeNull();
+  });
 });


### PR DESCRIPTION
Do not show the SIP/PIP download button if the SIP doesn't have failed as or failed key values.

Refs #1202.