### PR TITLE
Fix AIP download authn/authz checks 

### DIFF
--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -288,6 +288,7 @@ func main() {
 			storageHttpClient.CreateAip(),
 			storageHttpClient.SubmitAip(),
 			storageHttpClient.UpdateAip(),
+			storageHttpClient.DownloadAipRequest(),
 			storageHttpClient.DownloadAip(),
 			storageHttpClient.MoveAip(),
 			storageHttpClient.MoveAipStatus(),

--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -234,6 +234,10 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: bucketdownload.Name},
 		)
 		w.RegisterActivityWithOptions(
+			activities.NewGetSIPExtensionActivity().Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.GetSIPExtensionActivityName},
+		)
+		w.RegisterActivityWithOptions(
 			archiveextract.New(cfg.ExtractActivity).Execute,
 			temporalsdk_activity.RegisterOptions{Name: archiveextract.Name},
 		)

--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -241,6 +241,10 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: bucketdownload.Name},
 		)
 		w.RegisterActivityWithOptions(
+			activities.NewGetSIPExtensionActivity().Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.GetSIPExtensionActivityName},
+		)
+		w.RegisterActivityWithOptions(
 			archiveextract.New(cfg.ExtractActivity).Execute,
 			temporalsdk_activity.RegisterOptions{Name: archiveextract.Name},
 		)

--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -439,6 +439,7 @@ func newStorageClient(tp trace.TracerProvider, cfg config.Configuration) *goasto
 		storageHttpClient.CreateAip(),
 		storageHttpClient.SubmitAip(),
 		storageHttpClient.UpdateAip(),
+		storageHttpClient.DownloadAipRequest(),
 		storageHttpClient.DownloadAip(),
 		storageHttpClient.MoveAip(),
 		storageHttpClient.MoveAipStatus(),

--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -171,7 +171,7 @@ func main() {
 		}
 	}
 
-	// Set up the WebSocket ticket provider.
+	// Set up the WebSocket/downloads ticket provider.
 	var ticketProvider *auth.TicketProvider
 	{
 		var store auth.TicketStore
@@ -260,6 +260,7 @@ func main() {
 			storagePersistence,
 			temporalClient,
 			tokenVerifier,
+			ticketProvider,
 			rand.Reader,
 		)
 		if err != nil {
@@ -330,6 +331,7 @@ func main() {
 			storagePersistence,
 			temporalClient,
 			&auth.NoopTokenVerifier{},
+			ticketProvider,
 			rand.Reader,
 		)
 		if err != nil {

--- a/dashboard/src/client.ts
+++ b/dashboard/src/client.ts
@@ -24,16 +24,6 @@ function getPath(): string {
   return path.replace(/\/$/, "");
 }
 
-function storageServiceDownloadURL(aipId: string): string {
-  return (
-    getPath() +
-    `/storage/aips/{aip_id}/download`.replace(
-      `{${"aip_id"}}`,
-      encodeURIComponent(aipId),
-    )
-  );
-}
-
 function getWebSocketURL(): string {
   let url = getPath();
 
@@ -86,4 +76,4 @@ function createClient(): Client {
 
 const client = createClient();
 
-export { api, client, getPath, runtime, storageServiceDownloadURL };
+export { api, client, getPath, runtime };

--- a/dashboard/src/components/AipLocationCard.vue
+++ b/dashboard/src/components/AipLocationCard.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref } from "vue";
 import { openDialog } from "vue3-promise-dialog";
 
-import { storageServiceDownloadURL } from "@/client";
 import AipDeletionRequestDialog from "@/components/AipDeletionRequestDialog.vue";
 import LocationDialog from "@/components/LocationDialog.vue";
 import UUID from "@/components/UUID.vue";
@@ -24,14 +23,6 @@ const choose = async () => {
     failed.value = true;
   }
 };
-
-const download = () => {
-  if (!aipStore.current?.uuid) return;
-  const url = storageServiceDownloadURL(aipStore.current?.uuid);
-  window.open(url, "_blank");
-};
-
-watch(aipStore.ui.download, () => download());
 
 const requestDeletion = async () => {
   if (!aipStore.current) return;
@@ -59,50 +50,76 @@ const requestDeletion = async () => {
         >
         <span v-else><UUID :id="aipStore.current.locationId" /></span>
       </p>
-      <div v-if="!aipStore.isDeleted" class="d-flex flex-wrap gap-2">
-        <button
-          v-if="
-            authStore.checkAttributes(['storage:aips:download']) &&
-            (aipStore.isStored || aipStore.isPending)
-          "
-          type="button"
-          class="btn btn-primary btn-sm"
-          @click="download"
-        >
-          Download
-        </button>
-        <button
-          v-if="
-            false && // TODO: Enable this also based on location type and available locations.
-            authStore.checkAttributes(['storage:aips:move'])
-          "
-          type="button"
-          class="btn btn-primary btn-sm"
-          @click="choose"
-          :disabled="!aipStore.isMovable"
-        >
-          <template v-if="aipStore.isMoving">
-            <span
-              class="spinner-grow spinner-grow-sm me-2"
-              role="status"
-              aria-hidden="true"
-            ></span>
-            Moving...
-          </template>
-          <template v-else>Move</template>
-        </button>
-        <button
-          v-if="
-            authStore.checkAttributes(['storage:aips:deletion:request']) &&
-            aipStore.isStored
-          "
-          type="button"
-          class="btn btn-primary btn-sm"
-          @click="requestDeletion"
-        >
-          Delete
-        </button>
+      <div v-if="!aipStore.isDeleted">
+        <Transition mode="out-in">
+          <div
+            v-if="aipStore.downloadError"
+            class="alert alert-danger text-center mb-0"
+            role="alert"
+          >
+            {{ aipStore.downloadError }}
+          </div>
+          <div v-else class="d-flex flex-wrap gap-2">
+            <button
+              v-if="
+                authStore.checkAttributes(['storage:aips:download']) &&
+                (aipStore.isStored || aipStore.isPending)
+              "
+              type="button"
+              class="btn btn-primary btn-sm"
+              @click="aipStore.download()"
+            >
+              Download
+            </button>
+            <button
+              v-if="
+                false && // TODO: Enable this also based on location type and available locations.
+                authStore.checkAttributes(['storage:aips:move'])
+              "
+              type="button"
+              class="btn btn-primary btn-sm"
+              @click="choose"
+              :disabled="!aipStore.isMovable"
+            >
+              <template v-if="aipStore.isMoving">
+                <span
+                  class="spinner-grow spinner-grow-sm me-2"
+                  role="status"
+                  aria-hidden="true"
+                ></span>
+                Moving...
+              </template>
+              <template v-else>Move</template>
+            </button>
+            <button
+              v-if="
+                authStore.checkAttributes(['storage:aips:deletion:request']) &&
+                aipStore.isStored
+              "
+              type="button"
+              class="btn btn-primary btn-sm"
+              @click="requestDeletion"
+            >
+              Delete
+            </button>
+          </div>
+        </Transition>
       </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 0.3s;
+}
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+.v-enter-to,
+.v-leave-from {
+  opacity: 1;
+}
+</style>

--- a/dashboard/src/components/SipReviewAlert.vue
+++ b/dashboard/src/components/SipReviewAlert.vue
@@ -16,6 +16,10 @@ const emit = defineEmits<{
 const aipStore = useAipStore();
 const sipStore = useSipStore();
 
+if (sipStore.current?.aipId) {
+  aipStore.fetchCurrent(sipStore.current.aipId);
+}
+
 const confirm = async () => {
   const locationId = await openDialog(LocationDialog);
   if (!locationId) return;
@@ -42,7 +46,7 @@ const confirm = async () => {
       </li>
       <li>View a summary of the preservation metadata created</li>
       <li>
-        <a href="#" @click.prevent="aipStore.ui.download.request">Download</a>
+        <a href="#" @click.prevent="aipStore.download">Download</a>
         a local copy of the AIP for inspection
       </li>
     </ul>

--- a/dashboard/src/components/WorkflowCollapse.vue
+++ b/dashboard/src/components/WorkflowCollapse.vue
@@ -30,19 +30,21 @@ const { workflow, index } = toRefs(props);
 let expandCounter = ref<number>(0);
 
 const showSipReviewAlert = (
-  status:
-    | api.EnduroIngestSipWorkflowStatusEnum
-    | api.EnduroStorageAipWorkflowStatusEnum,
+  workflow: api.EnduroIngestSipWorkflow | api.EnduroStorageAipWorkflow,
 ) => {
-  return status == api.EnduroIngestSipWorkflowStatusEnum.Pending;
+  return (
+    workflow.type == api.EnduroIngestSipWorkflowTypeEnum.CreateAndReviewAip &&
+    workflow.status == api.EnduroIngestSipWorkflowStatusEnum.Pending
+  );
 };
 
 const showAipDeletionReviewAlert = (
-  status:
-    | api.EnduroIngestSipWorkflowStatusEnum
-    | api.EnduroStorageAipWorkflowStatusEnum,
+  workflow: api.EnduroIngestSipWorkflow | api.EnduroStorageAipWorkflow,
 ) => {
-  return status == api.EnduroStorageAipWorkflowStatusEnum.Pending;
+  return (
+    workflow.type == api.EnduroStorageAipWorkflowTypeEnum.DeleteAip &&
+    workflow.status == api.EnduroStorageAipWorkflowStatusEnum.Pending
+  );
 };
 </script>
 
@@ -92,13 +94,13 @@ const showAipDeletionReviewAlert = (
       <SipReviewAlert
         v-model:expandCounter="expandCounter"
         v-if="
-          showSipReviewAlert(workflow.status) &&
+          showSipReviewAlert(workflow) &&
           authStore.checkAttributes(['ingest:sips:review'])
         "
       />
       <AipDeletionReviewAlert
         v-if="
-          showAipDeletionReviewAlert(workflow.status) &&
+          showAipDeletionReviewAlert(workflow) &&
           (authStore.checkAttributes(['storage:aips:deletion:review']) ||
             authStore.checkAttributes(['storage:aips:deletion:request']))
         "

--- a/dashboard/src/components/__tests__/AipLocationCard.test.ts
+++ b/dashboard/src/components/__tests__/AipLocationCard.test.ts
@@ -1,7 +1,6 @@
 import { createTestingPinia } from "@pinia/testing";
 import { cleanup, render } from "@testing-library/vue";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { nextTick } from "vue";
 
 import { api } from "@/client";
 import AipLocationCard from "@/components/AipLocationCard.vue";
@@ -30,18 +29,22 @@ describe("AipLocationCard.vue", () => {
     });
 
     expect(html()).toMatchInlineSnapshot(`
-      "<div class="card mb-3">
-        <div class="card-body">
+      "<div data-v-09f60ec4="" class="card mb-3">
+        <div data-v-09f60ec4="" class="card-body">
           <!--v-if-->
           <!--v-if-->
-          <h4 class="card-title">Location</h4>
-          <p class="card-text"><span><div class="d-flex align-items-start gap-2"><span class="font-monospace">f8635e46-a320-4152-9a2c-98a28eeb50d1</span><button class="btn btn-sm btn-link link-secondary p-0" data-bs-toggle="tooltip" data-bs-title="Copy to clipboard">
+          <h4 data-v-09f60ec4="" class="card-title">Location</h4>
+          <p data-v-09f60ec4="" class="card-text"><span data-v-09f60ec4=""><div data-v-09f60ec4="" class="d-flex align-items-start gap-2"><span class="font-monospace">f8635e46-a320-4152-9a2c-98a28eeb50d1</span><button class="btn btn-sm btn-link link-secondary p-0" data-bs-toggle="tooltip" data-bs-title="Copy to clipboard">
               <!-- Copied visual hint. -->
               <!-- Copy icon. --><span><svg viewBox="0 0 24 24" width="1.2em" height="1.2em" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M8 4v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7.242a2 2 0 0 0-.602-1.43L16.083 2.57A2 2 0 0 0 14.685 2H10a2 2 0 0 0-2 2"></path><path d="M16 18v2a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h2"></path></g></svg><span class="visually-hidden">Copy to clipboard</span></span>
             </button>
         </div></span></p>
-        <div class="d-flex flex-wrap gap-2"><button type="button" class="btn btn-primary btn-sm"> Download </button>
-          <!--v-if--><button type="button" class="btn btn-primary btn-sm"> Delete </button>
+        <div data-v-09f60ec4="">
+          <transition-stub data-v-09f60ec4="" mode="out-in" appear="false" persisted="false" css="true">
+            <div data-v-09f60ec4="" class="d-flex flex-wrap gap-2"><button data-v-09f60ec4="" type="button" class="btn btn-primary btn-sm"> Download </button>
+              <!--v-if--><button data-v-09f60ec4="" type="button" class="btn btn-primary btn-sm"> Delete </button>
+            </div>
+          </transition-stub>
         </div>
       </div>
       </div>"
@@ -72,20 +75,24 @@ describe("AipLocationCard.vue", () => {
     });
 
     expect(html()).toMatchInlineSnapshot(`
-      "<div class="card mb-3">
-        <div class="card-body">
+      "<div data-v-09f60ec4="" class="card mb-3">
+        <div data-v-09f60ec4="" class="card-body">
           <!--v-if-->
           <!--v-if-->
-          <h4 class="card-title">Location</h4>
-          <p class="card-text"><span><div class="d-flex align-items-start gap-2"><span class="font-monospace">f8635e46-a320-4152-9a2c-98a28eeb50d1</span><button class="btn btn-sm btn-link link-secondary p-0" data-bs-toggle="tooltip" data-bs-title="Copy to clipboard">
+          <h4 data-v-09f60ec4="" class="card-title">Location</h4>
+          <p data-v-09f60ec4="" class="card-text"><span data-v-09f60ec4=""><div data-v-09f60ec4="" class="d-flex align-items-start gap-2"><span class="font-monospace">f8635e46-a320-4152-9a2c-98a28eeb50d1</span><button class="btn btn-sm btn-link link-secondary p-0" data-bs-toggle="tooltip" data-bs-title="Copy to clipboard">
               <!-- Copied visual hint. -->
               <!-- Copy icon. --><span><svg viewBox="0 0 24 24" width="1.2em" height="1.2em" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M8 4v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7.242a2 2 0 0 0-.602-1.43L16.083 2.57A2 2 0 0 0 14.685 2H10a2 2 0 0 0-2 2"></path><path d="M16 18v2a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h2"></path></g></svg><span class="visually-hidden">Copy to clipboard</span></span>
             </button>
         </div></span></p>
-        <div class="d-flex flex-wrap gap-2">
-          <!--v-if-->
-          <!--v-if-->
-          <!--v-if-->
+        <div data-v-09f60ec4="">
+          <transition-stub data-v-09f60ec4="" mode="out-in" appear="false" persisted="false" css="true">
+            <div data-v-09f60ec4="" class="d-flex flex-wrap gap-2">
+              <!--v-if-->
+              <!--v-if-->
+              <!--v-if-->
+            </div>
+          </transition-stub>
         </div>
       </div>
       </div>"
@@ -157,16 +164,20 @@ describe("AipLocationCard.vue", () => {
     });
 
     expect(html()).toMatchInlineSnapshot(`
-      "<div class="card mb-3">
-        <div class="card-body">
+      "<div data-v-09f60ec4="" class="card mb-3">
+        <div data-v-09f60ec4="" class="card-body">
           <!--v-if-->
           <!--v-if-->
-          <h4 class="card-title">Location</h4>
-          <p class="card-text"><span>Not available yet.</span></p>
-          <div class="d-flex flex-wrap gap-2">
-            <!--v-if-->
-            <!--v-if-->
-            <!--v-if-->
+          <h4 data-v-09f60ec4="" class="card-title">Location</h4>
+          <p data-v-09f60ec4="" class="card-text"><span data-v-09f60ec4="">Not available yet.</span></p>
+          <div data-v-09f60ec4="">
+            <transition-stub data-v-09f60ec4="" mode="out-in" appear="false" persisted="false" css="true">
+              <div data-v-09f60ec4="" class="d-flex flex-wrap gap-2">
+                <!--v-if-->
+                <!--v-if-->
+                <!--v-if-->
+              </div>
+            </transition-stub>
           </div>
         </div>
       </div>"
@@ -193,12 +204,12 @@ describe("AipLocationCard.vue", () => {
     });
 
     expect(html()).toMatchInlineSnapshot(`
-      "<div class="card mb-3">
-        <div class="card-body">
+      "<div data-v-09f60ec4="" class="card mb-3">
+        <div data-v-09f60ec4="" class="card-body">
           <!--v-if-->
           <!--v-if-->
-          <h4 class="card-title">Location</h4>
-          <p class="card-text"><span>AIP deleted.</span></p>
+          <h4 data-v-09f60ec4="" class="card-title">Location</h4>
+          <p data-v-09f60ec4="" class="card-text"><span data-v-09f60ec4="">AIP deleted.</span></p>
           <!--v-if-->
         </div>
       </div>"
@@ -225,58 +236,28 @@ describe("AipLocationCard.vue", () => {
     });
 
     expect(html()).toMatchInlineSnapshot(`
-      "<div class="card mb-3">
-        <div class="card-body">
+      "<div data-v-09f60ec4="" class="card mb-3">
+        <div data-v-09f60ec4="" class="card-body">
           <!--v-if-->
           <!--v-if-->
-          <h4 class="card-title">Location</h4>
-          <p class="card-text"><span><div class="d-flex align-items-start gap-2"><span class="font-monospace">f8635e46-a320-4152-9a2c-98a28eeb50d1</span><button class="btn btn-sm btn-link link-secondary p-0" data-bs-toggle="tooltip" data-bs-title="Copy to clipboard">
+          <h4 data-v-09f60ec4="" class="card-title">Location</h4>
+          <p data-v-09f60ec4="" class="card-text"><span data-v-09f60ec4=""><div data-v-09f60ec4="" class="d-flex align-items-start gap-2"><span class="font-monospace">f8635e46-a320-4152-9a2c-98a28eeb50d1</span><button class="btn btn-sm btn-link link-secondary p-0" data-bs-toggle="tooltip" data-bs-title="Copy to clipboard">
               <!-- Copied visual hint. -->
               <!-- Copy icon. --><span><svg viewBox="0 0 24 24" width="1.2em" height="1.2em" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M8 4v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7.242a2 2 0 0 0-.602-1.43L16.083 2.57A2 2 0 0 0 14.685 2H10a2 2 0 0 0-2 2"></path><path d="M16 18v2a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h2"></path></g></svg><span class="visually-hidden">Copy to clipboard</span></span>
             </button>
         </div></span></p>
-        <div class="d-flex flex-wrap gap-2">
-          <!--v-if-->
-          <!--v-if-->
-          <!--v-if-->
+        <div data-v-09f60ec4="">
+          <transition-stub data-v-09f60ec4="" mode="out-in" appear="false" persisted="false" css="true">
+            <div data-v-09f60ec4="" class="d-flex flex-wrap gap-2">
+              <!--v-if-->
+              <!--v-if-->
+              <!--v-if-->
+            </div>
+          </transition-stub>
         </div>
       </div>
       </div>"
     `);
-  });
-
-  it("watches download requests from the store", async () => {
-    render(AipLocationCard, {
-      global: {
-        plugins: [
-          createTestingPinia({
-            createSpy: vi.fn,
-            initialState: {
-              aip: {
-                current: {
-                  uuid: "89229d18-5554-4e0d-8c4e-d0d88afd3bae",
-                  status: api.EnduroStorageAipStatusEnum.Stored,
-                  locationId: "f8635e46-a320-4152-9a2c-98a28eeb50d1",
-                } as api.EnduroStorageAip,
-              },
-            },
-          }),
-        ],
-      },
-    });
-
-    vi.stubGlobal("open", vi.fn());
-
-    // Someone requests the download of the AIP via the AIP store.
-    const aipStore = useAipStore();
-    aipStore.ui.download.request();
-    await nextTick();
-
-    // Then we observe that the component download function is executed.
-    expect(window.open).toBeCalledWith(
-      "http://localhost:3000/api/storage/aips/89229d18-5554-4e0d-8c4e-d0d88afd3bae/download",
-      "_blank",
-    );
   });
 
   it("shows the download button", async () => {

--- a/dashboard/src/openapi-generator/apis/StorageApi.ts
+++ b/dashboard/src/openapi-generator/apis/StorageApi.ts
@@ -85,6 +85,11 @@ export interface StorageCreateLocationRequest {
 
 export interface StorageDownloadAipRequest {
     uuid: string;
+    enduroAipDownloadTicket?: string;
+}
+
+export interface StorageDownloadAipRequestRequest {
+    uuid: string;
 }
 
 export interface StorageListAipWorkflowsRequest {
@@ -205,7 +210,8 @@ export interface StorageApiInterface {
     /**
      * Download AIP by AIPID
      * @summary download_aip storage
-     * @param {string} uuid Identifier of AIP
+     * @param {string} uuid Identifier of the AIP to download
+     * @param {string} [enduroAipDownloadTicket] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof StorageApiInterface
@@ -217,6 +223,22 @@ export interface StorageApiInterface {
      * download_aip storage
      */
     storageDownloadAip(requestParameters: StorageDownloadAipRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Blob>;
+
+    /**
+     * Request access to AIP download
+     * @summary download_aip_request storage
+     * @param {string} uuid Identifier of the AIP to download
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof StorageApiInterface
+     */
+    storageDownloadAipRequestRaw(requestParameters: StorageDownloadAipRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>>;
+
+    /**
+     * Request access to AIP download
+     * download_aip_request storage
+     */
+    storageDownloadAipRequest(requestParameters: StorageDownloadAipRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void>;
 
     /**
      * List workflows related to an AIP
@@ -588,14 +610,6 @@ export class StorageApi extends runtime.BaseAPI implements StorageApiInterface {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (this.configuration && this.configuration.accessToken) {
-            const token = this.configuration.accessToken;
-            const tokenString = await token("jwt_header_Authorization", []);
-
-            if (tokenString) {
-                headerParameters["Authorization"] = `Bearer ${tokenString}`;
-            }
-        }
         const response = await this.request({
             path: `/storage/aips/{uuid}/download`.replace(`{${"uuid"}}`, encodeURIComponent(String(requestParameters.uuid))),
             method: 'GET',
@@ -613,6 +627,45 @@ export class StorageApi extends runtime.BaseAPI implements StorageApiInterface {
     async storageDownloadAip(requestParameters: StorageDownloadAipRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Blob> {
         const response = await this.storageDownloadAipRaw(requestParameters, initOverrides);
         return await response.value();
+    }
+
+    /**
+     * Request access to AIP download
+     * download_aip_request storage
+     */
+    async storageDownloadAipRequestRaw(requestParameters: StorageDownloadAipRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
+        if (requestParameters.uuid === null || requestParameters.uuid === undefined) {
+            throw new runtime.RequiredError('uuid','Required parameter requestParameters.uuid was null or undefined when calling storageDownloadAipRequest.');
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.accessToken) {
+            const token = this.configuration.accessToken;
+            const tokenString = await token("jwt_header_Authorization", []);
+
+            if (tokenString) {
+                headerParameters["Authorization"] = `Bearer ${tokenString}`;
+            }
+        }
+        const response = await this.request({
+            path: `/storage/aips/{uuid}/download`.replace(`{${"uuid"}}`, encodeURIComponent(String(requestParameters.uuid))),
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.VoidApiResponse(response);
+    }
+
+    /**
+     * Request access to AIP download
+     * download_aip_request storage
+     */
+    async storageDownloadAipRequest(requestParameters: StorageDownloadAipRequestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
+        await this.storageDownloadAipRequestRaw(requestParameters, initOverrides);
     }
 
     /**

--- a/docs/src/dev-manual/api/openapi3.json
+++ b/docs/src/dev-manual/api/openapi3.json
@@ -3683,15 +3683,25 @@
         "operationId": "storage#download_aip",
         "parameters": [
           {
-            "description": "Identifier of AIP",
+            "description": "Identifier of the AIP to download",
             "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "in": "path",
             "name": "uuid",
             "required": true,
             "schema": {
-              "description": "Identifier of AIP",
+              "description": "Identifier of the AIP to download",
               "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
               "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "example": "abc123",
+            "in": "cookie",
+            "name": "enduro-aip-download-ticket",
+            "schema": {
+              "example": "abc123",
               "type": "string"
             }
           }
@@ -3700,15 +3710,47 @@
           "200": {
             "content": {
               "application/json": {
-                "example": "YWJjMTIz",
                 "schema": {
-                  "example": "YWJjMTIz",
                   "format": "binary",
                   "type": "string"
                 }
               }
             },
-            "description": "OK response."
+            "description": "OK response.",
+            "headers": {
+              "Content-Disposition": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "example": 1,
+                "schema": {
+                  "example": 1,
+                  "format": "int64",
+                  "type": "integer"
+                }
+              },
+              "Content-Type": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "not_valid: Bad Request response."
           },
           "401": {
             "content": {
@@ -3747,6 +3789,111 @@
               }
             },
             "description": "not_found: AIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
+          }
+        },
+        "summary": "download_aip storage",
+        "tags": [
+          "storage"
+        ]
+      },
+      "post": {
+        "description": "Request access to AIP download",
+        "operationId": "storage#download_aip_request",
+        "parameters": [
+          {
+            "description": "Identifier of the AIP to download",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "description": "Identifier of the AIP to download",
+              "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "headers": {
+              "Set-Cookie": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "not_valid: Bad Request response."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized: Unauthorized response."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "forbidden: Forbidden response."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "abc123",
+                  "uuid": "abc123"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SIPNotFound"
+                }
+              }
+            },
+            "description": "not_found: AIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -3756,7 +3903,7 @@
             ]
           }
         ],
-        "summary": "download_aip storage",
+        "summary": "download_aip_request storage",
         "tags": [
           "storage"
         ]

--- a/enduro.toml
+++ b/enduro.toml
@@ -102,7 +102,7 @@ bucket = "sips"
 # Available workflow types are "create aip" and "create and review aip",
 # the later only works properly when the preservation system is "a3m".
 # Default: "create aip".
-workflowType = "create aip"
+workflowType = "create and review aip"
 
 [storage]
 enduroAddress = "enduro.enduro-sdps:9002"

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -63,7 +63,7 @@ func HTTPServer(
 	storageEndpoints := storage.NewEndpoints(storagesvc)
 	storageErrorHandler := errorHandler(logger, "Storage error.")
 	storageServer := storagesvr.New(storageEndpoints, mux, dec, enc, storageErrorHandler, nil)
-	storageServer.DownloadAip = writeTimeout(intstorage.Download(storagesvc, mux, dec), 0)
+	storageServer.DownloadAip = writeTimeout(storageServer.DownloadAip, 0)
 	storagesvr.Mount(mux, storageServer)
 
 	// About service.

--- a/internal/api/gen/http/openapi.json
+++ b/internal/api/gen/http/openapi.json
@@ -2518,6 +2518,59 @@
       "title": "StorageCreateLocationResponseBody",
       "type": "object"
     },
+    "StorageDownloadAipInternalErrorResponseBody": {
+      "description": "download_aip_internal_error_response_body result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
     "StorageDownloadAipNotFoundResponseBody": {
       "description": "AIP not found",
       "example": {
@@ -2541,6 +2594,190 @@
         "uuid"
       ],
       "title": "StorageDownloadAipNotFoundResponseBody",
+      "type": "object"
+    },
+    "StorageDownloadAipNotValidResponseBody": {
+      "description": "download_aip_not_valid_response_body result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
+    "StorageDownloadAipRequestInternalErrorResponseBody": {
+      "description": "download_aip_request_internal_error_response_body result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
+    "StorageDownloadAipRequestNotFoundResponseBody": {
+      "description": "AIP not found",
+      "example": {
+        "message": "abc123",
+        "uuid": "abc123"
+      },
+      "properties": {
+        "message": {
+          "description": "Message of error",
+          "example": "abc123",
+          "type": "string"
+        },
+        "uuid": {
+          "description": "Identifier of missing AIP",
+          "example": "abc123",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "uuid"
+      ],
+      "title": "StorageDownloadAipRequestNotFoundResponseBody",
+      "type": "object"
+    },
+    "StorageDownloadAipRequestNotValidResponseBody": {
+      "description": "download_aip_request_not_valid_response_body result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
       "type": "object"
     },
     "StorageListAipWorkflowsNotFoundResponseBody": {
@@ -5044,30 +5281,37 @@
     },
     "/storage/aips/{uuid}/download": {
       "get": {
-        "description": "Download AIP by AIPID\n\n**Required security scopes for jwt**:\n  * `storage:aips:download`",
+        "description": "Download AIP by AIPID",
         "operationId": "storage#download_aip",
         "parameters": [
           {
-            "description": "Identifier of AIP",
+            "description": "Identifier of the AIP to download",
             "format": "uuid",
             "in": "path",
             "name": "uuid",
             "required": true,
-            "type": "string"
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": false,
             "type": "string"
           }
         ],
         "responses": {
           "200": {
             "description": "OK response.",
+            "headers": {
+              "Content-Disposition": {
+                "type": "string"
+              },
+              "Content-Length": {
+                "type": "int64"
+              },
+              "Content-Type": {
+                "type": "string"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request response.",
             "schema": {
-              "format": "byte",
-              "type": "string"
+              "$ref": "#/definitions/StorageDownloadAipNotValidResponseBody"
             }
           },
           "401": {
@@ -5091,6 +5335,78 @@
                 "uuid"
               ]
             }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/StorageDownloadAipInternalErrorResponseBody"
+            }
+          }
+        },
+        "schemes": [
+          "http"
+        ],
+        "summary": "download_aip storage",
+        "tags": [
+          "storage"
+        ]
+      },
+      "post": {
+        "description": "Request access to AIP download\n\n**Required security scopes for jwt**:\n  * `storage:aips:download`",
+        "operationId": "storage#download_aip_request",
+        "parameters": [
+          {
+            "description": "Identifier of the AIP to download",
+            "format": "uuid",
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response."
+          },
+          "400": {
+            "description": "Bad Request response.",
+            "schema": {
+              "$ref": "#/definitions/StorageDownloadAipRequestNotValidResponseBody"
+            }
+          },
+          "401": {
+            "description": "Unauthorized response.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "403": {
+            "description": "Forbidden response.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "Not Found response.",
+            "schema": {
+              "$ref": "#/definitions/StorageDownloadAipRequestNotFoundResponseBody",
+              "required": [
+                "message",
+                "uuid"
+              ]
+            }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/StorageDownloadAipRequestInternalErrorResponseBody"
+            }
           }
         },
         "schemes": [
@@ -5101,7 +5417,7 @@
             "jwt_header_Authorization": []
           }
         ],
-        "summary": "download_aip storage",
+        "summary": "download_aip_request storage",
         "tags": [
           "storage"
         ]

--- a/internal/api/gen/http/openapi.yaml
+++ b/internal/api/gen/http/openapi.yaml
@@ -922,29 +922,29 @@ paths:
             tags:
                 - storage
             summary: download_aip storage
-            description: |-
-                Download AIP by AIPID
-
-                **Required security scopes for jwt**:
-                  * `storage:aips:download`
+            description: Download AIP by AIPID
             operationId: storage#download_aip
             parameters:
                 - name: uuid
                   in: path
-                  description: Identifier of AIP
+                  description: Identifier of the AIP to download
                   required: true
                   type: string
                   format: uuid
-                - name: Authorization
-                  in: header
-                  required: false
-                  type: string
             responses:
                 "200":
                     description: OK response.
+                    headers:
+                        Content-Disposition:
+                            type: string
+                        Content-Length:
+                            type: int64
+                        Content-Type:
+                            type: string
+                "400":
+                    description: Bad Request response.
                     schema:
-                        type: string
-                        format: byte
+                        $ref: '#/definitions/StorageDownloadAipNotValidResponseBody'
                 "401":
                     description: Unauthorized response.
                     schema:
@@ -960,6 +960,59 @@ paths:
                         required:
                             - message
                             - uuid
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/StorageDownloadAipInternalErrorResponseBody'
+            schemes:
+                - http
+        post:
+            tags:
+                - storage
+            summary: download_aip_request storage
+            description: |-
+                Request access to AIP download
+
+                **Required security scopes for jwt**:
+                  * `storage:aips:download`
+            operationId: storage#download_aip_request
+            parameters:
+                - name: uuid
+                  in: path
+                  description: Identifier of the AIP to download
+                  required: true
+                  type: string
+                  format: uuid
+                - name: Authorization
+                  in: header
+                  required: false
+                  type: string
+            responses:
+                "200":
+                    description: OK response.
+                "400":
+                    description: Bad Request response.
+                    schema:
+                        $ref: '#/definitions/StorageDownloadAipRequestNotValidResponseBody'
+                "401":
+                    description: Unauthorized response.
+                    schema:
+                        type: string
+                "403":
+                    description: Forbidden response.
+                    schema:
+                        type: string
+                "404":
+                    description: Not Found response.
+                    schema:
+                        $ref: '#/definitions/StorageDownloadAipRequestNotFoundResponseBody'
+                        required:
+                            - message
+                            - uuid
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/StorageDownloadAipRequestInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -3473,6 +3526,49 @@ definitions:
             uuid: abc123
         required:
             - uuid
+    StorageDownloadAipInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: download_aip_internal_error_response_body result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
     StorageDownloadAipNotFoundResponseBody:
         title: StorageDownloadAipNotFoundResponseBody
         type: object
@@ -3492,6 +3588,154 @@ definitions:
         required:
             - message
             - uuid
+    StorageDownloadAipNotValidResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: download_aip_not_valid_response_body result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
+    StorageDownloadAipRequestInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: download_aip_request_internal_error_response_body result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
+    StorageDownloadAipRequestNotFoundResponseBody:
+        title: StorageDownloadAipRequestNotFoundResponseBody
+        type: object
+        properties:
+            message:
+                type: string
+                description: Message of error
+                example: abc123
+            uuid:
+                type: string
+                description: Identifier of missing AIP
+                example: abc123
+        description: AIP not found
+        example:
+            message: abc123
+            uuid: abc123
+        required:
+            - message
+            - uuid
+    StorageDownloadAipRequestNotValidResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: download_aip_request_not_valid_response_body result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
     StorageListAipWorkflowsNotFoundResponseBody:
         title: StorageListAipWorkflowsNotFoundResponseBody
         type: object

--- a/internal/api/gen/http/openapi3.json
+++ b/internal/api/gen/http/openapi3.json
@@ -3683,15 +3683,25 @@
         "operationId": "storage#download_aip",
         "parameters": [
           {
-            "description": "Identifier of AIP",
+            "description": "Identifier of the AIP to download",
             "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "in": "path",
             "name": "uuid",
             "required": true,
             "schema": {
-              "description": "Identifier of AIP",
+              "description": "Identifier of the AIP to download",
               "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
               "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "example": "abc123",
+            "in": "cookie",
+            "name": "enduro-aip-download-ticket",
+            "schema": {
+              "example": "abc123",
               "type": "string"
             }
           }
@@ -3700,15 +3710,47 @@
           "200": {
             "content": {
               "application/json": {
-                "example": "YWJjMTIz",
                 "schema": {
-                  "example": "YWJjMTIz",
                   "format": "binary",
                   "type": "string"
                 }
               }
             },
-            "description": "OK response."
+            "description": "OK response.",
+            "headers": {
+              "Content-Disposition": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              },
+              "Content-Length": {
+                "example": 1,
+                "schema": {
+                  "example": 1,
+                  "format": "int64",
+                  "type": "integer"
+                }
+              },
+              "Content-Type": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "not_valid: Bad Request response."
           },
           "401": {
             "content": {
@@ -3747,6 +3789,111 @@
               }
             },
             "description": "not_found: AIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
+          }
+        },
+        "summary": "download_aip storage",
+        "tags": [
+          "storage"
+        ]
+      },
+      "post": {
+        "description": "Request access to AIP download",
+        "operationId": "storage#download_aip_request",
+        "parameters": [
+          {
+            "description": "Identifier of the AIP to download",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "description": "Identifier of the AIP to download",
+              "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "headers": {
+              "Set-Cookie": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "not_valid: Bad Request response."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized: Unauthorized response."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": "abc123",
+                "schema": {
+                  "example": "abc123",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "forbidden: Forbidden response."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "abc123",
+                  "uuid": "abc123"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SIPNotFound"
+                }
+              }
+            },
+            "description": "not_found: AIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -3756,7 +3903,7 @@
             ]
           }
         ],
-        "summary": "download_aip storage",
+        "summary": "download_aip_request storage",
         "tags": [
           "storage"
         ]

--- a/internal/api/gen/http/openapi3.yaml
+++ b/internal/api/gen/http/openapi3.yaml
@@ -1255,36 +1255,52 @@ paths:
             parameters:
                 - name: uuid
                   in: path
-                  description: Identifier of AIP
+                  description: Identifier of the AIP to download
                   required: true
                   schema:
                     type: string
-                    description: Identifier of AIP
+                    description: Identifier of the AIP to download
                     example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                     format: uuid
                   example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                - name: enduro-aip-download-ticket
+                  in: cookie
+                  allowEmptyValue: true
+                  schema:
+                    type: string
+                    example: abc123
+                  example: abc123
             responses:
                 "200":
                     description: OK response.
+                    headers:
+                        Content-Disposition:
+                            schema:
+                                type: string
+                                example: abc123
+                            example: abc123
+                        Content-Length:
+                            schema:
+                                type: integer
+                                example: 1
+                                format: int64
+                            example: 1
+                        Content-Type:
+                            schema:
+                                type: string
+                                example: abc123
+                            example: abc123
                     content:
                         application/json:
                             schema:
                                 type: string
-                                example:
-                                    - 97
-                                    - 98
-                                    - 99
-                                    - 49
-                                    - 50
-                                    - 51
                                 format: binary
-                            example:
-                                - 97
-                                - 98
-                                - 99
-                                - 49
-                                - 50
-                                - 51
+                "400":
+                    description: 'not_valid: Bad Request response.'
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
                 "401":
                     description: 'unauthorized: Unauthorized response.'
                     content:
@@ -1310,6 +1326,75 @@ paths:
                             example:
                                 message: abc123
                                 uuid: abc123
+                "500":
+                    description: 'internal_error: Internal Server Error response.'
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+        post:
+            tags:
+                - storage
+            summary: download_aip_request storage
+            description: Request access to AIP download
+            operationId: storage#download_aip_request
+            parameters:
+                - name: uuid
+                  in: path
+                  description: Identifier of the AIP to download
+                  required: true
+                  schema:
+                    type: string
+                    description: Identifier of the AIP to download
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                    format: uuid
+                  example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+            responses:
+                "200":
+                    description: OK response.
+                    headers:
+                        Set-Cookie:
+                            schema:
+                                type: string
+                                example: abc123
+                            example: abc123
+                "400":
+                    description: 'not_valid: Bad Request response.'
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: Unauthorized response.'
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+                                example: abc123
+                            example: abc123
+                "403":
+                    description: 'forbidden: Forbidden response.'
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+                                example: abc123
+                            example: abc123
+                "404":
+                    description: 'not_found: AIP not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SIPNotFound'
+                            example:
+                                message: abc123
+                                uuid: abc123
+                "500":
+                    description: 'internal_error: Internal Server Error response.'
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
             security:
                 - jwt_header_Authorization:
                     - storage:aips:download

--- a/internal/api/gen/http/storage/client/cli.go
+++ b/internal/api/gen/http/storage/client/cli.go
@@ -203,9 +203,34 @@ func BuildUpdateAipPayload(storageUpdateAipUUID string, storageUpdateAipToken st
 	return v, nil
 }
 
+// BuildDownloadAipRequestPayload builds the payload for the storage
+// download_aip_request endpoint from CLI flags.
+func BuildDownloadAipRequestPayload(storageDownloadAipRequestUUID string, storageDownloadAipRequestToken string) (*storage.DownloadAipRequestPayload, error) {
+	var err error
+	var uuid string
+	{
+		uuid = storageDownloadAipRequestUUID
+		err = goa.MergeErrors(err, goa.ValidateFormat("uuid", uuid, goa.FormatUUID))
+		if err != nil {
+			return nil, err
+		}
+	}
+	var token *string
+	{
+		if storageDownloadAipRequestToken != "" {
+			token = &storageDownloadAipRequestToken
+		}
+	}
+	v := &storage.DownloadAipRequestPayload{}
+	v.UUID = uuid
+	v.Token = token
+
+	return v, nil
+}
+
 // BuildDownloadAipPayload builds the payload for the storage download_aip
 // endpoint from CLI flags.
-func BuildDownloadAipPayload(storageDownloadAipUUID string, storageDownloadAipToken string) (*storage.DownloadAipPayload, error) {
+func BuildDownloadAipPayload(storageDownloadAipUUID string, storageDownloadAipTicket string) (*storage.DownloadAipPayload, error) {
 	var err error
 	var uuid string
 	{
@@ -215,15 +240,15 @@ func BuildDownloadAipPayload(storageDownloadAipUUID string, storageDownloadAipTo
 			return nil, err
 		}
 	}
-	var token *string
+	var ticket *string
 	{
-		if storageDownloadAipToken != "" {
-			token = &storageDownloadAipToken
+		if storageDownloadAipTicket != "" {
+			ticket = &storageDownloadAipTicket
 		}
 	}
 	v := &storage.DownloadAipPayload{}
 	v.UUID = uuid
-	v.Token = token
+	v.Ticket = ticket
 
 	return v, nil
 }

--- a/internal/api/gen/http/storage/client/paths.go
+++ b/internal/api/gen/http/storage/client/paths.go
@@ -32,6 +32,11 @@ func UpdateAipStoragePath(uuid string) string {
 	return fmt.Sprintf("/storage/aips/%v/update", uuid)
 }
 
+// DownloadAipRequestStoragePath returns the URL path to the storage service download_aip_request HTTP endpoint.
+func DownloadAipRequestStoragePath(uuid string) string {
+	return fmt.Sprintf("/storage/aips/%v/download", uuid)
+}
+
 // DownloadAipStoragePath returns the URL path to the storage service download_aip HTTP endpoint.
 func DownloadAipStoragePath(uuid string) string {
 	return fmt.Sprintf("/storage/aips/%v/download", uuid)

--- a/internal/api/gen/http/storage/client/types.go
+++ b/internal/api/gen/http/storage/client/types.go
@@ -303,6 +303,88 @@ type UpdateAipNotValidResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// DownloadAipRequestNotValidResponseBody is the type of the "storage" service
+// "download_aip_request" endpoint HTTP response body for the "not_valid" error.
+type DownloadAipRequestNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DownloadAipRequestInternalErrorResponseBody is the type of the "storage"
+// service "download_aip_request" endpoint HTTP response body for the
+// "internal_error" error.
+type DownloadAipRequestInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DownloadAipRequestNotFoundResponseBody is the type of the "storage" service
+// "download_aip_request" endpoint HTTP response body for the "not_found" error.
+type DownloadAipRequestNotFoundResponseBody struct {
+	// Message of error
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Identifier of missing AIP
+	UUID *uuid.UUID `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
+}
+
+// DownloadAipNotValidResponseBody is the type of the "storage" service
+// "download_aip" endpoint HTTP response body for the "not_valid" error.
+type DownloadAipNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// DownloadAipInternalErrorResponseBody is the type of the "storage" service
+// "download_aip" endpoint HTTP response body for the "internal_error" error.
+type DownloadAipInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // DownloadAipNotFoundResponseBody is the type of the "storage" service
 // "download_aip" endpoint HTTP response body for the "not_found" error.
 type DownloadAipNotFoundResponseBody struct {
@@ -926,6 +1008,113 @@ func NewUpdateAipForbidden(body string) storage.Forbidden {
 // unauthorized error.
 func NewUpdateAipUnauthorized(body string) storage.Unauthorized {
 	v := storage.Unauthorized(body)
+
+	return v
+}
+
+// NewDownloadAipRequestResultOK builds a "storage" service
+// "download_aip_request" endpoint result from a HTTP "OK" response.
+func NewDownloadAipRequestResultOK(ticket *string) *storage.DownloadAipRequestResult {
+	v := &storage.DownloadAipRequestResult{}
+	v.Ticket = ticket
+
+	return v
+}
+
+// NewDownloadAipRequestNotValid builds a storage service download_aip_request
+// endpoint not_valid error.
+func NewDownloadAipRequestNotValid(body *DownloadAipRequestNotValidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDownloadAipRequestInternalError builds a storage service
+// download_aip_request endpoint internal_error error.
+func NewDownloadAipRequestInternalError(body *DownloadAipRequestInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDownloadAipRequestNotFound builds a storage service download_aip_request
+// endpoint not_found error.
+func NewDownloadAipRequestNotFound(body *DownloadAipRequestNotFoundResponseBody) *storage.AIPNotFound {
+	v := &storage.AIPNotFound{
+		Message: *body.Message,
+		UUID:    *body.UUID,
+	}
+
+	return v
+}
+
+// NewDownloadAipRequestForbidden builds a storage service download_aip_request
+// endpoint forbidden error.
+func NewDownloadAipRequestForbidden(body string) storage.Forbidden {
+	v := storage.Forbidden(body)
+
+	return v
+}
+
+// NewDownloadAipRequestUnauthorized builds a storage service
+// download_aip_request endpoint unauthorized error.
+func NewDownloadAipRequestUnauthorized(body string) storage.Unauthorized {
+	v := storage.Unauthorized(body)
+
+	return v
+}
+
+// NewDownloadAipResultOK builds a "storage" service "download_aip" endpoint
+// result from a HTTP "OK" response.
+func NewDownloadAipResultOK(contentType string, contentLength int64, contentDisposition string) *storage.DownloadAipResult {
+	v := &storage.DownloadAipResult{}
+	v.ContentType = contentType
+	v.ContentLength = contentLength
+	v.ContentDisposition = contentDisposition
+
+	return v
+}
+
+// NewDownloadAipNotValid builds a storage service download_aip endpoint
+// not_valid error.
+func NewDownloadAipNotValid(body *DownloadAipNotValidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewDownloadAipInternalError builds a storage service download_aip endpoint
+// internal_error error.
+func NewDownloadAipInternalError(body *DownloadAipInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
 
 	return v
 }
@@ -1644,6 +1833,114 @@ func ValidateUpdateAipNotAvailableResponseBody(body *UpdateAipNotAvailableRespon
 // ValidateUpdateAipNotValidResponseBody runs the validations defined on
 // update_aip_not_valid_response_body
 func ValidateUpdateAipNotValidResponseBody(body *UpdateAipNotValidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDownloadAipRequestNotValidResponseBody runs the validations defined
+// on download_aip_request_not_valid_response_body
+func ValidateDownloadAipRequestNotValidResponseBody(body *DownloadAipRequestNotValidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDownloadAipRequestInternalErrorResponseBody runs the validations
+// defined on download_aip_request_internal_error_response_body
+func ValidateDownloadAipRequestInternalErrorResponseBody(body *DownloadAipRequestInternalErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDownloadAipRequestNotFoundResponseBody runs the validations defined
+// on download_aip_request_not_found_response_body
+func ValidateDownloadAipRequestNotFoundResponseBody(body *DownloadAipRequestNotFoundResponseBody) (err error) {
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.UUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "body"))
+	}
+	return
+}
+
+// ValidateDownloadAipNotValidResponseBody runs the validations defined on
+// download_aip_not_valid_response_body
+func ValidateDownloadAipNotValidResponseBody(body *DownloadAipNotValidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateDownloadAipInternalErrorResponseBody runs the validations defined on
+// download_aip_internal_error_response_body
+func ValidateDownloadAipInternalErrorResponseBody(body *DownloadAipInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/internal/api/gen/http/storage/server/encode_decode.go
+++ b/internal/api/gen/http/storage/server/encode_decode.go
@@ -490,21 +490,29 @@ func EncodeUpdateAipError(encoder func(context.Context, http.ResponseWriter) goa
 	}
 }
 
-// EncodeDownloadAipResponse returns an encoder for responses returned by the
-// storage download_aip endpoint.
-func EncodeDownloadAipResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+// EncodeDownloadAipRequestResponse returns an encoder for responses returned
+// by the storage download_aip_request endpoint.
+func EncodeDownloadAipRequestResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
 	return func(ctx context.Context, w http.ResponseWriter, v any) error {
-		res, _ := v.([]byte)
-		enc := encoder(ctx, w)
-		body := res
+		res, _ := v.(*storage.DownloadAipRequestResult)
+		if res.Ticket != nil {
+			ticket := *res.Ticket
+			http.SetCookie(w, &http.Cookie{
+				Name:     "enduro-aip-download-ticket",
+				Value:    ticket,
+				MaxAge:   5,
+				Secure:   true,
+				HttpOnly: true,
+			})
+		}
 		w.WriteHeader(http.StatusOK)
-		return enc.Encode(body)
+		return nil
 	}
 }
 
-// DecodeDownloadAipRequest returns a decoder for requests sent to the storage
-// download_aip endpoint.
-func DecodeDownloadAipRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+// DecodeDownloadAipRequestRequest returns a decoder for requests sent to the
+// storage download_aip_request endpoint.
+func DecodeDownloadAipRequestRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
 	return func(r *http.Request) (any, error) {
 		var (
 			uuid  string
@@ -522,7 +530,7 @@ func DecodeDownloadAipRequest(mux goahttp.Muxer, decoder func(*http.Request) goa
 		if err != nil {
 			return nil, err
 		}
-		payload := NewDownloadAipPayload(uuid, token)
+		payload := NewDownloadAipRequestPayload(uuid, token)
 		if payload.Token != nil {
 			if strings.Contains(*payload.Token, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")
@@ -530,6 +538,125 @@ func DecodeDownloadAipRequest(mux goahttp.Muxer, decoder func(*http.Request) goa
 				payload.Token = &cred
 			}
 		}
+
+		return payload, nil
+	}
+}
+
+// EncodeDownloadAipRequestError returns an encoder for errors returned by the
+// download_aip_request storage endpoint.
+func EncodeDownloadAipRequestError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "not_valid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDownloadAipRequestNotValidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDownloadAipRequestInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "not_found":
+			var res *storage.AIPNotFound
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDownloadAipRequestNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "forbidden":
+			var res storage.Forbidden
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			body := res
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "unauthorized":
+			var res storage.Unauthorized
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			body := res
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
+// EncodeDownloadAipResponse returns an encoder for responses returned by the
+// storage download_aip endpoint.
+func EncodeDownloadAipResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(*storage.DownloadAipResult)
+		w.Header().Set("Content-Type", res.ContentType)
+		{
+			val := res.ContentLength
+			contentLengths := strconv.FormatInt(val, 10)
+			w.Header().Set("Content-Length", contentLengths)
+		}
+		w.Header().Set("Content-Disposition", res.ContentDisposition)
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+}
+
+// DecodeDownloadAipRequest returns a decoder for requests sent to the storage
+// download_aip endpoint.
+func DecodeDownloadAipRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
+		var (
+			uuid   string
+			ticket *string
+			err    error
+			c      *http.Cookie
+
+			params = mux.Vars(r)
+		)
+		uuid = params["uuid"]
+		err = goa.MergeErrors(err, goa.ValidateFormat("uuid", uuid, goa.FormatUUID))
+		c, _ = r.Cookie("enduro-aip-download-ticket")
+		var ticketRaw string
+		if c != nil {
+			ticketRaw = c.Value
+		}
+		if ticketRaw != "" {
+			ticket = &ticketRaw
+		}
+		if err != nil {
+			return nil, err
+		}
+		payload := NewDownloadAipPayload(uuid, ticket)
 
 		return payload, nil
 	}
@@ -545,6 +672,32 @@ func EncodeDownloadAipError(encoder func(context.Context, http.ResponseWriter) g
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
+		case "not_valid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDownloadAipNotValidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDownloadAipInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
 		case "not_found":
 			var res *storage.AIPNotFound
 			errors.As(v, &res)

--- a/internal/api/gen/http/storage/server/paths.go
+++ b/internal/api/gen/http/storage/server/paths.go
@@ -32,6 +32,11 @@ func UpdateAipStoragePath(uuid string) string {
 	return fmt.Sprintf("/storage/aips/%v/update", uuid)
 }
 
+// DownloadAipRequestStoragePath returns the URL path to the storage service download_aip_request HTTP endpoint.
+func DownloadAipRequestStoragePath(uuid string) string {
+	return fmt.Sprintf("/storage/aips/%v/download", uuid)
+}
+
 // DownloadAipStoragePath returns the URL path to the storage service download_aip HTTP endpoint.
 func DownloadAipStoragePath(uuid string) string {
 	return fmt.Sprintf("/storage/aips/%v/download", uuid)

--- a/internal/api/gen/http/storage/server/types.go
+++ b/internal/api/gen/http/storage/server/types.go
@@ -293,6 +293,88 @@ type UpdateAipNotValidResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// DownloadAipRequestNotValidResponseBody is the type of the "storage" service
+// "download_aip_request" endpoint HTTP response body for the "not_valid" error.
+type DownloadAipRequestNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DownloadAipRequestInternalErrorResponseBody is the type of the "storage"
+// service "download_aip_request" endpoint HTTP response body for the
+// "internal_error" error.
+type DownloadAipRequestInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DownloadAipRequestNotFoundResponseBody is the type of the "storage" service
+// "download_aip_request" endpoint HTTP response body for the "not_found" error.
+type DownloadAipRequestNotFoundResponseBody struct {
+	// Message of error
+	Message string `form:"message" json:"message" xml:"message"`
+	// Identifier of missing AIP
+	UUID uuid.UUID `form:"uuid" json:"uuid" xml:"uuid"`
+}
+
+// DownloadAipNotValidResponseBody is the type of the "storage" service
+// "download_aip" endpoint HTTP response body for the "not_valid" error.
+type DownloadAipNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// DownloadAipInternalErrorResponseBody is the type of the "storage" service
+// "download_aip" endpoint HTTP response body for the "internal_error" error.
+type DownloadAipInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // DownloadAipNotFoundResponseBody is the type of the "storage" service
 // "download_aip" endpoint HTTP response body for the "not_found" error.
 type DownloadAipNotFoundResponseBody struct {
@@ -818,6 +900,73 @@ func NewUpdateAipNotValidResponseBody(res *goa.ServiceError) *UpdateAipNotValidR
 	return body
 }
 
+// NewDownloadAipRequestNotValidResponseBody builds the HTTP response body from
+// the result of the "download_aip_request" endpoint of the "storage" service.
+func NewDownloadAipRequestNotValidResponseBody(res *goa.ServiceError) *DownloadAipRequestNotValidResponseBody {
+	body := &DownloadAipRequestNotValidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDownloadAipRequestInternalErrorResponseBody builds the HTTP response body
+// from the result of the "download_aip_request" endpoint of the "storage"
+// service.
+func NewDownloadAipRequestInternalErrorResponseBody(res *goa.ServiceError) *DownloadAipRequestInternalErrorResponseBody {
+	body := &DownloadAipRequestInternalErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDownloadAipRequestNotFoundResponseBody builds the HTTP response body from
+// the result of the "download_aip_request" endpoint of the "storage" service.
+func NewDownloadAipRequestNotFoundResponseBody(res *storage.AIPNotFound) *DownloadAipRequestNotFoundResponseBody {
+	body := &DownloadAipRequestNotFoundResponseBody{
+		Message: res.Message,
+		UUID:    res.UUID,
+	}
+	return body
+}
+
+// NewDownloadAipNotValidResponseBody builds the HTTP response body from the
+// result of the "download_aip" endpoint of the "storage" service.
+func NewDownloadAipNotValidResponseBody(res *goa.ServiceError) *DownloadAipNotValidResponseBody {
+	body := &DownloadAipNotValidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDownloadAipInternalErrorResponseBody builds the HTTP response body from
+// the result of the "download_aip" endpoint of the "storage" service.
+func NewDownloadAipInternalErrorResponseBody(res *goa.ServiceError) *DownloadAipInternalErrorResponseBody {
+	body := &DownloadAipInternalErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
 // NewDownloadAipNotFoundResponseBody builds the HTTP response body from the
 // result of the "download_aip" endpoint of the "storage" service.
 func NewDownloadAipNotFoundResponseBody(res *storage.AIPNotFound) *DownloadAipNotFoundResponseBody {
@@ -1079,11 +1228,21 @@ func NewUpdateAipPayload(uuid string, token *string) *storage.UpdateAipPayload {
 	return v
 }
 
-// NewDownloadAipPayload builds a storage service download_aip endpoint payload.
-func NewDownloadAipPayload(uuid string, token *string) *storage.DownloadAipPayload {
-	v := &storage.DownloadAipPayload{}
+// NewDownloadAipRequestPayload builds a storage service download_aip_request
+// endpoint payload.
+func NewDownloadAipRequestPayload(uuid string, token *string) *storage.DownloadAipRequestPayload {
+	v := &storage.DownloadAipRequestPayload{}
 	v.UUID = uuid
 	v.Token = token
+
+	return v
+}
+
+// NewDownloadAipPayload builds a storage service download_aip endpoint payload.
+func NewDownloadAipPayload(uuid string, ticket *string) *storage.DownloadAipPayload {
+	v := &storage.DownloadAipPayload{}
+	v.UUID = uuid
+	v.Ticket = ticket
 
 	return v
 }

--- a/internal/ingest/workflow.go
+++ b/internal/ingest/workflow.go
@@ -97,7 +97,6 @@ func (svc *ingestImpl) readWorkflow(
 			workflow.status,
 			CONVERT_TZ(workflow.started_at, @@session.time_zone, '+00:00') AS started_at,
 			CONVERT_TZ(workflow.completed_at, @@session.time_zone, '+00:00') AS completed_at,
-			workflow.sip_id,
 			sip.uuid as sip_uuid
 		FROM workflow
 		LEFT JOIN sip ON (workflow.sip_id = sip.id)

--- a/internal/storage/client.go
+++ b/internal/storage/client.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"io"
 
 	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
 )
@@ -11,7 +12,11 @@ type Client interface {
 	SubmitAip(context.Context, *goastorage.SubmitAipPayload) (*goastorage.SubmitAIPResult, error)
 	CreateAip(context.Context, *goastorage.CreateAipPayload) (*goastorage.AIP, error)
 	UpdateAip(context.Context, *goastorage.UpdateAipPayload) error
-	DownloadAip(context.Context, *goastorage.DownloadAipPayload) ([]byte, error)
+	DownloadAipRequest(
+		context.Context,
+		*goastorage.DownloadAipRequestPayload,
+	) (*goastorage.DownloadAipRequestResult, error)
+	DownloadAip(context.Context, *goastorage.DownloadAipPayload) (*goastorage.DownloadAipResult, io.ReadCloser, error)
 	ListLocations(context.Context, *goastorage.ListLocationsPayload) (goastorage.LocationCollection, error)
 	CreateLocation(context.Context, *goastorage.CreateLocationPayload) (*goastorage.CreateLocationResult, error)
 	MoveAip(context.Context, *goastorage.MoveAipPayload) error

--- a/internal/storage/download_aip.go
+++ b/internal/storage/download_aip.go
@@ -1,0 +1,97 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"gocloud.dev/gcerrors"
+
+	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
+	"github.com/artefactual-sdps/enduro/internal/fsutil"
+	"github.com/artefactual-sdps/enduro/internal/storage/enums"
+)
+
+func (s *serviceImpl) DownloadAipRequest(
+	ctx context.Context,
+	payload *goastorage.DownloadAipRequestPayload,
+) (*goastorage.DownloadAipRequestResult, error) {
+	aip, err := s.ShowAip(ctx, &goastorage.ShowAipPayload{UUID: payload.UUID})
+	if err != nil {
+		return nil, err
+	}
+
+	if aip.Status != enums.AIPStatusStored.String() && aip.Status != enums.AIPStatusPending.String() {
+		return nil, goastorage.MakeNotValid(errors.New("AIP is not available for download"))
+	}
+
+	// Check if the failed AIP exists in the location bucket.
+	reader, err := s.AipReader(ctx, aip)
+	if err != nil {
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			return nil, &goastorage.AIPNotFound{
+				UUID:    aip.UUID,
+				Message: "AIP file not found in the location bucket",
+			}
+		} else {
+			return nil, goastorage.MakeInternalError(errors.New("error checking AIP file"))
+		}
+	}
+	reader.Close()
+
+	// Request a ticket.
+	ticket, err := s.ticketProvider.Request(ctx)
+	if err != nil {
+		return nil, goastorage.MakeInternalError(errors.New("ticket request failed"))
+	}
+
+	// A ticket is not provided when authentication is disabled.
+	// Do not set the ticket cookie in that case.
+	res := &goastorage.DownloadAipRequestResult{}
+	if ticket != "" {
+		res.Ticket = &ticket
+	}
+
+	return res, nil
+}
+
+func (s *serviceImpl) DownloadAip(
+	ctx context.Context,
+	payload *goastorage.DownloadAipPayload,
+) (*goastorage.DownloadAipResult, io.ReadCloser, error) {
+	// Verify the ticket.
+	if err := s.ticketProvider.Check(ctx, payload.Ticket); err != nil {
+		return nil, nil, ErrUnauthorized
+	}
+
+	aip, err := s.ShowAip(ctx, &goastorage.ShowAipPayload{UUID: payload.UUID})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if aip.Status != enums.AIPStatusStored.String() && aip.Status != enums.AIPStatusPending.String() {
+		return nil, nil, goastorage.MakeNotValid(errors.New("AIP is not available for download"))
+	}
+
+	// Get a reader from the location bucket for the AIP object key.
+	reader, err := s.AipReader(ctx, aip)
+	if err != nil {
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			return nil, nil, &goastorage.AIPNotFound{
+				UUID:    aip.UUID,
+				Message: "AIP file not found in the location bucket",
+			}
+		} else {
+			return nil, nil, goastorage.MakeInternalError(errors.New("error reading AIP file"))
+		}
+	}
+
+	filename := fmt.Sprintf("%s-%s.7z", fsutil.BaseNoExt(aip.Name), aip.UUID)
+
+	return &goastorage.DownloadAipResult{
+		ContentType:        reader.ContentType(),
+		ContentLength:      reader.Size(),
+		ContentDisposition: fmt.Sprintf("attachment; filename=\"%s\"", filename),
+	}, reader, nil
+}

--- a/internal/storage/download_aip_test.go
+++ b/internal/storage/download_aip_test.go
@@ -1,0 +1,393 @@
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"go.artefactual.dev/tools/ref"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+
+	"github.com/artefactual-sdps/enduro/internal/api/auth"
+	auth_fake "github.com/artefactual-sdps/enduro/internal/api/auth/fake"
+	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
+	"github.com/artefactual-sdps/enduro/internal/storage/enums"
+	persistence_fake "github.com/artefactual-sdps/enduro/internal/storage/persistence/fake"
+)
+
+func TestDownloadAipRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	td := fs.NewDir(t, "enduro-service-test")
+	missingAIPUUID := uuid.New()
+
+	// Write a test blob to the bucket.
+	writeTestBlob(ctx, t, "file://"+td.Path(), aipID.String())
+
+	for _, tt := range []struct {
+		name    string
+		payload *goastorage.DownloadAipRequestPayload
+		mock    func(context.Context, *auth_fake.MockTicketStore, *persistence_fake.MockStorage)
+		wantErr string
+		wantRes *goastorage.DownloadAipRequestResult
+	}{
+		{
+			name:    "Fails to request a AIP download (invalid UUID)",
+			payload: &goastorage.DownloadAipRequestPayload{UUID: "invalid-uuid"},
+			wantErr: "cannot perform operation",
+		},
+		{
+			name:    "Fails to request a AIP download (AIP not found)",
+			payload: &goastorage.DownloadAipRequestPayload{UUID: aipID.String()},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				psvc.EXPECT().
+					ReadAIP(ctx, aipID).
+					Return(nil, &goastorage.AIPNotFound{UUID: aipID, Message: "AIP not found"})
+			},
+			wantErr: "AIP not found.",
+		},
+		{
+			name:    "Fails to request a AIP download (persistence error)",
+			payload: &goastorage.DownloadAipRequestPayload{UUID: aipID.String()},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				psvc.EXPECT().
+					ReadAIP(ctx, aipID).
+					Return(nil, goastorage.MakeNotAvailable(errors.New("persistence error")))
+			},
+			wantErr: "persistence error",
+		},
+		{
+			name:    "Fails to request a AIP download (invalid status)",
+			payload: &goastorage.DownloadAipRequestPayload{UUID: aipID.String()},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				psvc.EXPECT().
+					ReadAIP(ctx, aipID).
+					Return(&goastorage.AIP{UUID: aipID, Status: enums.AIPStatusDeleted.String()}, nil)
+			},
+			wantErr: "AIP is not available for download",
+		},
+		{
+			name:    "Fails to request a AIP download (AIP file not found)",
+			payload: &goastorage.DownloadAipRequestPayload{UUID: missingAIPUUID.String()},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				psvc.EXPECT().
+					ReadAIP(ctx, missingAIPUUID).
+					Return(
+						&goastorage.AIP{
+							UUID:       missingAIPUUID,
+							Status:     enums.AIPStatusStored.String(),
+							ObjectKey:  missingAIPUUID,
+							LocationID: &locationID,
+						},
+						nil,
+					)
+				psvc.
+					EXPECT().
+					ReadLocation(ctx, locationID).
+					Return(
+						&goastorage.Location{
+							UUID: locationID,
+							Config: &goastorage.URLConfig{
+								URL: "file://" + td.Path(),
+							},
+						},
+						nil,
+					)
+			},
+			wantErr: "AIP not found.",
+		},
+		{
+			name:    "Fails to request a AIP download (fails to create ticket)",
+			payload: &goastorage.DownloadAipRequestPayload{UUID: aipID.String()},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				psvc.EXPECT().
+					ReadAIP(ctx, aipID).
+					Return(
+						&goastorage.AIP{
+							UUID:       aipID,
+							Status:     enums.AIPStatusStored.String(),
+							ObjectKey:  aipID,
+							LocationID: &locationID,
+						},
+						nil,
+					)
+				psvc.
+					EXPECT().
+					ReadLocation(ctx, locationID).
+					Return(
+						&goastorage.Location{
+							UUID: locationID,
+							Config: &goastorage.URLConfig{
+								URL: "file://" + td.Path(),
+							},
+						},
+						nil,
+					)
+				ts.EXPECT().
+					SetEx(ctx, "Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk", time.Second*5).
+					Return(errors.New("ticket error"))
+			},
+			wantErr: "ticket request failed",
+		},
+		{
+			name:    "Requests a AIP download",
+			payload: &goastorage.DownloadAipRequestPayload{UUID: aipID.String()},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				psvc.EXPECT().
+					ReadAIP(ctx, aipID).
+					Return(
+						&goastorage.AIP{
+							UUID:       aipID,
+							Status:     enums.AIPStatusStored.String(),
+							ObjectKey:  aipID,
+							LocationID: &locationID,
+						},
+						nil,
+					)
+				psvc.
+					EXPECT().
+					ReadLocation(ctx, locationID).
+					Return(
+						&goastorage.Location{
+							UUID: locationID,
+							Config: &goastorage.URLConfig{
+								URL: "file://" + td.Path(),
+							},
+						},
+						nil,
+					)
+				ts.EXPECT().SetEx(ctx, "Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk", time.Second*5).Return(nil)
+			},
+			wantRes: &goastorage.DownloadAipRequestResult{
+				Ticket: ref.New("Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk"),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rander := rand.New(rand.NewSource(1)) // #nosec
+			ticketStoreMock := auth_fake.NewMockTicketStore(gomock.NewController(t))
+			ticketProvider := auth.NewTicketProvider(ctx, ticketStoreMock, rander)
+
+			var attrs setUpAttrs
+			attrs.ticketProvider = ticketProvider
+			svc := setUpService(t, &attrs)
+
+			if tt.mock != nil {
+				tt.mock(ctx, ticketStoreMock, attrs.persistenceMock)
+			}
+
+			res, err := svc.DownloadAipRequest(ctx, tt.payload)
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.DeepEqual(t, res, tt.wantRes)
+		})
+	}
+}
+
+func TestDownloadAip(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	td := fs.NewDir(t, "enduro-service-test")
+	missingAIPUUID := uuid.New()
+	content := []byte("Testing 1-2-3!")
+
+	// Write a test blob to the bucket.
+	writeTestBlob(ctx, t, "file://"+td.Path(), aipID.String())
+
+	for _, tt := range []struct {
+		name     string
+		payload  *goastorage.DownloadAipPayload
+		mock     func(context.Context, *auth_fake.MockTicketStore, *persistence_fake.MockStorage)
+		wantErr  string
+		wantRes  *goastorage.DownloadAipResult
+		wantBody []byte
+	}{
+		{
+			name:    "Fails to download a AIP (missing ticket)",
+			payload: &goastorage.DownloadAipPayload{},
+			wantErr: "Unauthorized",
+		},
+		{
+			name:    "Fails to download a AIP (invalid ticket)",
+			payload: &goastorage.DownloadAipPayload{Ticket: ref.New("invalid-ticket")},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				ts.EXPECT().GetDel(ctx, "invalid-ticket").Return(auth.ErrKeyNotFound)
+			},
+			wantErr: "Unauthorized",
+		},
+		{
+			name: "Fails to download a AIP (invalid UUID)",
+			payload: &goastorage.DownloadAipPayload{
+				Ticket: ref.New("valid-ticket"),
+				UUID:   "invalid-uuid",
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket").Return(nil)
+			},
+			wantErr: "cannot perform operation",
+		},
+		{
+			name: "Fails to download a AIP (AIP not found)",
+			payload: &goastorage.DownloadAipPayload{
+				Ticket: ref.New("valid-ticket"),
+				UUID:   aipID.String(),
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket").Return(nil)
+				psvc.EXPECT().
+					ReadAIP(ctx, aipID).
+					Return(nil, &goastorage.AIPNotFound{UUID: aipID, Message: "AIP not found"})
+			},
+			wantErr: "AIP not found.",
+		},
+		{
+			name: "Fails to download a AIP (persistence error)",
+			payload: &goastorage.DownloadAipPayload{
+				Ticket: ref.New("valid-ticket"),
+				UUID:   aipID.String(),
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket").Return(nil)
+				psvc.EXPECT().
+					ReadAIP(ctx, aipID).
+					Return(nil, goastorage.MakeNotAvailable(errors.New("persistence error")))
+			},
+			wantErr: "persistence error",
+		},
+		{
+			name: "Fails to download a AIP (invalid status)",
+			payload: &goastorage.DownloadAipPayload{
+				Ticket: ref.New("valid-ticket"),
+				UUID:   aipID.String(),
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket").Return(nil)
+				psvc.EXPECT().
+					ReadAIP(ctx, aipID).
+					Return(&goastorage.AIP{UUID: aipID, Status: enums.AIPStatusDeleted.String()}, nil)
+			},
+			wantErr: "AIP is not available for download",
+		},
+		{
+			name: "Fails to download a AIP (AIP file not found)",
+			payload: &goastorage.DownloadAipPayload{
+				Ticket: ref.New("valid-ticket"),
+				UUID:   missingAIPUUID.String(),
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket").Return(nil)
+				psvc.EXPECT().
+					ReadAIP(ctx, missingAIPUUID).
+					Return(
+						&goastorage.AIP{
+							UUID:       missingAIPUUID,
+							Status:     enums.AIPStatusStored.String(),
+							ObjectKey:  missingAIPUUID,
+							LocationID: &locationID,
+						},
+						nil,
+					)
+				psvc.
+					EXPECT().
+					ReadLocation(ctx, locationID).
+					Return(
+						&goastorage.Location{
+							UUID: locationID,
+							Config: &goastorage.URLConfig{
+								URL: "file://" + td.Path(),
+							},
+						},
+						nil,
+					)
+			},
+			wantErr: "AIP not found.",
+		},
+		{
+			name: "Downloads a AIP",
+			payload: &goastorage.DownloadAipPayload{
+				Ticket: ref.New("valid-ticket"),
+				UUID:   aipID.String(),
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket").Return(nil)
+				psvc.EXPECT().
+					ReadAIP(ctx, aipID).
+					Return(
+						&goastorage.AIP{
+							Name:       "AIP.zip",
+							UUID:       aipID,
+							Status:     enums.AIPStatusStored.String(),
+							ObjectKey:  aipID,
+							LocationID: &locationID,
+						},
+						nil,
+					)
+				psvc.
+					EXPECT().
+					ReadLocation(ctx, locationID).
+					Return(
+						&goastorage.Location{
+							UUID: locationID,
+							Config: &goastorage.URLConfig{
+								URL: "file://" + td.Path(),
+							},
+						},
+						nil,
+					)
+			},
+			wantBody: content,
+			wantRes: &goastorage.DownloadAipResult{
+				ContentDisposition: fmt.Sprintf("attachment; filename=%q", fmt.Sprintf("AIP-%s.7z", aipID)),
+				ContentType:        "text/plain; charset=utf-8",
+				ContentLength:      int64(len(content)),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rander := rand.New(rand.NewSource(1)) // #nosec
+			ticketStoreMock := auth_fake.NewMockTicketStore(gomock.NewController(t))
+			ticketProvider := auth.NewTicketProvider(ctx, ticketStoreMock, rander)
+
+			var attrs setUpAttrs
+			attrs.ticketProvider = ticketProvider
+			svc := setUpService(t, &attrs)
+
+			if tt.mock != nil {
+				tt.mock(ctx, ticketStoreMock, attrs.persistenceMock)
+			}
+
+			res, body, err := svc.DownloadAip(ctx, tt.payload)
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				return
+			}
+
+			t.Cleanup(func() {
+				err := body.Close()
+				assert.NilError(t, err)
+			})
+
+			assert.DeepEqual(t, res, tt.wantRes)
+			cont, err := io.ReadAll(body)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, cont, tt.wantBody)
+		})
+	}
+}

--- a/internal/storage/fake/mock_client.go
+++ b/internal/storage/fake/mock_client.go
@@ -11,6 +11,7 @@ package fake
 
 import (
 	context "context"
+	io "io"
 	reflect "reflect"
 
 	storage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
@@ -119,12 +120,13 @@ func (c *MockClientCreateLocationCall) DoAndReturn(f func(context.Context, *stor
 }
 
 // DownloadAip mocks base method.
-func (m *MockClient) DownloadAip(arg0 context.Context, arg1 *storage.DownloadAipPayload) ([]byte, error) {
+func (m *MockClient) DownloadAip(arg0 context.Context, arg1 *storage.DownloadAipPayload) (*storage.DownloadAipResult, io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadAip", arg0, arg1)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(*storage.DownloadAipResult)
+	ret1, _ := ret[1].(io.ReadCloser)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // DownloadAip indicates an expected call of DownloadAip.
@@ -140,19 +142,58 @@ type MockClientDownloadAipCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockClientDownloadAipCall) Return(arg0 []byte, arg1 error) *MockClientDownloadAipCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockClientDownloadAipCall) Return(arg0 *storage.DownloadAipResult, arg1 io.ReadCloser, arg2 error) *MockClientDownloadAipCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientDownloadAipCall) Do(f func(context.Context, *storage.DownloadAipPayload) ([]byte, error)) *MockClientDownloadAipCall {
+func (c *MockClientDownloadAipCall) Do(f func(context.Context, *storage.DownloadAipPayload) (*storage.DownloadAipResult, io.ReadCloser, error)) *MockClientDownloadAipCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientDownloadAipCall) DoAndReturn(f func(context.Context, *storage.DownloadAipPayload) ([]byte, error)) *MockClientDownloadAipCall {
+func (c *MockClientDownloadAipCall) DoAndReturn(f func(context.Context, *storage.DownloadAipPayload) (*storage.DownloadAipResult, io.ReadCloser, error)) *MockClientDownloadAipCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// DownloadAipRequest mocks base method.
+func (m *MockClient) DownloadAipRequest(arg0 context.Context, arg1 *storage.DownloadAipRequestPayload) (*storage.DownloadAipRequestResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DownloadAipRequest", arg0, arg1)
+	ret0, _ := ret[0].(*storage.DownloadAipRequestResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DownloadAipRequest indicates an expected call of DownloadAipRequest.
+func (mr *MockClientMockRecorder) DownloadAipRequest(arg0, arg1 any) *MockClientDownloadAipRequestCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadAipRequest", reflect.TypeOf((*MockClient)(nil).DownloadAipRequest), arg0, arg1)
+	return &MockClientDownloadAipRequestCall{Call: call}
+}
+
+// MockClientDownloadAipRequestCall wrap *gomock.Call
+type MockClientDownloadAipRequestCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockClientDownloadAipRequestCall) Return(arg0 *storage.DownloadAipRequestResult, arg1 error) *MockClientDownloadAipRequestCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockClientDownloadAipRequestCall) Do(f func(context.Context, *storage.DownloadAipRequestPayload) (*storage.DownloadAipRequestResult, error)) *MockClientDownloadAipRequestCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockClientDownloadAipRequestCall) DoAndReturn(f func(context.Context, *storage.DownloadAipRequestPayload) (*storage.DownloadAipRequestResult, error)) *MockClientDownloadAipRequestCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/storage/fake/mock_storage.go
+++ b/internal/storage/fake/mock_storage.go
@@ -11,6 +11,7 @@ package fake
 
 import (
 	context "context"
+	io "io"
 	reflect "reflect"
 
 	storage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
@@ -354,12 +355,13 @@ func (c *MockServiceDeleteAipCall) DoAndReturn(f func(context.Context, uuid.UUID
 }
 
 // DownloadAip mocks base method.
-func (m *MockService) DownloadAip(arg0 context.Context, arg1 *storage.DownloadAipPayload) ([]byte, error) {
+func (m *MockService) DownloadAip(arg0 context.Context, arg1 *storage.DownloadAipPayload) (*storage.DownloadAipResult, io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadAip", arg0, arg1)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(*storage.DownloadAipResult)
+	ret1, _ := ret[1].(io.ReadCloser)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // DownloadAip indicates an expected call of DownloadAip.
@@ -375,19 +377,58 @@ type MockServiceDownloadAipCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockServiceDownloadAipCall) Return(arg0 []byte, arg1 error) *MockServiceDownloadAipCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockServiceDownloadAipCall) Return(arg0 *storage.DownloadAipResult, arg1 io.ReadCloser, arg2 error) *MockServiceDownloadAipCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockServiceDownloadAipCall) Do(f func(context.Context, *storage.DownloadAipPayload) ([]byte, error)) *MockServiceDownloadAipCall {
+func (c *MockServiceDownloadAipCall) Do(f func(context.Context, *storage.DownloadAipPayload) (*storage.DownloadAipResult, io.ReadCloser, error)) *MockServiceDownloadAipCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServiceDownloadAipCall) DoAndReturn(f func(context.Context, *storage.DownloadAipPayload) ([]byte, error)) *MockServiceDownloadAipCall {
+func (c *MockServiceDownloadAipCall) DoAndReturn(f func(context.Context, *storage.DownloadAipPayload) (*storage.DownloadAipResult, io.ReadCloser, error)) *MockServiceDownloadAipCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// DownloadAipRequest mocks base method.
+func (m *MockService) DownloadAipRequest(arg0 context.Context, arg1 *storage.DownloadAipRequestPayload) (*storage.DownloadAipRequestResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DownloadAipRequest", arg0, arg1)
+	ret0, _ := ret[0].(*storage.DownloadAipRequestResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DownloadAipRequest indicates an expected call of DownloadAipRequest.
+func (mr *MockServiceMockRecorder) DownloadAipRequest(arg0, arg1 any) *MockServiceDownloadAipRequestCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadAipRequest", reflect.TypeOf((*MockService)(nil).DownloadAipRequest), arg0, arg1)
+	return &MockServiceDownloadAipRequestCall{Call: call}
+}
+
+// MockServiceDownloadAipRequestCall wrap *gomock.Call
+type MockServiceDownloadAipRequestCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockServiceDownloadAipRequestCall) Return(arg0 *storage.DownloadAipRequestResult, arg1 error) *MockServiceDownloadAipRequestCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockServiceDownloadAipRequestCall) Do(f func(context.Context, *storage.DownloadAipRequestPayload) (*storage.DownloadAipRequestResult, error)) *MockServiceDownloadAipRequestCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockServiceDownloadAipRequestCall) DoAndReturn(f func(context.Context, *storage.DownloadAipRequestPayload) (*storage.DownloadAipRequestResult, error)) *MockServiceDownloadAipRequestCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/storage/service_test.go
+++ b/internal/storage/service_test.go
@@ -51,6 +51,7 @@ type setUpAttrs struct {
 	persistenceMock    *fake.MockStorage
 	temporalClientMock *temporalsdk_mocks.Client
 	tokenVerifier      auth.TokenVerifier
+	ticketProvider     *auth.TicketProvider
 }
 
 func setUpService(t *testing.T, attrs *setUpAttrs) storage.Service {
@@ -93,6 +94,9 @@ func setUpService(t *testing.T, attrs *setUpAttrs) storage.Service {
 	if attrs.tokenVerifier != nil {
 		params.tokenVerifier = attrs.tokenVerifier
 	}
+	if attrs.ticketProvider != nil {
+		params.ticketProvider = attrs.ticketProvider
+	}
 
 	*attrs = params
 
@@ -102,6 +106,7 @@ func setUpService(t *testing.T, attrs *setUpAttrs) storage.Service {
 		*params.persistence,
 		*params.temporalClient,
 		params.tokenVerifier,
+		params.ticketProvider,
 		rand.New(rand.NewSource(1)), // #nosec: G404
 	)
 	assert.NilError(t, err)
@@ -132,6 +137,7 @@ func TestNewService(t *testing.T) {
 			nil,
 			nil,
 			&auth.OIDCTokenVerifier{},
+			nil,
 			nil,
 		)
 
@@ -500,16 +506,6 @@ func TestServiceLocation(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestServiceDownload(t *testing.T) {
-	t.Parallel()
-
-	svc := setUpService(t, &setUpAttrs{})
-
-	blob, err := svc.DownloadAip(context.Background(), &goastorage.DownloadAipPayload{})
-	assert.NilError(t, err)
-	assert.DeepEqual(t, blob, []byte{}) // Not implemented.
 }
 
 func TestServiceList(t *testing.T) {


### PR DESCRIPTION
Follow the implementation for SIP download made in #1253 and #1266.
Do not overwrite the download endpoint to set the wirte timeout, create
request download and actual download endpoints following the Goa server
stubs. Update dashboard code to request in two steps using a cookie.

Refs #1265.