### PR TITLE
Remove flaky assertion from internal/sftp tests

### DIFF
--- a/internal/sftp/goclient_test.go
+++ b/internal/sftp/goclient_test.go
@@ -414,10 +414,9 @@ func TestUploadDirectory(t *testing.T) {
 				assert.Assert(t, reflect.TypeOf(err) == reflect.TypeOf(tc.wantErr))
 				return
 			}
-			assert.NilError(t, err)
 
+			assert.NilError(t, err)
 			assert.Equal(t, remotePath, tc.cfg.RemoteDir+"/"+filepath.Base(tc.params.src))
-			assert.Equal(t, upload.Bytes(), int64(0)) // Upload hasn't started yet.
 
 			select {
 			case <-upload.Done():


### PR DESCRIPTION
UploadDirectory works asynchronously and the upload may have started.

Re: https://github.com/artefactual-sdps/enduro/actions/runs/15854822602/job/44697344746?pr=1267