### PR TITLE
Use UUIDs as identifiers for workflows and tasks

### DIFF
--- a/dashboard/src/components/__tests__/Task.test.ts
+++ b/dashboard/src/components/__tests__/Task.test.ts
@@ -12,12 +12,11 @@ describe("Task.vue", () => {
       props: {
         index: 1,
         task: {
-          id: 1,
+          uuid: "task-uuid",
           name: "Task 1",
           startedAt: new Date("2020-02-25T17:21:03Z"),
           completedAt: new Date("2020-02-25T17:22:38Z"),
           status: "done",
-          taskId: "9614f71f-c21e-4da9-a07e-1661bd010d1f",
           note: "This is a note\nwith multiple lines",
         },
       },
@@ -44,11 +43,10 @@ describe("Task.vue", () => {
       props: {
         index: 1,
         task: {
-          id: 1,
+          uuid: "task-uuid",
           name: "Task 1",
           startedAt: new Date("2020-02-25T17:21:03Z"),
           status: "in progress",
-          taskId: "9614f71f-c21e-4da9-a07e-1661bd010d1f",
         },
       },
     });
@@ -84,12 +82,11 @@ describe("Task.vue", () => {
       props: {
         index: 1,
         task: {
-          id: 1,
+          uuid: "task-uuid",
           name: "Task 1",
           startedAt: new Date("2020-02-25T17:21:03Z"),
           completedAt: new Date("2020-02-25T17:22:38Z"),
           status: "done",
-          taskId: "9614f71f-c21e-4da9-a07e-1661bd010d1f",
           note: "This note is only one line",
         },
       },

--- a/dashboard/src/monitor.ts
+++ b/dashboard/src/monitor.ts
@@ -75,7 +75,7 @@ function handleWorkflowUpdated(data: unknown) {
   if (store.current?.uuid != event.item.sipUuid) return;
 
   // Find and update the workflow.
-  const workflow = store.getWorkflowById(event.id);
+  const workflow = store.getWorkflowById(event.uuid);
   if (!workflow) return;
 
   // Keep existing tasks, this event doesn't include them.
@@ -89,10 +89,10 @@ function handleTaskCreated(data: unknown) {
   const store = useSipStore();
 
   // Find and update the workflow.
-  if (!event.item.workflowId) return;
-  const workflow = store.getWorkflowById(event.item.workflowId);
+  if (!event.item.workflowUuid) return;
+  const workflow = store.getWorkflowById(event.item.workflowUuid);
   if (!workflow) return;
-  if (workflow.id === event.item.workflowId) {
+  if (workflow.uuid === event.item.workflowUuid) {
     if (!workflow.tasks) workflow.tasks = [];
     workflow.tasks.push(event.item);
   }
@@ -102,8 +102,8 @@ function handleTaskUpdated(data: unknown) {
   const event = api.SIPTaskUpdatedEventFromJSON(data);
   const store = useSipStore();
 
-  if (!event.item.workflowId) return;
-  const task = store.getTaskById(event.item.workflowId, event.id);
+  if (!event.item.workflowUuid) return;
+  const task = store.getTaskById(event.item.workflowUuid, event.uuid);
   if (!task) return;
   Object.assign(task, event.item);
 }

--- a/dashboard/src/openapi-generator/models/EnduroIngestSipTask.ts
+++ b/dashboard/src/openapi-generator/models/EnduroIngestSipTask.ts
@@ -27,12 +27,6 @@ export interface EnduroIngestSipTask {
     completedAt?: Date;
     /**
      * 
-     * @type {number}
-     * @memberof EnduroIngestSipTask
-     */
-    id: number;
-    /**
-     * 
      * @type {string}
      * @memberof EnduroIngestSipTask
      */
@@ -56,17 +50,17 @@ export interface EnduroIngestSipTask {
      */
     status: EnduroIngestSipTaskStatusEnum;
     /**
-     * 
+     * Identifier of the task
      * @type {string}
      * @memberof EnduroIngestSipTask
      */
-    taskId: string;
+    uuid: string;
     /**
-     * 
-     * @type {number}
+     * Identifier of related workflow
+     * @type {string}
      * @memberof EnduroIngestSipTask
      */
-    workflowId?: number;
+    workflowUuid: string;
 }
 
 
@@ -90,11 +84,11 @@ export type EnduroIngestSipTaskStatusEnum = typeof EnduroIngestSipTaskStatusEnum
  */
 export function instanceOfEnduroIngestSipTask(value: object): boolean {
     let isInstance = true;
-    isInstance = isInstance && "id" in value;
     isInstance = isInstance && "name" in value;
     isInstance = isInstance && "startedAt" in value;
     isInstance = isInstance && "status" in value;
-    isInstance = isInstance && "taskId" in value;
+    isInstance = isInstance && "uuid" in value;
+    isInstance = isInstance && "workflowUuid" in value;
 
     return isInstance;
 }
@@ -110,13 +104,12 @@ export function EnduroIngestSipTaskFromJSONTyped(json: any, ignoreDiscriminator:
     return {
         
         'completedAt': !exists(json, 'completed_at') ? undefined : (new Date(json['completed_at'])),
-        'id': json['id'],
         'name': json['name'],
         'note': !exists(json, 'note') ? undefined : json['note'],
         'startedAt': (new Date(json['started_at'])),
         'status': json['status'],
-        'taskId': json['task_id'],
-        'workflowId': !exists(json, 'workflow_id') ? undefined : json['workflow_id'],
+        'uuid': json['uuid'],
+        'workflowUuid': json['workflow_uuid'],
     };
 }
 
@@ -130,13 +123,12 @@ export function EnduroIngestSipTaskToJSON(value?: EnduroIngestSipTask | null): a
     return {
         
         'completed_at': value.completedAt === undefined ? undefined : (value.completedAt.toISOString()),
-        'id': value.id,
         'name': value.name,
         'note': value.note,
         'started_at': (value.startedAt.toISOString()),
         'status': value.status,
-        'task_id': value.taskId,
-        'workflow_id': value.workflowId,
+        'uuid': value.uuid,
+        'workflow_uuid': value.workflowUuid,
     };
 }
 

--- a/dashboard/src/openapi-generator/models/EnduroIngestSipWorkflow.ts
+++ b/dashboard/src/openapi-generator/models/EnduroIngestSipWorkflow.ts
@@ -33,12 +33,6 @@ export interface EnduroIngestSipWorkflow {
      */
     completedAt?: Date;
     /**
-     * 
-     * @type {number}
-     * @memberof EnduroIngestSipWorkflow
-     */
-    id: number;
-    /**
      * Identifier of related SIP
      * @type {string}
      * @memberof EnduroIngestSipWorkflow
@@ -74,6 +68,12 @@ export interface EnduroIngestSipWorkflow {
      * @memberof EnduroIngestSipWorkflow
      */
     type: EnduroIngestSipWorkflowTypeEnum;
+    /**
+     * Identifier of the workflow
+     * @type {string}
+     * @memberof EnduroIngestSipWorkflow
+     */
+    uuid: string;
 }
 
 
@@ -106,12 +106,12 @@ export type EnduroIngestSipWorkflowTypeEnum = typeof EnduroIngestSipWorkflowType
  */
 export function instanceOfEnduroIngestSipWorkflow(value: object): boolean {
     let isInstance = true;
-    isInstance = isInstance && "id" in value;
     isInstance = isInstance && "sipUuid" in value;
     isInstance = isInstance && "startedAt" in value;
     isInstance = isInstance && "status" in value;
     isInstance = isInstance && "temporalId" in value;
     isInstance = isInstance && "type" in value;
+    isInstance = isInstance && "uuid" in value;
 
     return isInstance;
 }
@@ -127,13 +127,13 @@ export function EnduroIngestSipWorkflowFromJSONTyped(json: any, ignoreDiscrimina
     return {
         
         'completedAt': !exists(json, 'completed_at') ? undefined : (new Date(json['completed_at'])),
-        'id': json['id'],
         'sipUuid': json['sip_uuid'],
         'startedAt': (new Date(json['started_at'])),
         'status': json['status'],
         'tasks': !exists(json, 'tasks') ? undefined : ((json['tasks'] as Array<any>).map(EnduroIngestSipTaskFromJSON)),
         'temporalId': json['temporal_id'],
         'type': json['type'],
+        'uuid': json['uuid'],
     };
 }
 
@@ -147,13 +147,13 @@ export function EnduroIngestSipWorkflowToJSON(value?: EnduroIngestSipWorkflow | 
     return {
         
         'completed_at': value.completedAt === undefined ? undefined : (value.completedAt.toISOString()),
-        'id': value.id,
         'sip_uuid': value.sipUuid,
         'started_at': (value.startedAt.toISOString()),
         'status': value.status,
         'tasks': value.tasks === undefined ? undefined : ((value.tasks as Array<any>).map(EnduroIngestSipTaskToJSON)),
         'temporal_id': value.temporalId,
         'type': value.type,
+        'uuid': value.uuid,
     };
 }
 

--- a/dashboard/src/openapi-generator/models/SIPTaskCreatedEvent.ts
+++ b/dashboard/src/openapi-generator/models/SIPTaskCreatedEvent.ts
@@ -27,17 +27,17 @@ import {
  */
 export interface SIPTaskCreatedEvent {
     /**
-     * Identifier of task
-     * @type {number}
-     * @memberof SIPTaskCreatedEvent
-     */
-    id: number;
-    /**
      * 
      * @type {EnduroIngestSipTask}
      * @memberof SIPTaskCreatedEvent
      */
     item: EnduroIngestSipTask;
+    /**
+     * Identifier of task
+     * @type {string}
+     * @memberof SIPTaskCreatedEvent
+     */
+    uuid: string;
 }
 
 /**
@@ -45,8 +45,8 @@ export interface SIPTaskCreatedEvent {
  */
 export function instanceOfSIPTaskCreatedEvent(value: object): boolean {
     let isInstance = true;
-    isInstance = isInstance && "id" in value;
     isInstance = isInstance && "item" in value;
+    isInstance = isInstance && "uuid" in value;
 
     return isInstance;
 }
@@ -61,8 +61,8 @@ export function SIPTaskCreatedEventFromJSONTyped(json: any, ignoreDiscriminator:
     }
     return {
         
-        'id': json['id'],
         'item': EnduroIngestSipTaskFromJSON(json['item']),
+        'uuid': json['uuid'],
     };
 }
 
@@ -75,8 +75,8 @@ export function SIPTaskCreatedEventToJSON(value?: SIPTaskCreatedEvent | null): a
     }
     return {
         
-        'id': value.id,
         'item': EnduroIngestSipTaskToJSON(value.item),
+        'uuid': value.uuid,
     };
 }
 

--- a/dashboard/src/openapi-generator/models/SIPTaskUpdatedEvent.ts
+++ b/dashboard/src/openapi-generator/models/SIPTaskUpdatedEvent.ts
@@ -27,17 +27,17 @@ import {
  */
 export interface SIPTaskUpdatedEvent {
     /**
-     * Identifier of task
-     * @type {number}
-     * @memberof SIPTaskUpdatedEvent
-     */
-    id: number;
-    /**
      * 
      * @type {EnduroIngestSipTask}
      * @memberof SIPTaskUpdatedEvent
      */
     item: EnduroIngestSipTask;
+    /**
+     * Identifier of task
+     * @type {string}
+     * @memberof SIPTaskUpdatedEvent
+     */
+    uuid: string;
 }
 
 /**
@@ -45,8 +45,8 @@ export interface SIPTaskUpdatedEvent {
  */
 export function instanceOfSIPTaskUpdatedEvent(value: object): boolean {
     let isInstance = true;
-    isInstance = isInstance && "id" in value;
     isInstance = isInstance && "item" in value;
+    isInstance = isInstance && "uuid" in value;
 
     return isInstance;
 }
@@ -61,8 +61,8 @@ export function SIPTaskUpdatedEventFromJSONTyped(json: any, ignoreDiscriminator:
     }
     return {
         
-        'id': json['id'],
         'item': EnduroIngestSipTaskFromJSON(json['item']),
+        'uuid': json['uuid'],
     };
 }
 
@@ -75,8 +75,8 @@ export function SIPTaskUpdatedEventToJSON(value?: SIPTaskUpdatedEvent | null): a
     }
     return {
         
-        'id': value.id,
         'item': EnduroIngestSipTaskToJSON(value.item),
+        'uuid': value.uuid,
     };
 }
 

--- a/dashboard/src/openapi-generator/models/SIPWorkflowCreatedEvent.ts
+++ b/dashboard/src/openapi-generator/models/SIPWorkflowCreatedEvent.ts
@@ -27,17 +27,17 @@ import {
  */
 export interface SIPWorkflowCreatedEvent {
     /**
-     * Identifier of workflow
-     * @type {number}
-     * @memberof SIPWorkflowCreatedEvent
-     */
-    id: number;
-    /**
      * 
      * @type {EnduroIngestSipWorkflow}
      * @memberof SIPWorkflowCreatedEvent
      */
     item: EnduroIngestSipWorkflow;
+    /**
+     * Identifier of workflow
+     * @type {string}
+     * @memberof SIPWorkflowCreatedEvent
+     */
+    uuid: string;
 }
 
 /**
@@ -45,8 +45,8 @@ export interface SIPWorkflowCreatedEvent {
  */
 export function instanceOfSIPWorkflowCreatedEvent(value: object): boolean {
     let isInstance = true;
-    isInstance = isInstance && "id" in value;
     isInstance = isInstance && "item" in value;
+    isInstance = isInstance && "uuid" in value;
 
     return isInstance;
 }
@@ -61,8 +61,8 @@ export function SIPWorkflowCreatedEventFromJSONTyped(json: any, ignoreDiscrimina
     }
     return {
         
-        'id': json['id'],
         'item': EnduroIngestSipWorkflowFromJSON(json['item']),
+        'uuid': json['uuid'],
     };
 }
 
@@ -75,8 +75,8 @@ export function SIPWorkflowCreatedEventToJSON(value?: SIPWorkflowCreatedEvent | 
     }
     return {
         
-        'id': value.id,
         'item': EnduroIngestSipWorkflowToJSON(value.item),
+        'uuid': value.uuid,
     };
 }
 

--- a/dashboard/src/openapi-generator/models/SIPWorkflowUpdatedEvent.ts
+++ b/dashboard/src/openapi-generator/models/SIPWorkflowUpdatedEvent.ts
@@ -27,17 +27,17 @@ import {
  */
 export interface SIPWorkflowUpdatedEvent {
     /**
-     * Identifier of workflow
-     * @type {number}
-     * @memberof SIPWorkflowUpdatedEvent
-     */
-    id: number;
-    /**
      * 
      * @type {EnduroIngestSipWorkflow}
      * @memberof SIPWorkflowUpdatedEvent
      */
     item: EnduroIngestSipWorkflow;
+    /**
+     * Identifier of workflow
+     * @type {string}
+     * @memberof SIPWorkflowUpdatedEvent
+     */
+    uuid: string;
 }
 
 /**
@@ -45,8 +45,8 @@ export interface SIPWorkflowUpdatedEvent {
  */
 export function instanceOfSIPWorkflowUpdatedEvent(value: object): boolean {
     let isInstance = true;
-    isInstance = isInstance && "id" in value;
     isInstance = isInstance && "item" in value;
+    isInstance = isInstance && "uuid" in value;
 
     return isInstance;
 }
@@ -61,8 +61,8 @@ export function SIPWorkflowUpdatedEventFromJSONTyped(json: any, ignoreDiscrimina
     }
     return {
         
-        'id': json['id'],
         'item': EnduroIngestSipWorkflowFromJSON(json['item']),
+        'uuid': json['uuid'],
     };
 }
 
@@ -75,8 +75,8 @@ export function SIPWorkflowUpdatedEventToJSON(value?: SIPWorkflowUpdatedEvent | 
     }
     return {
         
-        'id': value.id,
         'item': EnduroIngestSipWorkflowToJSON(value.item),
+        'uuid': value.uuid,
     };
 }
 

--- a/dashboard/src/pages/ingest/sips/[id]/index.vue
+++ b/dashboard/src/pages/ingest/sips/[id]/index.vue
@@ -107,7 +107,7 @@ onMounted(() => {
           :workflow="workflow"
           :index="index"
           v-for="(workflow, index) in sipStore.currentWorkflows?.workflows"
-          v-bind:key="workflow.id"
+          v-bind:key="workflow.uuid"
         />
       </div>
     </div>

--- a/dashboard/src/stores/__tests__/sip.test.ts
+++ b/dashboard/src/stores/__tests__/sip.test.ts
@@ -36,14 +36,14 @@ describe("useSipStore", () => {
       currentWorkflows: {
         workflows: [
           {
-            id: 1,
+            uuid: "workflow-uuid-1",
             type: api.EnduroIngestSipWorkflowTypeEnum.CreateAip,
             startedAt: now,
             status: api.EnduroIngestSipWorkflowStatusEnum.Done,
             temporalId: "c18d00f2-a1c4-4161-820c-6fc6ce707811",
           },
           {
-            id: 2,
+            uuid: "workflow-uuid-2",
             type: api.EnduroIngestSipWorkflowTypeEnum.CreateAndReviewAip,
             startedAt: now,
             status: api.EnduroIngestSipWorkflowStatusEnum.Done,
@@ -53,21 +53,21 @@ describe("useSipStore", () => {
       },
     });
 
-    expect(sipStore.getWorkflowById(1)).toEqual({
-      id: 1,
+    expect(sipStore.getWorkflowById("workflow-uuid-1")).toEqual({
+      uuid: "workflow-uuid-1",
       type: api.EnduroIngestSipWorkflowTypeEnum.CreateAip,
       startedAt: now,
       status: api.EnduroIngestSipWorkflowStatusEnum.Done,
       temporalId: "c18d00f2-a1c4-4161-820c-6fc6ce707811",
     });
-    expect(sipStore.getWorkflowById(2)).toEqual({
-      id: 2,
+    expect(sipStore.getWorkflowById("workflow-uuid-2")).toEqual({
+      uuid: "workflow-uuid-2",
       type: api.EnduroIngestSipWorkflowTypeEnum.CreateAndReviewAip,
       startedAt: now,
       status: api.EnduroIngestSipWorkflowStatusEnum.Done,
       temporalId: "051cf998-6f87-4461-8091-8561ebf479c4",
     });
-    expect(sipStore.getWorkflowById(3)).toBeUndefined();
+    expect(sipStore.getWorkflowById("workflow-uuid-3")).toBeUndefined();
   });
 
   it("getTaskById finds tasks", () => {
@@ -77,48 +77,44 @@ describe("useSipStore", () => {
       currentWorkflows: {
         workflows: [
           {
-            id: 1,
+            uuid: "workflow-uuid-1",
             type: api.EnduroIngestSipWorkflowTypeEnum.CreateAip,
             startedAt: now,
             status: api.EnduroIngestSipWorkflowStatusEnum.Done,
             temporalId: "c18d00f2-a1c4-4161-820c-6fc6ce707811",
             tasks: [
               {
-                id: 1,
+                uuid: "task-uuid-1",
                 name: "Task 1",
                 startedAt: now,
                 status: api.EnduroIngestSipTaskStatusEnum.Done,
-                taskId: "1",
               },
               {
-                id: 2,
+                uuid: "task-uuid-2",
                 name: "Task 2",
                 startedAt: now,
                 status: api.EnduroIngestSipTaskStatusEnum.Done,
-                taskId: "2",
               },
             ],
           },
           {
-            id: 2,
+            uuid: "workflow-uuid-2",
             type: api.EnduroIngestSipWorkflowTypeEnum.CreateAndReviewAip,
             startedAt: now,
             status: api.EnduroIngestSipWorkflowStatusEnum.Done,
             temporalId: "051cf998-6f87-4461-8091-8561ebf479c4",
             tasks: [
               {
-                id: 3,
+                uuid: "task-uuid-3",
                 name: "Task 3",
                 startedAt: now,
                 status: api.EnduroIngestSipTaskStatusEnum.Done,
-                taskId: "3",
               },
               {
-                id: 4,
+                uuid: "task-uuid-4",
                 name: "Task 4",
                 startedAt: now,
                 status: api.EnduroIngestSipTaskStatusEnum.Done,
-                taskId: "4",
               },
             ],
           },
@@ -126,37 +122,37 @@ describe("useSipStore", () => {
       },
     });
 
-    expect(sipStore.getTaskById(1, 1)).toEqual({
-      id: 1,
+    expect(sipStore.getTaskById("workflow-uuid-1", "task-uuid-1")).toEqual({
+      uuid: "task-uuid-1",
       name: "Task 1",
       startedAt: now,
       status: api.EnduroIngestSipTaskStatusEnum.Done,
-      taskId: "1",
     });
-    expect(sipStore.getTaskById(1, 2)).toEqual({
-      id: 2,
+    expect(sipStore.getTaskById("workflow-uuid-1", "task-uuid-2")).toEqual({
+      uuid: "task-uuid-2",
       name: "Task 2",
       startedAt: now,
       status: api.EnduroIngestSipTaskStatusEnum.Done,
-      taskId: "2",
     });
-    expect(sipStore.getTaskById(1, 3)).toBeUndefined();
+    expect(
+      sipStore.getTaskById("workflow-uuid-1", "task-uuid-3"),
+    ).toBeUndefined();
 
-    expect(sipStore.getTaskById(2, 3)).toEqual({
-      id: 3,
+    expect(sipStore.getTaskById("workflow-uuid-2", "task-uuid-3")).toEqual({
+      uuid: "task-uuid-3",
       name: "Task 3",
       startedAt: now,
       status: api.EnduroIngestSipTaskStatusEnum.Done,
-      taskId: "3",
     });
-    expect(sipStore.getTaskById(2, 4)).toEqual({
-      id: 4,
+    expect(sipStore.getTaskById("workflow-uuid-2", "task-uuid-4")).toEqual({
+      uuid: "task-uuid-4",
       name: "Task 4",
       startedAt: now,
       status: api.EnduroIngestSipTaskStatusEnum.Done,
-      taskId: "4",
     });
-    expect(sipStore.getTaskById(2, 5)).toBeUndefined();
+    expect(
+      sipStore.getTaskById("workflow-uuid-2", "task-uuid-5"),
+    ).toBeUndefined();
   });
 
   it("fetches current SIP", async () => {
@@ -207,7 +203,7 @@ describe("useSipStore", () => {
     const mockWorkflows: api.SIPWorkflows = {
       workflows: [
         {
-          id: 1,
+          uuid: "workflow-uuid-1",
           startedAt: new Date("2025-01-01T00:00:00Z"),
           status: api.EnduroIngestSipWorkflowStatusEnum.Done,
           type: api.EnduroIngestSipWorkflowTypeEnum.CreateAip,
@@ -222,7 +218,7 @@ describe("useSipStore", () => {
       .mockResolvedValue(mockWorkflows);
 
     const store = useSipStore();
-    await store.fetchCurrentWorkflows("1");
+    await store.fetchCurrentWorkflows("sip-uuid");
 
     expect(store.currentWorkflows).toEqual(mockWorkflows);
   });
@@ -238,7 +234,7 @@ describe("useSipStore", () => {
         "Response returned an error code",
       ),
     );
-    await expect(store.fetchCurrentWorkflows("1")).rejects.toThrow(
+    await expect(store.fetchCurrentWorkflows("sip-uuid")).rejects.toThrow(
       "Couldn't load workflows",
     );
     expect(store.currentWorkflows).toBeNull();
@@ -257,7 +253,9 @@ describe("useSipStore", () => {
       ),
     );
 
-    await expect(store.fetchCurrentWorkflows("1")).resolves.toBeUndefined();
+    await expect(
+      store.fetchCurrentWorkflows("sip-uuid"),
+    ).resolves.toBeUndefined();
     expect(store.currentWorkflows).toBeNull();
   });
 

--- a/dashboard/src/stores/sip.ts
+++ b/dashboard/src/stores/sip.ts
@@ -36,24 +36,26 @@ export const useSipStore = defineStore("sip", {
       return this.current?.status == api.EnduroIngestSipStatusEnum.Pending;
     },
     getWorkflowById: (state) => {
-      return (workflowId: number): api.EnduroIngestSipWorkflow | undefined => {
+      return (workflowId: string): api.EnduroIngestSipWorkflow | undefined => {
         const x = state.currentWorkflows?.workflows?.find(
-          (workflow: api.EnduroIngestSipWorkflow) => workflow.id === workflowId,
+          (workflow: api.EnduroIngestSipWorkflow) =>
+            workflow.uuid === workflowId,
         );
         return x;
       };
     },
     getTaskById: (state) => {
       return (
-        workflowId: number,
-        taskId: number,
+        workflowId: string,
+        taskId: string,
       ): api.EnduroIngestSipTask | undefined => {
         const workflow = state.currentWorkflows?.workflows?.find(
-          (workflow: api.EnduroIngestSipWorkflow) => workflow.id === workflowId,
+          (workflow: api.EnduroIngestSipWorkflow) =>
+            workflow.uuid === workflowId,
         );
         if (!workflow) return;
         return workflow.tasks?.find(
-          (task: api.EnduroIngestSipTask) => task.id === taskId,
+          (task: api.EnduroIngestSipTask) => task.uuid === taskId,
         );
       };
     },

--- a/docs/src/dev-manual/api/openapi3.json
+++ b/docs/src/dev-manual/api/openapi3.json
@@ -504,24 +504,18 @@
         "description": "SIPTask describes a SIP workflow task.",
         "example": {
           "completed_at": "1970-01-01T00:00:01Z",
-          "id": 1,
           "name": "abc123",
           "note": "abc123",
           "started_at": "1970-01-01T00:00:01Z",
           "status": "in progress",
-          "task_id": "abc123",
-          "workflow_id": 1
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+          "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         },
         "properties": {
           "completed_at": {
             "example": "1970-01-01T00:00:01Z",
             "format": "date-time",
             "type": "string"
-          },
-          "id": {
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
           },
           "name": {
             "example": "abc123",
@@ -549,22 +543,23 @@
             "example": "in progress",
             "type": "string"
           },
-          "task_id": {
-            "example": "abc123",
+          "uuid": {
+            "description": "Identifier of the task",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "type": "string"
           },
-          "workflow_id": {
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
+          "workflow_uuid": {
+            "description": "Identifier of related workflow",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
           }
         },
         "required": [
-          "id",
-          "task_id",
+          "uuid",
           "name",
           "status",
-          "started_at"
+          "started_at",
+          "workflow_uuid"
         ],
         "type": "object"
       },
@@ -572,35 +567,29 @@
         "description": "SIPWorkflow describes a workflow of a SIP.",
         "example": {
           "completed_at": "1970-01-01T00:00:01Z",
-          "id": 1,
           "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
           "started_at": "1970-01-01T00:00:01Z",
           "status": "in progress",
           "tasks": [
             {
               "completed_at": "1970-01-01T00:00:01Z",
-              "id": 1,
               "name": "abc123",
               "note": "abc123",
               "started_at": "1970-01-01T00:00:01Z",
               "status": "in progress",
-              "task_id": "abc123",
-              "workflow_id": 1
+              "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+              "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
             }
           ],
           "temporal_id": "abc123",
-          "type": "create and review aip"
+          "type": "create and review aip",
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         },
         "properties": {
           "completed_at": {
             "example": "1970-01-01T00:00:01Z",
             "format": "date-time",
             "type": "string"
-          },
-          "id": {
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
           },
           "sip_uuid": {
             "description": "Identifier of related SIP",
@@ -639,10 +628,15 @@
             ],
             "example": "create and review aip",
             "type": "string"
+          },
+          "uuid": {
+            "description": "Identifier of the workflow",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
           }
         },
         "required": [
-          "id",
+          "uuid",
           "temporal_id",
           "type",
           "status",
@@ -1411,13 +1405,12 @@
         "example": [
           {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "name": "abc123",
             "note": "abc123",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
-            "task_id": "abc123",
-            "workflow_id": 1
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
           }
         ],
         "items": {
@@ -1427,62 +1420,58 @@
       },
       "SIPTaskCreatedEvent": {
         "example": {
-          "id": 1,
           "item": {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "name": "abc123",
             "note": "abc123",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
-            "task_id": "abc123",
-            "workflow_id": 1
-          }
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+          },
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         },
         "properties": {
-          "id": {
-            "description": "Identifier of task",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          },
           "item": {
             "$ref": "#/components/schemas/EnduroIngestSipTask"
+          },
+          "uuid": {
+            "description": "Identifier of task",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
           }
         },
         "required": [
-          "id",
+          "uuid",
           "item"
         ],
         "type": "object"
       },
       "SIPTaskUpdatedEvent": {
         "example": {
-          "id": 1,
           "item": {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "name": "abc123",
             "note": "abc123",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
-            "task_id": "abc123",
-            "workflow_id": 1
-          }
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+          },
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         },
         "properties": {
-          "id": {
-            "description": "Identifier of task",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          },
           "item": {
             "$ref": "#/components/schemas/EnduroIngestSipTask"
+          },
+          "uuid": {
+            "description": "Identifier of task",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
           }
         },
         "required": [
-          "id",
+          "uuid",
           "item"
         ],
         "type": "object"
@@ -1525,24 +1514,23 @@
         "example": [
           {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
             "tasks": [
               {
                 "completed_at": "1970-01-01T00:00:01Z",
-                "id": 1,
                 "name": "abc123",
                 "note": "abc123",
                 "started_at": "1970-01-01T00:00:01Z",
                 "status": "in progress",
-                "task_id": "abc123",
-                "workflow_id": 1
+                "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+                "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
               }
             ],
             "temporal_id": "abc123",
-            "type": "create and review aip"
+            "type": "create and review aip",
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
           }
         ],
         "items": {
@@ -1552,84 +1540,80 @@
       },
       "SIPWorkflowCreatedEvent": {
         "example": {
-          "id": 1,
           "item": {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
             "tasks": [
               {
                 "completed_at": "1970-01-01T00:00:01Z",
-                "id": 1,
                 "name": "abc123",
                 "note": "abc123",
                 "started_at": "1970-01-01T00:00:01Z",
                 "status": "in progress",
-                "task_id": "abc123",
-                "workflow_id": 1
+                "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+                "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
               }
             ],
             "temporal_id": "abc123",
-            "type": "create and review aip"
-          }
+            "type": "create and review aip",
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+          },
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         },
         "properties": {
-          "id": {
-            "description": "Identifier of workflow",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          },
           "item": {
             "$ref": "#/components/schemas/EnduroIngestSipWorkflow"
+          },
+          "uuid": {
+            "description": "Identifier of workflow",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
           }
         },
         "required": [
-          "id",
+          "uuid",
           "item"
         ],
         "type": "object"
       },
       "SIPWorkflowUpdatedEvent": {
         "example": {
-          "id": 1,
           "item": {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
             "tasks": [
               {
                 "completed_at": "1970-01-01T00:00:01Z",
-                "id": 1,
                 "name": "abc123",
                 "note": "abc123",
                 "started_at": "1970-01-01T00:00:01Z",
                 "status": "in progress",
-                "task_id": "abc123",
-                "workflow_id": 1
+                "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+                "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
               }
             ],
             "temporal_id": "abc123",
-            "type": "create and review aip"
-          }
+            "type": "create and review aip",
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+          },
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         },
         "properties": {
-          "id": {
-            "description": "Identifier of workflow",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          },
           "item": {
             "$ref": "#/components/schemas/EnduroIngestSipWorkflow"
+          },
+          "uuid": {
+            "description": "Identifier of workflow",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
           }
         },
         "required": [
-          "id",
+          "uuid",
           "item"
         ],
         "type": "object"
@@ -1639,24 +1623,23 @@
           "workflows": [
             {
               "completed_at": "1970-01-01T00:00:01Z",
-              "id": 1,
               "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
               "started_at": "1970-01-01T00:00:01Z",
               "status": "in progress",
               "tasks": [
                 {
                   "completed_at": "1970-01-01T00:00:01Z",
-                  "id": 1,
                   "name": "abc123",
                   "note": "abc123",
                   "started_at": "1970-01-01T00:00:01Z",
                   "status": "in progress",
-                  "task_id": "abc123",
-                  "workflow_id": 1
+                  "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+                  "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
                 }
               ],
               "temporal_id": "abc123",
-              "type": "create and review aip"
+              "type": "create and review aip",
+              "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
             }
           ]
         },
@@ -2855,24 +2838,23 @@
                   "workflows": [
                     {
                       "completed_at": "1970-01-01T00:00:01Z",
-                      "id": 1,
                       "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
                       "started_at": "1970-01-01T00:00:01Z",
                       "status": "in progress",
                       "tasks": [
                         {
                           "completed_at": "1970-01-01T00:00:01Z",
-                          "id": 1,
                           "name": "abc123",
                           "note": "abc123",
                           "started_at": "1970-01-01T00:00:01Z",
                           "status": "in progress",
-                          "task_id": "abc123",
-                          "workflow_id": 1
+                          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+                          "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
                         }
                       ],
                       "temporal_id": "abc123",
-                      "type": "create and review aip"
+                      "type": "create and review aip",
+                      "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
                     }
                   ]
                 },

--- a/internal/a3m/a3m_test.go
+++ b/internal/a3m/a3m_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	transferservice "buf.build/gen/go/artefactual/a3m/protocolbuffers/go/a3m/api/transferservice/v1beta1"
+	"github.com/google/uuid"
 	"go.artefactual.dev/tools/mockutil"
 	"go.opentelemetry.io/otel/trace/noop"
 	temporalsdk_activity "go.temporal.io/sdk/activity"
@@ -25,6 +26,7 @@ import (
 func TestCreateAIPActivity(t *testing.T) {
 	t.Parallel()
 
+	taskUUID := uuid.New()
 	ts := &temporalsdk_testsuite.WorkflowTestSuite{}
 	env := ts.NewTestActivityEnvironment()
 	ctrl := gomock.NewController(t)
@@ -53,7 +55,7 @@ func TestCreateAIPActivity(t *testing.T) {
 			&transferservice.ReadResponse{
 				Jobs: []*transferservice.Job{
 					{
-						Id:        "721f6e04-ce12-42b6-a53c-482dc1571d5a",
+						Id:        taskUUID.String(),
 						Status:    transferservice.Job_STATUS_COMPLETE,
 						StartTime: timestamppb.New(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)),
 					},
@@ -64,7 +66,7 @@ func TestCreateAIPActivity(t *testing.T) {
 
 	ingestsvc := ingest_fake.NewMockService(ctrl)
 	ingestsvc.EXPECT().CreateTask(mockutil.Context(), &datatypes.Task{
-		TaskID: "721f6e04-ce12-42b6-a53c-482dc1571d5a",
+		UUID:   taskUUID,
 		Status: enums.TaskStatusDone,
 		StartedAt: sql.NullTime{
 			Time:  time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),

--- a/internal/am/poll_ingest.go
+++ b/internal/am/poll_ingest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"go.artefactual.dev/amclient"
 	temporal_tools "go.artefactual.dev/tools/temporal"
@@ -16,8 +17,8 @@ import (
 const PollIngestActivityName = "poll-ingest-activity"
 
 type PollIngestActivityParams struct {
-	WorkflowID int
-	SIPID      string
+	WorkflowUUID uuid.UUID
+	SIPID        string
 }
 
 type PollIngestActivity struct {
@@ -62,12 +63,12 @@ func (a *PollIngestActivity) Execute(
 ) (*PollIngestActivityResult, error) {
 	logger := temporal_tools.GetLogger(ctx)
 	logger.V(1).Info("Executing PollIngestActivity",
-		"WorkflowID", params.WorkflowID,
+		"WorkflowUUID", params.WorkflowUUID,
 		"SIPID", params.SIPID,
 	)
 
 	var taskCount int
-	jobTracker := NewJobTracker(a.clock, a.jobSvc, a.ingestsvc, params.WorkflowID)
+	jobTracker := NewJobTracker(a.clock, a.jobSvc, a.ingestsvc, params.WorkflowUUID)
 	ticker := time.NewTicker(a.cfg.PollInterval)
 	defer ticker.Stop()
 

--- a/internal/am/poll_ingest_test.go
+++ b/internal/am/poll_ingest_test.go
@@ -26,7 +26,7 @@ func TestPollIngestActivity(t *testing.T) {
 
 	clock := clockwork.NewFakeClock()
 	path := "/var/archivematica/fake/sip"
-	workflowID := 2
+	wUUID := uuid.New()
 	sipID := uuid.New().String()
 
 	httpError := func(m *amclienttest.MockIngestServiceMockRecorder, statusCode int) {
@@ -155,10 +155,10 @@ func TestPollIngestActivity(t *testing.T) {
 			ingestRec: func(m *ingest_fake.MockServiceMockRecorder) {
 				tasks := make([]*datatypes.Task, len(jobs))
 				for i, job := range jobs {
-					task := am.ConvertJobToTask(job)
-					task.WorkflowID = workflowID
+					task, _ := am.ConvertJobToTask(job)
+					task.WorkflowUUID = wUUID
 
-					tasks[i] = &task
+					tasks[i] = task
 				}
 
 				// Poll 2: save first job.
@@ -276,8 +276,8 @@ func TestPollIngestActivity(t *testing.T) {
 			enc, err := env.ExecuteActivity(
 				am.PollIngestActivityName,
 				am.PollIngestActivityParams{
-					WorkflowID: workflowID,
-					SIPID:      sipID,
+					WorkflowUUID: wUUID,
+					SIPID:        sipID,
 				},
 			)
 			if tt.wantErr != "" {

--- a/internal/am/poll_transfer.go
+++ b/internal/am/poll_transfer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"go.artefactual.dev/amclient"
 	temporal_tools "go.artefactual.dev/tools/temporal"
@@ -17,8 +18,8 @@ import (
 const PollTransferActivityName = "poll-transfer-activity"
 
 type PollTransferActivityParams struct {
-	WorkflowID int
-	TransferID string
+	WorkflowUUID uuid.UUID
+	TransferID   string
 }
 
 type PollTransferActivity struct {
@@ -69,11 +70,11 @@ func (a *PollTransferActivity) Execute(
 
 	logger := temporal_tools.GetLogger(ctx)
 	logger.V(1).Info("Executing PollTransferActivity",
-		"WorkflowID", params.WorkflowID,
+		"WorkflowUUID", params.WorkflowUUID,
 		"TransferID", params.TransferID,
 	)
 
-	jobTracker := NewJobTracker(a.clock, a.jobSvc, a.ingestsvc, params.WorkflowID)
+	jobTracker := NewJobTracker(a.clock, a.jobSvc, a.ingestsvc, params.WorkflowUUID)
 	ticker := time.NewTicker(a.cfg.PollInterval)
 	defer ticker.Stop()
 

--- a/internal/am/poll_transfer_test.go
+++ b/internal/am/poll_transfer_test.go
@@ -28,7 +28,7 @@ var (
 func TestPollTransferActivity(t *testing.T) {
 	t.Parallel()
 	transferID := uuid.New().String()
-	workflowID := 1
+	wUUID := uuid.New()
 	sipID := uuid.New().String()
 	path := "/var/archivematica/fake/sip"
 
@@ -82,8 +82,8 @@ func TestPollTransferActivity(t *testing.T) {
 		{
 			name: "Polls twice then returns successfully",
 			params: &am.PollTransferActivityParams{
-				WorkflowID: workflowID,
-				TransferID: transferID,
+				WorkflowUUID: wUUID,
+				TransferID:   transferID,
 			},
 			tfrRec: func(m *amclienttest.MockTransferServiceMockRecorder) {
 				// First poll. AM sometimes returns a "400 Bad Request" error
@@ -149,9 +149,9 @@ func TestPollTransferActivity(t *testing.T) {
 			ingestRec: func(m *ingest_fake.MockServiceMockRecorder) {
 				// Second poll.
 				for _, job := range jobs {
-					task := am.ConvertJobToTask(job)
-					task.WorkflowID = workflowID
-					m.CreateTask(mockutil.Context(), &task).Return(nil)
+					task, _ := am.ConvertJobToTask(job)
+					task.WorkflowUUID = wUUID
+					m.CreateTask(mockutil.Context(), task).Return(nil)
 
 				}
 			},
@@ -306,8 +306,8 @@ func TestPollTransferActivity(t *testing.T) {
 			enc, err := env.ExecuteActivity(
 				am.PollTransferActivityName,
 				am.PollTransferActivityParams{
-					WorkflowID: workflowID,
-					TransferID: transferID,
+					WorkflowUUID: wUUID,
+					TransferID:   transferID,
 				},
 			)
 			if tt.wantErr != "" {

--- a/internal/api/design/ingest.go
+++ b/internal/api/design/ingest.go
@@ -453,7 +453,7 @@ var SIPWorkflow = ResultType("application/vnd.enduro.ingest.sip.workflow", func(
 	Description("SIPWorkflow describes a workflow of a SIP.")
 	TypeName("SIPWorkflow")
 	Attributes(func() {
-		Attribute("id", UInt)
+		TypedAttributeUUID("uuid", "Identifier of the workflow")
 		Attribute("temporal_id", String)
 		Attribute("type", String, func() {
 			EnumWorkflowType()
@@ -471,7 +471,7 @@ var SIPWorkflow = ResultType("application/vnd.enduro.ingest.sip.workflow", func(
 		TypedAttributeUUID("sip_uuid", "Identifier of related SIP")
 	})
 	View("simple", func() {
-		Attribute("id")
+		Attribute("uuid")
 		Attribute("temporal_id")
 		Attribute("type")
 		Attribute("status")
@@ -479,7 +479,7 @@ var SIPWorkflow = ResultType("application/vnd.enduro.ingest.sip.workflow", func(
 		Attribute("completed_at")
 		Attribute("sip_uuid")
 	})
-	Required("id", "temporal_id", "type", "status", "started_at", "sip_uuid")
+	Required("uuid", "temporal_id", "type", "status", "started_at", "sip_uuid")
 })
 
 var EnumTaskStatus = func() {
@@ -490,8 +490,7 @@ var SIPTask = ResultType("application/vnd.enduro.ingest.sip.task", func() {
 	Description("SIPTask describes a SIP workflow task.")
 	TypeName("SIPTask")
 	Attributes(func() {
-		Attribute("id", UInt)
-		Attribute("task_id", String)
+		TypedAttributeUUID("uuid", "Identifier of the task")
 		Attribute("name", String)
 		Attribute("status", String, func() {
 			EnumTaskStatus()
@@ -503,7 +502,7 @@ var SIPTask = ResultType("application/vnd.enduro.ingest.sip.task", func() {
 			Format(FormatDateTime)
 		})
 		Attribute("note", String)
-		Attribute("workflow_id", UInt)
+		TypedAttributeUUID("workflow_uuid", "Identifier of related workflow")
 	})
-	Required("id", "task_id", "name", "status", "started_at")
+	Required("uuid", "name", "status", "started_at", "workflow_uuid")
 })

--- a/internal/api/design/ingest_monitor.go
+++ b/internal/api/design/ingest_monitor.go
@@ -67,44 +67,44 @@ var SIPStatusUpdatedEvent = Type("SIPStatusUpdatedEvent", func() {
 })
 
 var SIPWorkflowCreatedEvent = Type("SIPWorkflowCreatedEvent", func() {
-	Attribute("id", UInt, "Identifier of workflow")
+	TypedAttributeUUID("uuid", "Identifier of workflow")
 	Attribute("item", SIPWorkflow, func() {
 		View("simple")
 	})
-	Required("id", "item")
+	Required("uuid", "item")
 
 	Meta("type:generate:force")
 	Meta("openapi:typename", "SIPWorkflowCreatedEvent")
 })
 
 var SIPWorkflowUpdatedEvent = Type("SIPWorkflowUpdatedEvent", func() {
-	Attribute("id", UInt, "Identifier of workflow")
+	TypedAttributeUUID("uuid", "Identifier of workflow")
 	Attribute("item", SIPWorkflow, func() {
 		View("simple")
 	})
-	Required("id", "item")
+	Required("uuid", "item")
 
 	Meta("type:generate:force")
 	Meta("openapi:typename", "SIPWorkflowUpdatedEvent")
 })
 
 var SIPTaskCreatedEvent = Type("SIPTaskCreatedEvent", func() {
-	Attribute("id", UInt, "Identifier of task")
+	TypedAttributeUUID("uuid", "Identifier of task")
 	Attribute("item", SIPTask, func() {
 		View("default")
 	})
-	Required("id", "item")
+	Required("uuid", "item")
 
 	Meta("type:generate:force")
 	Meta("openapi:typename", "SIPTaskCreatedEvent")
 })
 
 var SIPTaskUpdatedEvent = Type("SIPTaskUpdatedEvent", func() {
-	Attribute("id", UInt, "Identifier of task")
+	TypedAttributeUUID("uuid", "Identifier of task")
 	Attribute("item", SIPTask, func() {
 		View("default")
 	})
-	Required("id", "item")
+	Required("uuid", "item")
 
 	Meta("type:generate:force")
 	Meta("openapi:typename", "SIPTaskUpdatedEvent")

--- a/internal/api/gen/about/service.go
+++ b/internal/api/gen/about/service.go
@@ -117,27 +117,28 @@ type SIPStatusUpdatedEvent struct {
 
 // SIPTask describes a SIP workflow task.
 type SIPTask struct {
-	ID          uint
-	TaskID      string
+	// Identifier of the task
+	UUID        uuid.UUID
 	Name        string
 	Status      string
 	StartedAt   string
 	CompletedAt *string
 	Note        *string
-	WorkflowID  *uint
+	// Identifier of related workflow
+	WorkflowUUID uuid.UUID
 }
 
 type SIPTaskCollection []*SIPTask
 
 type SIPTaskCreatedEvent struct {
 	// Identifier of task
-	ID   uint
+	UUID uuid.UUID
 	Item *SIPTask
 }
 
 type SIPTaskUpdatedEvent struct {
 	// Identifier of task
-	ID   uint
+	UUID uuid.UUID
 	Item *SIPTask
 }
 
@@ -149,7 +150,8 @@ type SIPUpdatedEvent struct {
 
 // SIPWorkflow describes a workflow of a SIP.
 type SIPWorkflow struct {
-	ID          uint
+	// Identifier of the workflow
+	UUID        uuid.UUID
 	TemporalID  string
 	Type        string
 	Status      string
@@ -162,13 +164,13 @@ type SIPWorkflow struct {
 
 type SIPWorkflowCreatedEvent struct {
 	// Identifier of workflow
-	ID   uint
+	UUID uuid.UUID
 	Item *SIPWorkflow
 }
 
 type SIPWorkflowUpdatedEvent struct {
 	// Identifier of workflow
-	ID   uint
+	UUID uuid.UUID
 	Item *SIPWorkflow
 }
 

--- a/internal/api/gen/http/ingest/client/encode_decode.go
+++ b/internal/api/gen/http/ingest/client/encode_decode.go
@@ -1633,7 +1633,7 @@ func unmarshalSIPWorkflowResponseBodyToIngestviewsSIPWorkflowView(v *SIPWorkflow
 		return nil
 	}
 	res := &ingestviews.SIPWorkflowView{
-		ID:          v.ID,
+		UUID:        v.UUID,
 		TemporalID:  v.TemporalID,
 		Type:        v.Type,
 		Status:      v.Status,
@@ -1658,14 +1658,13 @@ func unmarshalSIPTaskResponseBodyToIngestviewsSIPTaskView(v *SIPTaskResponseBody
 		return nil
 	}
 	res := &ingestviews.SIPTaskView{
-		ID:          v.ID,
-		TaskID:      v.TaskID,
-		Name:        v.Name,
-		Status:      v.Status,
-		StartedAt:   v.StartedAt,
-		CompletedAt: v.CompletedAt,
-		Note:        v.Note,
-		WorkflowID:  v.WorkflowID,
+		UUID:         v.UUID,
+		Name:         v.Name,
+		Status:       v.Status,
+		StartedAt:    v.StartedAt,
+		CompletedAt:  v.CompletedAt,
+		Note:         v.Note,
+		WorkflowUUID: v.WorkflowUUID,
 	}
 
 	return res

--- a/internal/api/gen/http/ingest/client/types.go
+++ b/internal/api/gen/http/ingest/client/types.go
@@ -490,7 +490,8 @@ type SIPWorkflowCollectionResponseBody []*SIPWorkflowResponseBody
 
 // SIPWorkflowResponseBody is used to define fields on response body types.
 type SIPWorkflowResponseBody struct {
-	ID          *uint                         `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Identifier of the workflow
+	UUID        *uuid.UUID                    `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
 	TemporalID  *string                       `form:"temporal_id,omitempty" json:"temporal_id,omitempty" xml:"temporal_id,omitempty"`
 	Type        *string                       `form:"type,omitempty" json:"type,omitempty" xml:"type,omitempty"`
 	Status      *string                       `form:"status,omitempty" json:"status,omitempty" xml:"status,omitempty"`
@@ -507,14 +508,15 @@ type SIPTaskCollectionResponseBody []*SIPTaskResponseBody
 
 // SIPTaskResponseBody is used to define fields on response body types.
 type SIPTaskResponseBody struct {
-	ID          *uint   `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
-	TaskID      *string `form:"task_id,omitempty" json:"task_id,omitempty" xml:"task_id,omitempty"`
-	Name        *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
-	Status      *string `form:"status,omitempty" json:"status,omitempty" xml:"status,omitempty"`
-	StartedAt   *string `form:"started_at,omitempty" json:"started_at,omitempty" xml:"started_at,omitempty"`
-	CompletedAt *string `form:"completed_at,omitempty" json:"completed_at,omitempty" xml:"completed_at,omitempty"`
-	Note        *string `form:"note,omitempty" json:"note,omitempty" xml:"note,omitempty"`
-	WorkflowID  *uint   `form:"workflow_id,omitempty" json:"workflow_id,omitempty" xml:"workflow_id,omitempty"`
+	// Identifier of the task
+	UUID        *uuid.UUID `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
+	Name        *string    `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	Status      *string    `form:"status,omitempty" json:"status,omitempty" xml:"status,omitempty"`
+	StartedAt   *string    `form:"started_at,omitempty" json:"started_at,omitempty" xml:"started_at,omitempty"`
+	CompletedAt *string    `form:"completed_at,omitempty" json:"completed_at,omitempty" xml:"completed_at,omitempty"`
+	Note        *string    `form:"note,omitempty" json:"note,omitempty" xml:"note,omitempty"`
+	// Identifier of related workflow
+	WorkflowUUID *uuid.UUID `form:"workflow_uuid,omitempty" json:"workflow_uuid,omitempty" xml:"workflow_uuid,omitempty"`
 }
 
 // UserCollectionResponseBody is used to define fields on response body types.
@@ -1750,8 +1752,8 @@ func ValidateSIPWorkflowCollectionResponseBody(body SIPWorkflowCollectionRespons
 // ValidateSIPWorkflowResponseBody runs the validations defined on
 // SIPWorkflowResponseBody
 func ValidateSIPWorkflowResponseBody(body *SIPWorkflowResponseBody) (err error) {
-	if body.ID == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	if body.UUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "body"))
 	}
 	if body.TemporalID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("temporal_id", "body"))
@@ -1808,11 +1810,8 @@ func ValidateSIPTaskCollectionResponseBody(body SIPTaskCollectionResponseBody) (
 // ValidateSIPTaskResponseBody runs the validations defined on
 // SIPTaskResponseBody
 func ValidateSIPTaskResponseBody(body *SIPTaskResponseBody) (err error) {
-	if body.ID == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
-	}
-	if body.TaskID == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("task_id", "body"))
+	if body.UUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "body"))
 	}
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
@@ -1822,6 +1821,9 @@ func ValidateSIPTaskResponseBody(body *SIPTaskResponseBody) (err error) {
 	}
 	if body.StartedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("started_at", "body"))
+	}
+	if body.WorkflowUUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("workflow_uuid", "body"))
 	}
 	if body.Status != nil {
 		if !(*body.Status == "unspecified" || *body.Status == "in progress" || *body.Status == "done" || *body.Status == "error" || *body.Status == "queued" || *body.Status == "pending" || *body.Status == "failed") {

--- a/internal/api/gen/http/ingest/server/encode_decode.go
+++ b/internal/api/gen/http/ingest/server/encode_decode.go
@@ -1291,7 +1291,7 @@ func marshalIngestviewsSIPWorkflowViewToSIPWorkflowResponseBody(v *ingestviews.S
 		return nil
 	}
 	res := &SIPWorkflowResponseBody{
-		ID:          *v.ID,
+		UUID:        *v.UUID,
 		TemporalID:  *v.TemporalID,
 		Type:        *v.Type,
 		Status:      *v.Status,
@@ -1316,14 +1316,13 @@ func marshalIngestviewsSIPTaskViewToSIPTaskResponseBody(v *ingestviews.SIPTaskVi
 		return nil
 	}
 	res := &SIPTaskResponseBody{
-		ID:          *v.ID,
-		TaskID:      *v.TaskID,
-		Name:        *v.Name,
-		Status:      *v.Status,
-		StartedAt:   *v.StartedAt,
-		CompletedAt: v.CompletedAt,
-		Note:        v.Note,
-		WorkflowID:  v.WorkflowID,
+		UUID:         *v.UUID,
+		Name:         *v.Name,
+		Status:       *v.Status,
+		StartedAt:    *v.StartedAt,
+		CompletedAt:  v.CompletedAt,
+		Note:         v.Note,
+		WorkflowUUID: *v.WorkflowUUID,
 	}
 
 	return res

--- a/internal/api/gen/http/ingest/server/types.go
+++ b/internal/api/gen/http/ingest/server/types.go
@@ -490,7 +490,8 @@ type SIPWorkflowResponseBodyCollection []*SIPWorkflowResponseBody
 
 // SIPWorkflowResponseBody is used to define fields on response body types.
 type SIPWorkflowResponseBody struct {
-	ID          uint                          `form:"id" json:"id" xml:"id"`
+	// Identifier of the workflow
+	UUID        uuid.UUID                     `form:"uuid" json:"uuid" xml:"uuid"`
 	TemporalID  string                        `form:"temporal_id" json:"temporal_id" xml:"temporal_id"`
 	Type        string                        `form:"type" json:"type" xml:"type"`
 	Status      string                        `form:"status" json:"status" xml:"status"`
@@ -507,14 +508,15 @@ type SIPTaskResponseBodyCollection []*SIPTaskResponseBody
 
 // SIPTaskResponseBody is used to define fields on response body types.
 type SIPTaskResponseBody struct {
-	ID          uint    `form:"id" json:"id" xml:"id"`
-	TaskID      string  `form:"task_id" json:"task_id" xml:"task_id"`
-	Name        string  `form:"name" json:"name" xml:"name"`
-	Status      string  `form:"status" json:"status" xml:"status"`
-	StartedAt   string  `form:"started_at" json:"started_at" xml:"started_at"`
-	CompletedAt *string `form:"completed_at,omitempty" json:"completed_at,omitempty" xml:"completed_at,omitempty"`
-	Note        *string `form:"note,omitempty" json:"note,omitempty" xml:"note,omitempty"`
-	WorkflowID  *uint   `form:"workflow_id,omitempty" json:"workflow_id,omitempty" xml:"workflow_id,omitempty"`
+	// Identifier of the task
+	UUID        uuid.UUID `form:"uuid" json:"uuid" xml:"uuid"`
+	Name        string    `form:"name" json:"name" xml:"name"`
+	Status      string    `form:"status" json:"status" xml:"status"`
+	StartedAt   string    `form:"started_at" json:"started_at" xml:"started_at"`
+	CompletedAt *string   `form:"completed_at,omitempty" json:"completed_at,omitempty" xml:"completed_at,omitempty"`
+	Note        *string   `form:"note,omitempty" json:"note,omitempty" xml:"note,omitempty"`
+	// Identifier of related workflow
+	WorkflowUUID uuid.UUID `form:"workflow_uuid" json:"workflow_uuid" xml:"workflow_uuid"`
 }
 
 // UserResponseBodyCollection is used to define fields on response body types.

--- a/internal/api/gen/http/openapi.json
+++ b/internal/api/gen/http/openapi.json
@@ -908,24 +908,23 @@
         "workflows": [
           {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
             "tasks": [
               {
                 "completed_at": "1970-01-01T00:00:01Z",
-                "id": 1,
                 "name": "abc123",
                 "note": "abc123",
                 "started_at": "1970-01-01T00:00:01Z",
                 "status": "in progress",
-                "task_id": "abc123",
-                "workflow_id": 1
+                "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+                "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
               }
             ],
             "temporal_id": "abc123",
-            "type": "create and review aip"
+            "type": "create and review aip",
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
           }
         ]
       },
@@ -1950,24 +1949,18 @@
       "description": "SIPTask describes a SIP workflow task. (default view)",
       "example": {
         "completed_at": "1970-01-01T00:00:01Z",
-        "id": 1,
         "name": "abc123",
         "note": "abc123",
         "started_at": "1970-01-01T00:00:01Z",
         "status": "in progress",
-        "task_id": "abc123",
-        "workflow_id": 1
+        "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+        "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
       },
       "properties": {
         "completed_at": {
           "example": "1970-01-01T00:00:01Z",
           "format": "date-time",
           "type": "string"
-        },
-        "id": {
-          "example": 1,
-          "format": "int64",
-          "type": "integer"
         },
         "name": {
           "example": "abc123",
@@ -1995,22 +1988,23 @@
           "example": "in progress",
           "type": "string"
         },
-        "task_id": {
-          "example": "abc123",
+        "uuid": {
+          "description": "Identifier of the task",
+          "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
           "type": "string"
         },
-        "workflow_id": {
-          "example": 1,
-          "format": "int64",
-          "type": "integer"
+        "workflow_uuid": {
+          "description": "Identifier of related workflow",
+          "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+          "type": "string"
         }
       },
       "required": [
-        "id",
-        "task_id",
+        "uuid",
         "name",
         "status",
-        "started_at"
+        "started_at",
+        "workflow_uuid"
       ],
       "title": "Mediatype identifier: application/vnd.enduro.ingest.sip.task; view=default",
       "type": "object"
@@ -2020,13 +2014,12 @@
       "example": [
         {
           "completed_at": "1970-01-01T00:00:01Z",
-          "id": 1,
           "name": "abc123",
           "note": "abc123",
           "started_at": "1970-01-01T00:00:01Z",
           "status": "in progress",
-          "task_id": "abc123",
-          "workflow_id": 1
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+          "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         }
       ],
       "items": {
@@ -2039,35 +2032,29 @@
       "description": "SIPWorkflow describes a workflow of a SIP. (default view)",
       "example": {
         "completed_at": "1970-01-01T00:00:01Z",
-        "id": 1,
         "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
         "started_at": "1970-01-01T00:00:01Z",
         "status": "in progress",
         "tasks": [
           {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "name": "abc123",
             "note": "abc123",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
-            "task_id": "abc123",
-            "workflow_id": 1
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
           }
         ],
         "temporal_id": "abc123",
-        "type": "create and review aip"
+        "type": "create and review aip",
+        "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
       },
       "properties": {
         "completed_at": {
           "example": "1970-01-01T00:00:01Z",
           "format": "date-time",
           "type": "string"
-        },
-        "id": {
-          "example": 1,
-          "format": "int64",
-          "type": "integer"
         },
         "sip_uuid": {
           "description": "Identifier of related SIP",
@@ -2106,10 +2093,15 @@
           ],
           "example": "create and review aip",
           "type": "string"
+        },
+        "uuid": {
+          "description": "Identifier of the workflow",
+          "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+          "type": "string"
         }
       },
       "required": [
-        "id",
+        "uuid",
         "temporal_id",
         "type",
         "status",
@@ -2124,24 +2116,23 @@
       "example": [
         {
           "completed_at": "1970-01-01T00:00:01Z",
-          "id": 1,
           "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
           "started_at": "1970-01-01T00:00:01Z",
           "status": "in progress",
           "tasks": [
             {
               "completed_at": "1970-01-01T00:00:01Z",
-              "id": 1,
               "name": "abc123",
               "note": "abc123",
               "started_at": "1970-01-01T00:00:01Z",
               "status": "in progress",
-              "task_id": "abc123",
-              "workflow_id": 1
+              "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+              "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
             }
           ],
           "temporal_id": "abc123",
-          "type": "create and review aip"
+          "type": "create and review aip",
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         }
       ],
       "items": {

--- a/internal/api/gen/http/openapi.yaml
+++ b/internal/api/gen/http/openapi.yaml
@@ -2235,21 +2235,20 @@ definitions:
         example:
             workflows:
                 - completed_at: "1970-01-01T00:00:01Z"
-                  id: 1
                   sip_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                   started_at: "1970-01-01T00:00:01Z"
                   status: in progress
                   tasks:
                     - completed_at: "1970-01-01T00:00:01Z"
-                      id: 1
                       name: abc123
                       note: abc123
                       started_at: "1970-01-01T00:00:01Z"
                       status: in progress
-                      task_id: abc123
-                      workflow_id: 1
+                      uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                      workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                   temporal_id: abc123
                   type: create and review aip
+                  uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
     IngestListSipsNotValidResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object
@@ -3075,10 +3074,6 @@ definitions:
                 type: string
                 example: "1970-01-01T00:00:01Z"
                 format: date-time
-            id:
-                type: integer
-                example: 1
-                format: int64
             name:
                 type: string
                 example: abc123
@@ -3100,29 +3095,29 @@ definitions:
                     - queued
                     - pending
                     - failed
-            task_id:
+            uuid:
                 type: string
-                example: abc123
-            workflow_id:
-                type: integer
-                example: 1
-                format: int64
+                description: Identifier of the task
+                example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+            workflow_uuid:
+                type: string
+                description: Identifier of related workflow
+                example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
         description: SIPTask describes a SIP workflow task. (default view)
         example:
             completed_at: "1970-01-01T00:00:01Z"
-            id: 1
             name: abc123
             note: abc123
             started_at: "1970-01-01T00:00:01Z"
             status: in progress
-            task_id: abc123
-            workflow_id: 1
+            uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+            workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
         required:
-            - id
-            - task_id
+            - uuid
             - name
             - status
             - started_at
+            - workflow_uuid
     SIPTaskResponseBodyCollection:
         title: 'Mediatype identifier: application/vnd.enduro.ingest.sip.task; type=collection; view=default'
         type: array
@@ -3131,13 +3126,12 @@ definitions:
         description: SIPTaskCollectionResponseBody is the result type for an array of SIPTaskResponseBody (default view)
         example:
             - completed_at: "1970-01-01T00:00:01Z"
-              id: 1
               name: abc123
               note: abc123
               started_at: "1970-01-01T00:00:01Z"
               status: in progress
-              task_id: abc123
-              workflow_id: 1
+              uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+              workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
     SIPWorkflowResponseBody:
         title: 'Mediatype identifier: application/vnd.enduro.ingest.sip.workflow; view=default'
         type: object
@@ -3146,10 +3140,6 @@ definitions:
                 type: string
                 example: "1970-01-01T00:00:01Z"
                 format: date-time
-            id:
-                type: integer
-                example: 1
-                format: int64
             sip_uuid:
                 type: string
                 description: Identifier of related SIP
@@ -3180,26 +3170,29 @@ definitions:
                 enum:
                     - create aip
                     - create and review aip
+            uuid:
+                type: string
+                description: Identifier of the workflow
+                example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
         description: SIPWorkflow describes a workflow of a SIP. (default view)
         example:
             completed_at: "1970-01-01T00:00:01Z"
-            id: 1
             sip_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             started_at: "1970-01-01T00:00:01Z"
             status: in progress
             tasks:
                 - completed_at: "1970-01-01T00:00:01Z"
-                  id: 1
                   name: abc123
                   note: abc123
                   started_at: "1970-01-01T00:00:01Z"
                   status: in progress
-                  task_id: abc123
-                  workflow_id: 1
+                  uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                  workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             temporal_id: abc123
             type: create and review aip
+            uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
         required:
-            - id
+            - uuid
             - temporal_id
             - type
             - status
@@ -3213,21 +3206,20 @@ definitions:
         description: SIPWorkflowCollectionResponseBody is the result type for an array of SIPWorkflowResponseBody (default view)
         example:
             - completed_at: "1970-01-01T00:00:01Z"
-              id: 1
               sip_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
               started_at: "1970-01-01T00:00:01Z"
               status: in progress
               tasks:
                 - completed_at: "1970-01-01T00:00:01Z"
-                  id: 1
                   name: abc123
                   note: abc123
                   started_at: "1970-01-01T00:00:01Z"
                   status: in progress
-                  task_id: abc123
-                  workflow_id: 1
+                  uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                  workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
               temporal_id: abc123
               type: create and review aip
+              uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
     StorageAIPResponseCollection:
         title: 'Mediatype identifier: application/vnd.enduro.storage.aip; type=collection; view=default'
         type: array

--- a/internal/api/gen/http/openapi3.json
+++ b/internal/api/gen/http/openapi3.json
@@ -504,24 +504,18 @@
         "description": "SIPTask describes a SIP workflow task.",
         "example": {
           "completed_at": "1970-01-01T00:00:01Z",
-          "id": 1,
           "name": "abc123",
           "note": "abc123",
           "started_at": "1970-01-01T00:00:01Z",
           "status": "in progress",
-          "task_id": "abc123",
-          "workflow_id": 1
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+          "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         },
         "properties": {
           "completed_at": {
             "example": "1970-01-01T00:00:01Z",
             "format": "date-time",
             "type": "string"
-          },
-          "id": {
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
           },
           "name": {
             "example": "abc123",
@@ -549,22 +543,23 @@
             "example": "in progress",
             "type": "string"
           },
-          "task_id": {
-            "example": "abc123",
+          "uuid": {
+            "description": "Identifier of the task",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "type": "string"
           },
-          "workflow_id": {
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
+          "workflow_uuid": {
+            "description": "Identifier of related workflow",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
           }
         },
         "required": [
-          "id",
-          "task_id",
+          "uuid",
           "name",
           "status",
-          "started_at"
+          "started_at",
+          "workflow_uuid"
         ],
         "type": "object"
       },
@@ -572,35 +567,29 @@
         "description": "SIPWorkflow describes a workflow of a SIP.",
         "example": {
           "completed_at": "1970-01-01T00:00:01Z",
-          "id": 1,
           "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
           "started_at": "1970-01-01T00:00:01Z",
           "status": "in progress",
           "tasks": [
             {
               "completed_at": "1970-01-01T00:00:01Z",
-              "id": 1,
               "name": "abc123",
               "note": "abc123",
               "started_at": "1970-01-01T00:00:01Z",
               "status": "in progress",
-              "task_id": "abc123",
-              "workflow_id": 1
+              "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+              "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
             }
           ],
           "temporal_id": "abc123",
-          "type": "create and review aip"
+          "type": "create and review aip",
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         },
         "properties": {
           "completed_at": {
             "example": "1970-01-01T00:00:01Z",
             "format": "date-time",
             "type": "string"
-          },
-          "id": {
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
           },
           "sip_uuid": {
             "description": "Identifier of related SIP",
@@ -639,10 +628,15 @@
             ],
             "example": "create and review aip",
             "type": "string"
+          },
+          "uuid": {
+            "description": "Identifier of the workflow",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
           }
         },
         "required": [
-          "id",
+          "uuid",
           "temporal_id",
           "type",
           "status",
@@ -1411,13 +1405,12 @@
         "example": [
           {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "name": "abc123",
             "note": "abc123",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
-            "task_id": "abc123",
-            "workflow_id": 1
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
           }
         ],
         "items": {
@@ -1427,62 +1420,58 @@
       },
       "SIPTaskCreatedEvent": {
         "example": {
-          "id": 1,
           "item": {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "name": "abc123",
             "note": "abc123",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
-            "task_id": "abc123",
-            "workflow_id": 1
-          }
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+          },
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         },
         "properties": {
-          "id": {
-            "description": "Identifier of task",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          },
           "item": {
             "$ref": "#/components/schemas/EnduroIngestSipTask"
+          },
+          "uuid": {
+            "description": "Identifier of task",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
           }
         },
         "required": [
-          "id",
+          "uuid",
           "item"
         ],
         "type": "object"
       },
       "SIPTaskUpdatedEvent": {
         "example": {
-          "id": 1,
           "item": {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "name": "abc123",
             "note": "abc123",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
-            "task_id": "abc123",
-            "workflow_id": 1
-          }
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+          },
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         },
         "properties": {
-          "id": {
-            "description": "Identifier of task",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          },
           "item": {
             "$ref": "#/components/schemas/EnduroIngestSipTask"
+          },
+          "uuid": {
+            "description": "Identifier of task",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
           }
         },
         "required": [
-          "id",
+          "uuid",
           "item"
         ],
         "type": "object"
@@ -1525,24 +1514,23 @@
         "example": [
           {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
             "tasks": [
               {
                 "completed_at": "1970-01-01T00:00:01Z",
-                "id": 1,
                 "name": "abc123",
                 "note": "abc123",
                 "started_at": "1970-01-01T00:00:01Z",
                 "status": "in progress",
-                "task_id": "abc123",
-                "workflow_id": 1
+                "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+                "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
               }
             ],
             "temporal_id": "abc123",
-            "type": "create and review aip"
+            "type": "create and review aip",
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
           }
         ],
         "items": {
@@ -1552,84 +1540,80 @@
       },
       "SIPWorkflowCreatedEvent": {
         "example": {
-          "id": 1,
           "item": {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
             "tasks": [
               {
                 "completed_at": "1970-01-01T00:00:01Z",
-                "id": 1,
                 "name": "abc123",
                 "note": "abc123",
                 "started_at": "1970-01-01T00:00:01Z",
                 "status": "in progress",
-                "task_id": "abc123",
-                "workflow_id": 1
+                "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+                "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
               }
             ],
             "temporal_id": "abc123",
-            "type": "create and review aip"
-          }
+            "type": "create and review aip",
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+          },
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         },
         "properties": {
-          "id": {
-            "description": "Identifier of workflow",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          },
           "item": {
             "$ref": "#/components/schemas/EnduroIngestSipWorkflow"
+          },
+          "uuid": {
+            "description": "Identifier of workflow",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
           }
         },
         "required": [
-          "id",
+          "uuid",
           "item"
         ],
         "type": "object"
       },
       "SIPWorkflowUpdatedEvent": {
         "example": {
-          "id": 1,
           "item": {
             "completed_at": "1970-01-01T00:00:01Z",
-            "id": 1,
             "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
             "started_at": "1970-01-01T00:00:01Z",
             "status": "in progress",
             "tasks": [
               {
                 "completed_at": "1970-01-01T00:00:01Z",
-                "id": 1,
                 "name": "abc123",
                 "note": "abc123",
                 "started_at": "1970-01-01T00:00:01Z",
                 "status": "in progress",
-                "task_id": "abc123",
-                "workflow_id": 1
+                "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+                "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
               }
             ],
             "temporal_id": "abc123",
-            "type": "create and review aip"
-          }
+            "type": "create and review aip",
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+          },
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
         },
         "properties": {
-          "id": {
-            "description": "Identifier of workflow",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          },
           "item": {
             "$ref": "#/components/schemas/EnduroIngestSipWorkflow"
+          },
+          "uuid": {
+            "description": "Identifier of workflow",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
           }
         },
         "required": [
-          "id",
+          "uuid",
           "item"
         ],
         "type": "object"
@@ -1639,24 +1623,23 @@
           "workflows": [
             {
               "completed_at": "1970-01-01T00:00:01Z",
-              "id": 1,
               "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
               "started_at": "1970-01-01T00:00:01Z",
               "status": "in progress",
               "tasks": [
                 {
                   "completed_at": "1970-01-01T00:00:01Z",
-                  "id": 1,
                   "name": "abc123",
                   "note": "abc123",
                   "started_at": "1970-01-01T00:00:01Z",
                   "status": "in progress",
-                  "task_id": "abc123",
-                  "workflow_id": 1
+                  "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+                  "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
                 }
               ],
               "temporal_id": "abc123",
-              "type": "create and review aip"
+              "type": "create and review aip",
+              "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
             }
           ]
         },
@@ -2855,24 +2838,23 @@
                   "workflows": [
                     {
                       "completed_at": "1970-01-01T00:00:01Z",
-                      "id": 1,
                       "sip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
                       "started_at": "1970-01-01T00:00:01Z",
                       "status": "in progress",
                       "tasks": [
                         {
                           "completed_at": "1970-01-01T00:00:01Z",
-                          "id": 1,
                           "name": "abc123",
                           "note": "abc123",
                           "started_at": "1970-01-01T00:00:01Z",
                           "status": "in progress",
-                          "task_id": "abc123",
-                          "workflow_id": 1
+                          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+                          "workflow_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
                         }
                       ],
                       "temporal_id": "abc123",
-                      "type": "create and review aip"
+                      "type": "create and review aip",
+                      "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
                     }
                   ]
                 },

--- a/internal/api/gen/http/openapi3.yaml
+++ b/internal/api/gen/http/openapi3.yaml
@@ -648,21 +648,20 @@ paths:
                             example:
                                 workflows:
                                     - completed_at: "1970-01-01T00:00:01Z"
-                                      id: 1
                                       sip_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                                       started_at: "1970-01-01T00:00:01Z"
                                       status: in progress
                                       tasks:
                                         - completed_at: "1970-01-01T00:00:01Z"
-                                          id: 1
                                           name: abc123
                                           note: abc123
                                           started_at: "1970-01-01T00:00:01Z"
                                           status: in progress
-                                          task_id: abc123
-                                          workflow_id: 1
+                                          uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                                          workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                                       temporal_id: abc123
                                       type: create and review aip
+                                      uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                 "401":
                     description: 'unauthorized: Unauthorized response.'
                     content:
@@ -2411,10 +2410,6 @@ components:
                     type: string
                     example: "1970-01-01T00:00:01Z"
                     format: date-time
-                id:
-                    type: integer
-                    example: 1
-                    format: int64
                 name:
                     type: string
                     example: abc123
@@ -2436,29 +2431,29 @@ components:
                         - queued
                         - pending
                         - failed
-                task_id:
+                uuid:
                     type: string
-                    example: abc123
-                workflow_id:
-                    type: integer
-                    example: 1
-                    format: int64
+                    description: Identifier of the task
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                workflow_uuid:
+                    type: string
+                    description: Identifier of related workflow
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             description: SIPTask describes a SIP workflow task.
             example:
                 completed_at: "1970-01-01T00:00:01Z"
-                id: 1
                 name: abc123
                 note: abc123
                 started_at: "1970-01-01T00:00:01Z"
                 status: in progress
-                task_id: abc123
-                workflow_id: 1
+                uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             required:
-                - id
-                - task_id
+                - uuid
                 - name
                 - status
                 - started_at
+                - workflow_uuid
         EnduroIngestSipWorkflow:
             type: object
             properties:
@@ -2466,10 +2461,6 @@ components:
                     type: string
                     example: "1970-01-01T00:00:01Z"
                     format: date-time
-                id:
-                    type: integer
-                    example: 1
-                    format: int64
                 sip_uuid:
                     type: string
                     description: Identifier of related SIP
@@ -2500,26 +2491,29 @@ components:
                     enum:
                         - create aip
                         - create and review aip
+                uuid:
+                    type: string
+                    description: Identifier of the workflow
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             description: SIPWorkflow describes a workflow of a SIP.
             example:
                 completed_at: "1970-01-01T00:00:01Z"
-                id: 1
                 sip_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                 started_at: "1970-01-01T00:00:01Z"
                 status: in progress
                 tasks:
                     - completed_at: "1970-01-01T00:00:01Z"
-                      id: 1
                       name: abc123
                       note: abc123
                       started_at: "1970-01-01T00:00:01Z"
                       status: in progress
-                      task_id: abc123
-                      workflow_id: 1
+                      uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                      workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                 temporal_id: abc123
                 type: create and review aip
+                uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             required:
-                - id
+                - uuid
                 - temporal_id
                 - type
                 - status
@@ -3128,60 +3122,55 @@ components:
                 $ref: '#/components/schemas/EnduroIngestSipTask'
             example:
                 - completed_at: "1970-01-01T00:00:01Z"
-                  id: 1
                   name: abc123
                   note: abc123
                   started_at: "1970-01-01T00:00:01Z"
                   status: in progress
-                  task_id: abc123
-                  workflow_id: 1
+                  uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                  workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
         SIPTaskCreatedEvent:
             type: object
             properties:
-                id:
-                    type: integer
-                    description: Identifier of task
-                    example: 1
-                    format: int64
                 item:
                     $ref: '#/components/schemas/EnduroIngestSipTask'
+                uuid:
+                    type: string
+                    description: Identifier of task
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             example:
-                id: 1
                 item:
                     completed_at: "1970-01-01T00:00:01Z"
-                    id: 1
                     name: abc123
                     note: abc123
                     started_at: "1970-01-01T00:00:01Z"
                     status: in progress
-                    task_id: abc123
-                    workflow_id: 1
+                    uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                    workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             required:
-                - id
+                - uuid
                 - item
         SIPTaskUpdatedEvent:
             type: object
             properties:
-                id:
-                    type: integer
-                    description: Identifier of task
-                    example: 1
-                    format: int64
                 item:
                     $ref: '#/components/schemas/EnduroIngestSipTask'
+                uuid:
+                    type: string
+                    description: Identifier of task
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             example:
-                id: 1
                 item:
                     completed_at: "1970-01-01T00:00:01Z"
-                    id: 1
                     name: abc123
                     note: abc123
                     started_at: "1970-01-01T00:00:01Z"
                     status: in progress
-                    task_id: abc123
-                    workflow_id: 1
+                    uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                    workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             required:
-                - id
+                - uuid
                 - item
         SIPUpdatedEvent:
             type: object
@@ -3216,84 +3205,79 @@ components:
                 $ref: '#/components/schemas/EnduroIngestSipWorkflow'
             example:
                 - completed_at: "1970-01-01T00:00:01Z"
-                  id: 1
                   sip_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                   started_at: "1970-01-01T00:00:01Z"
                   status: in progress
                   tasks:
                     - completed_at: "1970-01-01T00:00:01Z"
-                      id: 1
                       name: abc123
                       note: abc123
                       started_at: "1970-01-01T00:00:01Z"
                       status: in progress
-                      task_id: abc123
-                      workflow_id: 1
+                      uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                      workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                   temporal_id: abc123
                   type: create and review aip
+                  uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
         SIPWorkflowCreatedEvent:
             type: object
             properties:
-                id:
-                    type: integer
-                    description: Identifier of workflow
-                    example: 1
-                    format: int64
                 item:
                     $ref: '#/components/schemas/EnduroIngestSipWorkflow'
+                uuid:
+                    type: string
+                    description: Identifier of workflow
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             example:
-                id: 1
                 item:
                     completed_at: "1970-01-01T00:00:01Z"
-                    id: 1
                     sip_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                     started_at: "1970-01-01T00:00:01Z"
                     status: in progress
                     tasks:
                         - completed_at: "1970-01-01T00:00:01Z"
-                          id: 1
                           name: abc123
                           note: abc123
                           started_at: "1970-01-01T00:00:01Z"
                           status: in progress
-                          task_id: abc123
-                          workflow_id: 1
+                          uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                          workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                     temporal_id: abc123
                     type: create and review aip
+                    uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             required:
-                - id
+                - uuid
                 - item
         SIPWorkflowUpdatedEvent:
             type: object
             properties:
-                id:
-                    type: integer
-                    description: Identifier of workflow
-                    example: 1
-                    format: int64
                 item:
                     $ref: '#/components/schemas/EnduroIngestSipWorkflow'
+                uuid:
+                    type: string
+                    description: Identifier of workflow
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             example:
-                id: 1
                 item:
                     completed_at: "1970-01-01T00:00:01Z"
-                    id: 1
                     sip_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                     started_at: "1970-01-01T00:00:01Z"
                     status: in progress
                     tasks:
                         - completed_at: "1970-01-01T00:00:01Z"
-                          id: 1
                           name: abc123
                           note: abc123
                           started_at: "1970-01-01T00:00:01Z"
                           status: in progress
-                          task_id: abc123
-                          workflow_id: 1
+                          uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                          workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                     temporal_id: abc123
                     type: create and review aip
+                    uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
             required:
-                - id
+                - uuid
                 - item
         SIPWorkflows:
             type: object
@@ -3303,21 +3287,20 @@ components:
             example:
                 workflows:
                     - completed_at: "1970-01-01T00:00:01Z"
-                      id: 1
                       sip_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                       started_at: "1970-01-01T00:00:01Z"
                       status: in progress
                       tasks:
                         - completed_at: "1970-01-01T00:00:01Z"
-                          id: 1
                           name: abc123
                           note: abc123
                           started_at: "1970-01-01T00:00:01Z"
                           status: in progress
-                          task_id: abc123
-                          workflow_id: 1
+                          uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                          workflow_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
                       temporal_id: abc123
                       type: create and review aip
+                      uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
         SIPs:
             type: object
             properties:

--- a/internal/api/gen/ingest/service.go
+++ b/internal/api/gen/ingest/service.go
@@ -258,27 +258,28 @@ type SIPStatusUpdatedEvent struct {
 
 // SIPTask describes a SIP workflow task.
 type SIPTask struct {
-	ID          uint
-	TaskID      string
+	// Identifier of the task
+	UUID        uuid.UUID
 	Name        string
 	Status      string
 	StartedAt   string
 	CompletedAt *string
 	Note        *string
-	WorkflowID  *uint
+	// Identifier of related workflow
+	WorkflowUUID uuid.UUID
 }
 
 type SIPTaskCollection []*SIPTask
 
 type SIPTaskCreatedEvent struct {
 	// Identifier of task
-	ID   uint
+	UUID uuid.UUID
 	Item *SIPTask
 }
 
 type SIPTaskUpdatedEvent struct {
 	// Identifier of task
-	ID   uint
+	UUID uuid.UUID
 	Item *SIPTask
 }
 
@@ -290,7 +291,8 @@ type SIPUpdatedEvent struct {
 
 // SIPWorkflow describes a workflow of a SIP.
 type SIPWorkflow struct {
-	ID          uint
+	// Identifier of the workflow
+	UUID        uuid.UUID
 	TemporalID  string
 	Type        string
 	Status      string
@@ -305,13 +307,13 @@ type SIPWorkflowCollection []*SIPWorkflow
 
 type SIPWorkflowCreatedEvent struct {
 	// Identifier of workflow
-	ID   uint
+	UUID uuid.UUID
 	Item *SIPWorkflow
 }
 
 type SIPWorkflowUpdatedEvent struct {
 	// Identifier of workflow
-	ID   uint
+	UUID uuid.UUID
 	Item *SIPWorkflow
 }
 
@@ -689,8 +691,8 @@ func newSIPWorkflowSimple(vres *ingestviews.SIPWorkflowView) *SIPWorkflow {
 	res := &SIPWorkflow{
 		CompletedAt: vres.CompletedAt,
 	}
-	if vres.ID != nil {
-		res.ID = *vres.ID
+	if vres.UUID != nil {
+		res.UUID = *vres.UUID
 	}
 	if vres.TemporalID != nil {
 		res.TemporalID = *vres.TemporalID
@@ -719,8 +721,8 @@ func newSIPWorkflow(vres *ingestviews.SIPWorkflowView) *SIPWorkflow {
 	res := &SIPWorkflow{
 		CompletedAt: vres.CompletedAt,
 	}
-	if vres.ID != nil {
-		res.ID = *vres.ID
+	if vres.UUID != nil {
+		res.UUID = *vres.UUID
 	}
 	if vres.TemporalID != nil {
 		res.TemporalID = *vres.TemporalID
@@ -747,7 +749,7 @@ func newSIPWorkflow(vres *ingestviews.SIPWorkflowView) *SIPWorkflow {
 // SIPWorkflowView using the "simple" view.
 func newSIPWorkflowViewSimple(res *SIPWorkflow) *ingestviews.SIPWorkflowView {
 	vres := &ingestviews.SIPWorkflowView{
-		ID:          &res.ID,
+		UUID:        &res.UUID,
 		TemporalID:  &res.TemporalID,
 		Type:        &res.Type,
 		Status:      &res.Status,
@@ -762,7 +764,7 @@ func newSIPWorkflowViewSimple(res *SIPWorkflow) *ingestviews.SIPWorkflowView {
 // SIPWorkflowView using the "default" view.
 func newSIPWorkflowView(res *SIPWorkflow) *ingestviews.SIPWorkflowView {
 	vres := &ingestviews.SIPWorkflowView{
-		ID:          &res.ID,
+		UUID:        &res.UUID,
 		TemporalID:  &res.TemporalID,
 		Type:        &res.Type,
 		Status:      &res.Status,
@@ -801,13 +803,9 @@ func newSIPTask(vres *ingestviews.SIPTaskView) *SIPTask {
 	res := &SIPTask{
 		CompletedAt: vres.CompletedAt,
 		Note:        vres.Note,
-		WorkflowID:  vres.WorkflowID,
 	}
-	if vres.ID != nil {
-		res.ID = *vres.ID
-	}
-	if vres.TaskID != nil {
-		res.TaskID = *vres.TaskID
+	if vres.UUID != nil {
+		res.UUID = *vres.UUID
 	}
 	if vres.Name != nil {
 		res.Name = *vres.Name
@@ -818,6 +816,9 @@ func newSIPTask(vres *ingestviews.SIPTaskView) *SIPTask {
 	if vres.StartedAt != nil {
 		res.StartedAt = *vres.StartedAt
 	}
+	if vres.WorkflowUUID != nil {
+		res.WorkflowUUID = *vres.WorkflowUUID
+	}
 	return res
 }
 
@@ -825,14 +826,13 @@ func newSIPTask(vres *ingestviews.SIPTaskView) *SIPTask {
 // using the "default" view.
 func newSIPTaskView(res *SIPTask) *ingestviews.SIPTaskView {
 	vres := &ingestviews.SIPTaskView{
-		ID:          &res.ID,
-		TaskID:      &res.TaskID,
-		Name:        &res.Name,
-		Status:      &res.Status,
-		StartedAt:   &res.StartedAt,
-		CompletedAt: res.CompletedAt,
-		Note:        res.Note,
-		WorkflowID:  res.WorkflowID,
+		UUID:         &res.UUID,
+		Name:         &res.Name,
+		Status:       &res.Status,
+		StartedAt:    &res.StartedAt,
+		CompletedAt:  res.CompletedAt,
+		Note:         res.Note,
+		WorkflowUUID: &res.WorkflowUUID,
 	}
 	return vres
 }

--- a/internal/api/gen/ingest/views/view.go
+++ b/internal/api/gen/ingest/views/view.go
@@ -103,7 +103,8 @@ type SIPWorkflowCollectionView []*SIPWorkflowView
 
 // SIPWorkflowView is a type that runs validations on a projected type.
 type SIPWorkflowView struct {
-	ID          *uint
+	// Identifier of the workflow
+	UUID        *uuid.UUID
 	TemporalID  *string
 	Type        *string
 	Status      *string
@@ -119,14 +120,15 @@ type SIPTaskCollectionView []*SIPTaskView
 
 // SIPTaskView is a type that runs validations on a projected type.
 type SIPTaskView struct {
-	ID          *uint
-	TaskID      *string
+	// Identifier of the task
+	UUID        *uuid.UUID
 	Name        *string
 	Status      *string
 	StartedAt   *string
 	CompletedAt *string
 	Note        *string
-	WorkflowID  *uint
+	// Identifier of related workflow
+	WorkflowUUID *uuid.UUID
 }
 
 // UsersView is a type that runs validations on a projected type.
@@ -220,7 +222,7 @@ var (
 	// SIPWorkflowCollection by view name.
 	SIPWorkflowCollectionMap = map[string][]string{
 		"simple": {
-			"id",
+			"uuid",
 			"temporal_id",
 			"type",
 			"status",
@@ -229,7 +231,7 @@ var (
 			"sip_uuid",
 		},
 		"default": {
-			"id",
+			"uuid",
 			"temporal_id",
 			"type",
 			"status",
@@ -243,7 +245,7 @@ var (
 	// name.
 	SIPWorkflowMap = map[string][]string{
 		"simple": {
-			"id",
+			"uuid",
 			"temporal_id",
 			"type",
 			"status",
@@ -252,7 +254,7 @@ var (
 			"sip_uuid",
 		},
 		"default": {
-			"id",
+			"uuid",
 			"temporal_id",
 			"type",
 			"status",
@@ -266,27 +268,25 @@ var (
 	// SIPTaskCollection by view name.
 	SIPTaskCollectionMap = map[string][]string{
 		"default": {
-			"id",
-			"task_id",
+			"uuid",
 			"name",
 			"status",
 			"started_at",
 			"completed_at",
 			"note",
-			"workflow_id",
+			"workflow_uuid",
 		},
 	}
 	// SIPTaskMap is a map indexing the attribute names of SIPTask by view name.
 	SIPTaskMap = map[string][]string{
 		"default": {
-			"id",
-			"task_id",
+			"uuid",
 			"name",
 			"status",
 			"started_at",
 			"completed_at",
 			"note",
-			"workflow_id",
+			"workflow_uuid",
 		},
 	}
 	// UserCollectionMap is a map indexing the attribute names of UserCollection by
@@ -472,8 +472,8 @@ func ValidateSIPWorkflowCollectionView(result SIPWorkflowCollectionView) (err er
 // ValidateSIPWorkflowViewSimple runs the validations defined on
 // SIPWorkflowView using the "simple" view.
 func ValidateSIPWorkflowViewSimple(result *SIPWorkflowView) (err error) {
-	if result.ID == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("id", "result"))
+	if result.UUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "result"))
 	}
 	if result.TemporalID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("temporal_id", "result"))
@@ -512,8 +512,8 @@ func ValidateSIPWorkflowViewSimple(result *SIPWorkflowView) (err error) {
 // ValidateSIPWorkflowView runs the validations defined on SIPWorkflowView
 // using the "default" view.
 func ValidateSIPWorkflowView(result *SIPWorkflowView) (err error) {
-	if result.ID == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("id", "result"))
+	if result.UUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "result"))
 	}
 	if result.TemporalID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("temporal_id", "result"))
@@ -568,11 +568,8 @@ func ValidateSIPTaskCollectionView(result SIPTaskCollectionView) (err error) {
 // ValidateSIPTaskView runs the validations defined on SIPTaskView using the
 // "default" view.
 func ValidateSIPTaskView(result *SIPTaskView) (err error) {
-	if result.ID == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("id", "result"))
-	}
-	if result.TaskID == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("task_id", "result"))
+	if result.UUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "result"))
 	}
 	if result.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "result"))
@@ -582,6 +579,9 @@ func ValidateSIPTaskView(result *SIPTaskView) (err error) {
 	}
 	if result.StartedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("started_at", "result"))
+	}
+	if result.WorkflowUUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("workflow_uuid", "result"))
 	}
 	if result.Status != nil {
 		if !(*result.Status == "unspecified" || *result.Status == "in progress" || *result.Status == "done" || *result.Status == "error" || *result.Status == "queued" || *result.Status == "pending" || *result.Status == "failed") {

--- a/internal/api/gen/storage/service.go
+++ b/internal/api/gen/storage/service.go
@@ -413,27 +413,28 @@ type SIPStatusUpdatedEvent struct {
 
 // SIPTask describes a SIP workflow task.
 type SIPTask struct {
-	ID          uint
-	TaskID      string
+	// Identifier of the task
+	UUID        uuid.UUID
 	Name        string
 	Status      string
 	StartedAt   string
 	CompletedAt *string
 	Note        *string
-	WorkflowID  *uint
+	// Identifier of related workflow
+	WorkflowUUID uuid.UUID
 }
 
 type SIPTaskCollection []*SIPTask
 
 type SIPTaskCreatedEvent struct {
 	// Identifier of task
-	ID   uint
+	UUID uuid.UUID
 	Item *SIPTask
 }
 
 type SIPTaskUpdatedEvent struct {
 	// Identifier of task
-	ID   uint
+	UUID uuid.UUID
 	Item *SIPTask
 }
 
@@ -445,7 +446,8 @@ type SIPUpdatedEvent struct {
 
 // SIPWorkflow describes a workflow of a SIP.
 type SIPWorkflow struct {
-	ID          uint
+	// Identifier of the workflow
+	UUID        uuid.UUID
 	TemporalID  string
 	Type        string
 	Status      string
@@ -458,13 +460,13 @@ type SIPWorkflow struct {
 
 type SIPWorkflowCreatedEvent struct {
 	// Identifier of workflow
-	ID   uint
+	UUID uuid.UUID
 	Item *SIPWorkflow
 }
 
 type SIPWorkflowUpdatedEvent struct {
 	// Identifier of workflow
-	ID   uint
+	UUID uuid.UUID
 	Item *SIPWorkflow
 }
 

--- a/internal/datatypes/task.go
+++ b/internal/datatypes/task.go
@@ -4,19 +4,21 @@ import (
 	"database/sql"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/artefactual-sdps/enduro/internal/enums"
 )
 
 // Task represents a workflow task in the task table.
 type Task struct {
-	ID          int              `db:"id"`
-	TaskID      string           `db:"task_id"`
-	Name        string           `db:"name"`
-	Status      enums.TaskStatus `db:"status"`
-	StartedAt   sql.NullTime     `db:"started_at"`
-	CompletedAt sql.NullTime     `db:"completed_at"`
-	Note        string           `db:"note"`
-	WorkflowID  int              `db:"workflow_id"`
+	ID           int              `db:"id"`
+	UUID         uuid.UUID        `db:"uuid"`
+	Name         string           `db:"name"`
+	Status       enums.TaskStatus `db:"status"`
+	StartedAt    sql.NullTime     `db:"started_at"`
+	CompletedAt  sql.NullTime     `db:"completed_at"`
+	Note         string           `db:"note"`
+	WorkflowUUID uuid.UUID        `db:"workflow_uuid"`
 }
 
 // SystemError indicates that a system error occurred during task execution.

--- a/internal/datatypes/workflow.go
+++ b/internal/datatypes/workflow.go
@@ -10,6 +10,7 @@ import (
 
 type Workflow struct {
 	ID          int                  `db:"id"`
+	UUID        uuid.UUID            `db:"uuid"`
 	TemporalID  string               `db:"temporal_id"`
 	Type        enums.WorkflowType   `db:"type"`
 	Status      enums.WorkflowStatus `db:"status"`

--- a/internal/db/migrations/20250709054510_add_uuid_columns.up.sql
+++ b/internal/db/migrations/20250709054510_add_uuid_columns.up.sql
@@ -1,0 +1,10 @@
+-- Rename "task_id" column to "uuid" in "task" table and add unique index
+ALTER TABLE `task` CHANGE COLUMN `task_id` `uuid` CHAR(36) NOT NULL, ADD UNIQUE INDEX `uuid` (`uuid`);
+-- Add nullable "uuid" column to "workflow" table
+ALTER TABLE `workflow` ADD COLUMN `uuid` CHAR(36) NULL;
+-- Add "uuid" values
+UPDATE `workflow` SET `uuid` = BIN_TO_UUID(
+    RANDOM_BYTES(16) & 0xffffffffffff0fff3fffffffffffffff | 0x00000000000040008000000000000000
+) WHERE uuid IS NULL;
+-- Make "uuid" column not nullable and add unique index
+ALTER TABLE `workflow` MODIFY COLUMN `uuid` CHAR(36) NOT NULL, ADD UNIQUE INDEX `uuid` (`uuid`);

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:QIoq3kUP98AXSmHMHpFirbJphh3xK7OY83scOjUKgIM=
+h1:P9Ax9aFC2OMLr067DtqfregVtnoxhJEdadaM9BKb11g=
 1570659451_init.up.sql h1:zyiKKl39RqMxuEhop5jeeiPTxPiSSq00Tn6u06gyNmk=
 1710442322_nullable_aip_id.up.sql h1:vL4eG5YELXr3k4ymhHuRD/R7KpNt3/DNRhH26t83x3A=
 20250207193001_rename_package_table.up.sql h1:d2RjfIturPoFYMMtFocrMvvjEXEqDXDdxQRttcknX/0=
@@ -13,3 +13,4 @@ h1:QIoq3kUP98AXSmHMHpFirbJphh3xK7OY83scOjUKgIM=
 20250519181224_update_workflow_types.up.sql h1:E17yEe45fUHXiQpU/cKINtqUZbEkN3jYNJd+SwcysC0=
 20250528183140_add_failed_columns_to_sip_table.up.sql h1:ggwXsUY9uWeE8B26fPClG/Ll1fj2UTZyT8RBV7AmUz0=
 20250612181940_add_user_table.up.sql h1:AaIySTeKTMiJPZ4kHw3QTbFjzFP793AnHpXk5MLL5Rc=
+20250709054510_add_uuid_columns.up.sql h1:7hdG5ZX+ZmUMKXLmM/9C2acdvmcXrc76K7eZ5+k+uQ0=

--- a/internal/ingest/convert.go
+++ b/internal/ingest/convert.go
@@ -32,13 +32,8 @@ func workflowToGoa(w *datatypes.Workflow) *goaingest.SIPWorkflow {
 		startedAt = w.StartedAt.Time.Format(time.RFC3339)
 	}
 
-	var id uint
-	if w.ID > 0 {
-		id = uint(w.ID) // #nosec G115 -- range validated.
-	}
-
 	return &goaingest.SIPWorkflow{
-		ID:          id,
+		UUID:        w.UUID,
 		TemporalID:  w.TemporalID,
 		Type:        w.Type.String(),
 		Status:      w.Status.String(),
@@ -50,19 +45,8 @@ func workflowToGoa(w *datatypes.Workflow) *goaingest.SIPWorkflow {
 
 // taskToGoa returns the API representation of a task.
 func taskToGoa(task *datatypes.Task) *goaingest.SIPTask {
-	var id uint
-	if task.ID > 0 {
-		id = uint(task.ID) // #nosec G115 -- range validated.
-	}
-
-	var wID uint
-	if task.WorkflowID > 0 {
-		wID = uint(task.WorkflowID) // #nosec G115 -- range validated.
-	}
-
 	return &goaingest.SIPTask{
-		ID:     id,
-		TaskID: task.TaskID,
+		UUID:   task.UUID,
 		Name:   task.Name,
 		Status: task.Status.String(),
 
@@ -70,9 +54,9 @@ func taskToGoa(task *datatypes.Task) *goaingest.SIPTask {
 		// convert a null time to an empty (zero value) string.
 		StartedAt: ref.DerefZero(db.FormatOptionalTime(task.CompletedAt)),
 
-		CompletedAt: db.FormatOptionalTime(task.CompletedAt),
-		Note:        &task.Note,
-		WorkflowID:  ref.New(wID),
+		CompletedAt:  db.FormatOptionalTime(task.CompletedAt),
+		Note:         &task.Note,
+		WorkflowUUID: task.WorkflowUUID,
 	}
 }
 

--- a/internal/ingest/goa.go
+++ b/internal/ingest/goa.go
@@ -195,7 +195,7 @@ func (w *goaWrapper) ListSipWorkflows(
 		return nil, goaingest.MakeNotAvailable(errors.New("cannot perform operation"))
 	}
 
-	query := "SELECT id, temporal_id, type, status, CONVERT_TZ(started_at, @@session.time_zone, '+00:00') AS started_at, CONVERT_TZ(completed_at, @@session.time_zone, '+00:00') AS completed_at FROM workflow WHERE sip_id = ? ORDER BY started_at DESC"
+	query := "SELECT id, uuid, temporal_id, type, status, CONVERT_TZ(started_at, @@session.time_zone, '+00:00') AS started_at, CONVERT_TZ(completed_at, @@session.time_zone, '+00:00') AS completed_at FROM workflow WHERE sip_id = ? ORDER BY started_at DESC"
 	args := []any{s.ID}
 
 	rows, err := w.db.QueryxContext(ctx, query, args...)
@@ -213,7 +213,7 @@ func (w *goaWrapper) ListSipWorkflows(
 		workflow.SIPUUID = s.UUID
 		goaworkflow := workflowToGoa(&workflow)
 
-		ptQuery := "SELECT id, task_id, name, status, CONVERT_TZ(started_at, @@session.time_zone, '+00:00') AS started_at, CONVERT_TZ(completed_at, @@session.time_zone, '+00:00') AS completed_at, note FROM task WHERE workflow_id = ?"
+		ptQuery := "SELECT id, uuid, name, status, CONVERT_TZ(started_at, @@session.time_zone, '+00:00') AS started_at, CONVERT_TZ(completed_at, @@session.time_zone, '+00:00') AS completed_at, note FROM task WHERE workflow_id = ?"
 		ptQueryArgs := []any{workflow.ID}
 
 		ptRows, err := w.db.QueryxContext(ctx, ptQuery, ptQueryArgs...)

--- a/internal/ingest/task.go
+++ b/internal/ingest/task.go
@@ -19,7 +19,7 @@ func (svc *ingestImpl) CreateTask(ctx context.Context, task *datatypes.Task) err
 	}
 
 	event.PublishEvent(ctx, svc.evsvc, &goaingest.SIPTaskCreatedEvent{
-		ID:   uint(task.ID), // #nosec G115 -- constrained value.
+		UUID: task.UUID,
 		Item: taskToGoa(task),
 	})
 
@@ -58,7 +58,7 @@ func (svc *ingestImpl) CompleteTask(
 	}
 
 	event.PublishEvent(ctx, svc.evsvc, &goaingest.SIPTaskUpdatedEvent{
-		ID:   uint(id), // #nosec G115 -- range validated.
+		UUID: task.UUID,
 		Item: taskToGoa(task),
 	})
 

--- a/internal/ingest/task_test.go
+++ b/internal/ingest/task_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"go.artefactual.dev/tools/mockutil"
 	"go.artefactual.dev/tools/ref"
 	"gotest.tools/v3/assert"
@@ -21,7 +22,8 @@ import (
 func TestCreateTask(t *testing.T) {
 	t.Parallel()
 
-	taskID := "a499e8fc-7309-4e26-b39d-d8ab68466c27"
+	taskUUID := uuid.New()
+	wUUID := uuid.New()
 
 	type test struct {
 		name    string
@@ -34,17 +36,17 @@ func TestCreateTask(t *testing.T) {
 		{
 			name: "Creates a task",
 			task: datatypes.Task{
-				TaskID:     taskID,
-				Name:       "PT1",
-				Status:     enums.TaskStatusInProgress,
-				WorkflowID: 11,
+				UUID:         taskUUID,
+				Name:         "PT1",
+				Status:       enums.TaskStatusInProgress,
+				WorkflowUUID: wUUID,
 			},
 			want: datatypes.Task{
-				ID:         1,
-				TaskID:     taskID,
-				Name:       "PT1",
-				Status:     enums.TaskStatusInProgress,
-				WorkflowID: 11,
+				ID:           1,
+				UUID:         taskUUID,
+				Name:         "PT1",
+				Status:       enums.TaskStatusInProgress,
+				WorkflowUUID: wUUID,
 			},
 			mock: func(svc *persistence_fake.MockService, task datatypes.Task) *persistence_fake.MockService {
 				svc.EXPECT().
@@ -61,7 +63,7 @@ func TestCreateTask(t *testing.T) {
 		{
 			name: "Creates a task with optional values",
 			task: datatypes.Task{
-				TaskID: taskID,
+				UUID:   taskUUID,
 				Name:   "PT2",
 				Status: enums.TaskStatusInProgress,
 				StartedAt: sql.NullTime{
@@ -72,8 +74,8 @@ func TestCreateTask(t *testing.T) {
 					Time:  time.Date(2024, 3, 27, 11, 32, 43, 0, time.UTC),
 					Valid: true,
 				},
-				Note:       "PT2 Note",
-				WorkflowID: 12,
+				Note:         "PT2 Note",
+				WorkflowUUID: wUUID,
 			},
 			mock: func(svc *persistence_fake.MockService, task datatypes.Task) *persistence_fake.MockService {
 				svc.EXPECT().
@@ -88,7 +90,7 @@ func TestCreateTask(t *testing.T) {
 			},
 			want: datatypes.Task{
 				ID:     2,
-				TaskID: taskID,
+				UUID:   taskUUID,
 				Name:   "PT2",
 				Status: enums.TaskStatusInProgress,
 				StartedAt: sql.NullTime{
@@ -99,8 +101,8 @@ func TestCreateTask(t *testing.T) {
 					Time:  time.Date(2024, 3, 27, 11, 32, 43, 0, time.UTC),
 					Valid: true,
 				},
-				Note:       "PT2 Note",
-				WorkflowID: 12,
+				Note:         "PT2 Note",
+				WorkflowUUID: wUUID,
 			},
 		},
 		{

--- a/internal/ingest/workflow.go
+++ b/internal/ingest/workflow.go
@@ -21,7 +21,7 @@ func (svc *ingestImpl) CreateWorkflow(
 	}
 
 	ev := &goaingest.SIPWorkflowCreatedEvent{
-		ID:   uint(w.ID), // #nosec G115 -- constrained value.
+		UUID: w.UUID,
 		Item: workflowToGoa(w),
 	}
 	event.PublishEvent(ctx, svc.evsvc, ev)
@@ -49,7 +49,7 @@ func (svc *ingestImpl) SetWorkflowStatus(
 		event.PublishEvent(
 			ctx,
 			svc.evsvc,
-			&goaingest.SIPWorkflowUpdatedEvent{ID: item.ID, Item: item},
+			&goaingest.SIPWorkflowUpdatedEvent{UUID: item.UUID, Item: item},
 		)
 	}
 
@@ -78,7 +78,7 @@ func (svc *ingestImpl) CompleteWorkflow(
 		event.PublishEvent(
 			ctx,
 			svc.evsvc,
-			&goaingest.SIPWorkflowUpdatedEvent{ID: item.ID, Item: item},
+			&goaingest.SIPWorkflowUpdatedEvent{UUID: item.UUID, Item: item},
 		)
 	}
 
@@ -92,6 +92,7 @@ func (svc *ingestImpl) readWorkflow(
 	query := `
 		SELECT
 			workflow.id,
+			workflow.uuid,
 			workflow.temporal_id,
 			workflow.type,
 			workflow.status,

--- a/internal/persistence/ent/client/client_test.go
+++ b/internal/persistence/ent/client/client_test.go
@@ -16,7 +16,10 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/persistence/ent/db/enttest"
 )
 
-var sipUUID = uuid.New()
+var (
+	sipUUID = uuid.New()
+	wUUID   = uuid.New()
+)
 
 func setUpClient(t *testing.T, logger logr.Logger) (*db.Client, persistence.Service) {
 	t.Helper()
@@ -65,6 +68,7 @@ func createWorkflow(
 	status enums.WorkflowStatus,
 ) (*db.Workflow, error) {
 	return entc.Workflow.Create().
+		SetUUID(wUUID).
 		SetTemporalID("12345").
 		SetType(enums.WorkflowTypeCreateAip).
 		SetStatus(int8(status)). // #nosec G115 -- constrained value.

--- a/internal/persistence/ent/client/convert.go
+++ b/internal/persistence/ent/client/convert.go
@@ -63,15 +63,20 @@ func convertTask(task *db.Task) *datatypes.Task {
 		status = uint(task.Status) // #nosec G115 -- range validated.
 	}
 
+	var wUUID uuid.UUID
+	if task.Edges.Workflow != nil {
+		wUUID = task.Edges.Workflow.UUID
+	}
+
 	return &datatypes.Task{
-		ID:          task.ID,
-		TaskID:      task.TaskID.String(),
-		Name:        task.Name,
-		Status:      enums.TaskStatus(status),
-		StartedAt:   started,
-		CompletedAt: completed,
-		Note:        task.Note,
-		WorkflowID:  task.WorkflowID,
+		ID:           task.ID,
+		UUID:         task.UUID,
+		Name:         task.Name,
+		Status:       enums.TaskStatus(status),
+		StartedAt:    started,
+		CompletedAt:  completed,
+		Note:         task.Note,
+		WorkflowUUID: wUUID,
 	}
 }
 

--- a/internal/persistence/ent/client/errors.go
+++ b/internal/persistence/ent/client/errors.go
@@ -39,14 +39,6 @@ func newDBErrorWithDetails(err error, details string) error {
 	return fmt.Errorf("%w: %s", newDBError(err), details)
 }
 
-func newParseError(err error, field string) error {
-	if err == nil {
-		return nil
-	}
-
-	return fmt.Errorf("%w: parse error: field %q: %v", persistence.ErrNotValid, field, err)
-}
-
 func newRequiredFieldError(field string) error {
 	return fmt.Errorf("%w: field %q is required", persistence.ErrNotValid, field)
 }

--- a/internal/persistence/ent/client/workflow.go
+++ b/internal/persistence/ent/client/workflow.go
@@ -12,6 +12,9 @@ import (
 
 func (c *client) CreateWorkflow(ctx context.Context, w *datatypes.Workflow) error {
 	// Validate required fields.
+	if w.UUID == uuid.Nil {
+		return newRequiredFieldError("UUID")
+	}
 	if w.TemporalID == "" {
 		return newRequiredFieldError("TemporalID")
 	}
@@ -43,6 +46,7 @@ func (c *client) CreateWorkflow(ctx context.Context, w *datatypes.Workflow) erro
 	}
 
 	q := tx.Workflow.Create().
+		SetUUID(w.UUID).
 		SetTemporalID(w.TemporalID).
 		SetType(w.Type).
 		SetStatus(int8(w.Status)). // #nosec G115 -- constrained value.

--- a/internal/persistence/ent/client/workflow_test.go
+++ b/internal/persistence/ent/client/workflow_test.go
@@ -16,6 +16,7 @@ import (
 func TestCreateWorkflow(t *testing.T) {
 	t.Parallel()
 
+	workflowUUID := uuid.New()
 	temporalID := "processing-workflow-720db1d4-825c-4911-9a20-61c212cf23ff"
 	started := sql.NullTime{Time: time.Now(), Valid: true}
 	completed := sql.NullTime{Time: started.Time.Add(time.Second), Valid: true}
@@ -29,6 +30,7 @@ func TestCreateWorkflow(t *testing.T) {
 		{
 			name: "Saves a new workflow to the database",
 			args: &datatypes.Workflow{
+				UUID:        workflowUUID,
 				TemporalID:  temporalID,
 				Type:        enums.WorkflowTypeCreateAip,
 				Status:      enums.WorkflowStatusDone,
@@ -38,6 +40,7 @@ func TestCreateWorkflow(t *testing.T) {
 			},
 			want: &datatypes.Workflow{
 				ID:          1,
+				UUID:        workflowUUID,
 				TemporalID:  temporalID,
 				Type:        enums.WorkflowTypeCreateAip,
 				Status:      enums.WorkflowStatusDone,
@@ -47,8 +50,17 @@ func TestCreateWorkflow(t *testing.T) {
 			},
 		},
 		{
+			name: "Required field error for missing UUID",
+			args: &datatypes.Workflow{
+				Type:   enums.WorkflowTypeCreateAip,
+				Status: enums.WorkflowStatusDone,
+			},
+			wantErr: "invalid data error: field \"UUID\" is required",
+		},
+		{
 			name: "Required field error for missing TemporalID",
 			args: &datatypes.Workflow{
+				UUID:   workflowUUID,
 				Type:   enums.WorkflowTypeCreateAip,
 				Status: enums.WorkflowStatusDone,
 			},
@@ -57,6 +69,7 @@ func TestCreateWorkflow(t *testing.T) {
 		{
 			name: "Required field error for missing SIPUUID",
 			args: &datatypes.Workflow{
+				UUID:       workflowUUID,
 				TemporalID: temporalID,
 				Type:       enums.WorkflowTypeCreateAip,
 				Status:     enums.WorkflowStatusDone,
@@ -66,6 +79,7 @@ func TestCreateWorkflow(t *testing.T) {
 		{
 			name: "Invalid Type field error",
 			args: &datatypes.Workflow{
+				UUID:       workflowUUID,
 				SIPUUID:    sipUUID,
 				TemporalID: temporalID,
 				Type:       "invalid",
@@ -75,6 +89,7 @@ func TestCreateWorkflow(t *testing.T) {
 		{
 			name: "Not found SIP error",
 			args: &datatypes.Workflow{
+				UUID:       workflowUUID,
 				TemporalID: temporalID,
 				Type:       enums.WorkflowTypeCreateAip,
 				Status:     enums.WorkflowStatusDone,

--- a/internal/persistence/ent/db/migrate/schema.go
+++ b/internal/persistence/ent/db/migrate/schema.go
@@ -75,7 +75,7 @@ var (
 	// TaskColumns holds the columns for the "task" table.
 	TaskColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
-		{Name: "task_id", Type: field.TypeUUID},
+		{Name: "uuid", Type: field.TypeUUID, Unique: true},
 		{Name: "name", Type: field.TypeString, Size: 2048},
 		{Name: "status", Type: field.TypeInt8},
 		{Name: "started_at", Type: field.TypeTime, Nullable: true},
@@ -134,6 +134,7 @@ var (
 	// WorkflowColumns holds the columns for the "workflow" table.
 	WorkflowColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
+		{Name: "uuid", Type: field.TypeUUID, Unique: true},
 		{Name: "temporal_id", Type: field.TypeString, Size: 255},
 		{Name: "type", Type: field.TypeEnum, Enums: []string{"create aip", "create and review aip"}},
 		{Name: "status", Type: field.TypeInt8},
@@ -149,7 +150,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "workflow_sip_workflows",
-				Columns:    []*schema.Column{WorkflowColumns[6]},
+				Columns:    []*schema.Column{WorkflowColumns[7]},
 				RefColumns: []*schema.Column{SipColumns[0]},
 				OnDelete:   schema.Cascade,
 			},

--- a/internal/persistence/ent/db/mutation.go
+++ b/internal/persistence/ent/db/mutation.go
@@ -1125,7 +1125,7 @@ type TaskMutation struct {
 	op              Op
 	typ             string
 	id              *int
-	task_id         *uuid.UUID
+	uuid            *uuid.UUID
 	name            *string
 	status          *int8
 	addstatus       *int8
@@ -1238,40 +1238,40 @@ func (m *TaskMutation) IDs(ctx context.Context) ([]int, error) {
 	}
 }
 
-// SetTaskID sets the "task_id" field.
-func (m *TaskMutation) SetTaskID(u uuid.UUID) {
-	m.task_id = &u
+// SetUUID sets the "uuid" field.
+func (m *TaskMutation) SetUUID(u uuid.UUID) {
+	m.uuid = &u
 }
 
-// TaskID returns the value of the "task_id" field in the mutation.
-func (m *TaskMutation) TaskID() (r uuid.UUID, exists bool) {
-	v := m.task_id
+// UUID returns the value of the "uuid" field in the mutation.
+func (m *TaskMutation) UUID() (r uuid.UUID, exists bool) {
+	v := m.uuid
 	if v == nil {
 		return
 	}
 	return *v, true
 }
 
-// OldTaskID returns the old "task_id" field's value of the Task entity.
+// OldUUID returns the old "uuid" field's value of the Task entity.
 // If the Task object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *TaskMutation) OldTaskID(ctx context.Context) (v uuid.UUID, err error) {
+func (m *TaskMutation) OldUUID(ctx context.Context) (v uuid.UUID, err error) {
 	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldTaskID is only allowed on UpdateOne operations")
+		return v, errors.New("OldUUID is only allowed on UpdateOne operations")
 	}
 	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldTaskID requires an ID field in the mutation")
+		return v, errors.New("OldUUID requires an ID field in the mutation")
 	}
 	oldValue, err := m.oldValue(ctx)
 	if err != nil {
-		return v, fmt.Errorf("querying old value for OldTaskID: %w", err)
+		return v, fmt.Errorf("querying old value for OldUUID: %w", err)
 	}
-	return oldValue.TaskID, nil
+	return oldValue.UUID, nil
 }
 
-// ResetTaskID resets all changes to the "task_id" field.
-func (m *TaskMutation) ResetTaskID() {
-	m.task_id = nil
+// ResetUUID resets all changes to the "uuid" field.
+func (m *TaskMutation) ResetUUID() {
+	m.uuid = nil
 }
 
 // SetName sets the "name" field.
@@ -1598,8 +1598,8 @@ func (m *TaskMutation) Type() string {
 // AddedFields().
 func (m *TaskMutation) Fields() []string {
 	fields := make([]string, 0, 7)
-	if m.task_id != nil {
-		fields = append(fields, task.FieldTaskID)
+	if m.uuid != nil {
+		fields = append(fields, task.FieldUUID)
 	}
 	if m.name != nil {
 		fields = append(fields, task.FieldName)
@@ -1627,8 +1627,8 @@ func (m *TaskMutation) Fields() []string {
 // schema.
 func (m *TaskMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case task.FieldTaskID:
-		return m.TaskID()
+	case task.FieldUUID:
+		return m.UUID()
 	case task.FieldName:
 		return m.Name()
 	case task.FieldStatus:
@@ -1650,8 +1650,8 @@ func (m *TaskMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *TaskMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case task.FieldTaskID:
-		return m.OldTaskID(ctx)
+	case task.FieldUUID:
+		return m.OldUUID(ctx)
 	case task.FieldName:
 		return m.OldName(ctx)
 	case task.FieldStatus:
@@ -1673,12 +1673,12 @@ func (m *TaskMutation) OldField(ctx context.Context, name string) (ent.Value, er
 // type.
 func (m *TaskMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case task.FieldTaskID:
+	case task.FieldUUID:
 		v, ok := value.(uuid.UUID)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
-		m.SetTaskID(v)
+		m.SetUUID(v)
 		return nil
 	case task.FieldName:
 		v, ok := value.(string)
@@ -1801,8 +1801,8 @@ func (m *TaskMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *TaskMutation) ResetField(name string) error {
 	switch name {
-	case task.FieldTaskID:
-		m.ResetTaskID()
+	case task.FieldUUID:
+		m.ResetUUID()
 		return nil
 	case task.FieldName:
 		m.ResetName()
@@ -2674,6 +2674,7 @@ type WorkflowMutation struct {
 	op            Op
 	typ           string
 	id            *int
+	uuid          *uuid.UUID
 	temporal_id   *string
 	_type         *enums.WorkflowType
 	status        *int8
@@ -2787,6 +2788,42 @@ func (m *WorkflowMutation) IDs(ctx context.Context) ([]int, error) {
 	default:
 		return nil, fmt.Errorf("IDs is not allowed on %s operations", m.op)
 	}
+}
+
+// SetUUID sets the "uuid" field.
+func (m *WorkflowMutation) SetUUID(u uuid.UUID) {
+	m.uuid = &u
+}
+
+// UUID returns the value of the "uuid" field in the mutation.
+func (m *WorkflowMutation) UUID() (r uuid.UUID, exists bool) {
+	v := m.uuid
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUUID returns the old "uuid" field's value of the Workflow entity.
+// If the Workflow object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *WorkflowMutation) OldUUID(ctx context.Context) (v uuid.UUID, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldUUID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldUUID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUUID: %w", err)
+	}
+	return oldValue.UUID, nil
+}
+
+// ResetUUID resets all changes to the "uuid" field.
+func (m *WorkflowMutation) ResetUUID() {
+	m.uuid = nil
 }
 
 // SetTemporalID sets the "temporal_id" field.
@@ -3166,7 +3203,10 @@ func (m *WorkflowMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *WorkflowMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
+	if m.uuid != nil {
+		fields = append(fields, workflow.FieldUUID)
+	}
 	if m.temporal_id != nil {
 		fields = append(fields, workflow.FieldTemporalID)
 	}
@@ -3193,6 +3233,8 @@ func (m *WorkflowMutation) Fields() []string {
 // schema.
 func (m *WorkflowMutation) Field(name string) (ent.Value, bool) {
 	switch name {
+	case workflow.FieldUUID:
+		return m.UUID()
 	case workflow.FieldTemporalID:
 		return m.TemporalID()
 	case workflow.FieldType:
@@ -3214,6 +3256,8 @@ func (m *WorkflowMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *WorkflowMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
+	case workflow.FieldUUID:
+		return m.OldUUID(ctx)
 	case workflow.FieldTemporalID:
 		return m.OldTemporalID(ctx)
 	case workflow.FieldType:
@@ -3235,6 +3279,13 @@ func (m *WorkflowMutation) OldField(ctx context.Context, name string) (ent.Value
 // type.
 func (m *WorkflowMutation) SetField(name string, value ent.Value) error {
 	switch name {
+	case workflow.FieldUUID:
+		v, ok := value.(uuid.UUID)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUUID(v)
+		return nil
 	case workflow.FieldTemporalID:
 		v, ok := value.(string)
 		if !ok {
@@ -3356,6 +3407,9 @@ func (m *WorkflowMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *WorkflowMutation) ResetField(name string) error {
 	switch name {
+	case workflow.FieldUUID:
+		m.ResetUUID()
+		return nil
 	case workflow.FieldTemporalID:
 		m.ResetTemporalID()
 		return nil

--- a/internal/persistence/ent/db/runtime.go
+++ b/internal/persistence/ent/db/runtime.go
@@ -41,7 +41,7 @@ func init() {
 	workflowFields := schema.Workflow{}.Fields()
 	_ = workflowFields
 	// workflowDescSipID is the schema descriptor for sip_id field.
-	workflowDescSipID := workflowFields[5].Descriptor()
+	workflowDescSipID := workflowFields[6].Descriptor()
 	// workflow.SipIDValidator is a validator for the "sip_id" field. It is called by the builders before save.
 	workflow.SipIDValidator = workflowDescSipID.Validators[0].(func(int) error)
 }

--- a/internal/persistence/ent/db/task.go
+++ b/internal/persistence/ent/db/task.go
@@ -19,8 +19,8 @@ type Task struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID int `json:"id,omitempty"`
-	// TaskID holds the value of the "task_id" field.
-	TaskID uuid.UUID `json:"task_id,omitempty"`
+	// UUID holds the value of the "uuid" field.
+	UUID uuid.UUID `json:"uuid,omitempty"`
 	// Name holds the value of the "name" field.
 	Name string `json:"name,omitempty"`
 	// Status holds the value of the "status" field.
@@ -70,7 +70,7 @@ func (*Task) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullString)
 		case task.FieldStartedAt, task.FieldCompletedAt:
 			values[i] = new(sql.NullTime)
-		case task.FieldTaskID:
+		case task.FieldUUID:
 			values[i] = new(uuid.UUID)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -93,11 +93,11 @@ func (t *Task) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field id", value)
 			}
 			t.ID = int(value.Int64)
-		case task.FieldTaskID:
+		case task.FieldUUID:
 			if value, ok := values[i].(*uuid.UUID); !ok {
-				return fmt.Errorf("unexpected type %T for field task_id", values[i])
+				return fmt.Errorf("unexpected type %T for field uuid", values[i])
 			} else if value != nil {
-				t.TaskID = *value
+				t.UUID = *value
 			}
 		case task.FieldName:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -176,8 +176,8 @@ func (t *Task) String() string {
 	var builder strings.Builder
 	builder.WriteString("Task(")
 	builder.WriteString(fmt.Sprintf("id=%v, ", t.ID))
-	builder.WriteString("task_id=")
-	builder.WriteString(fmt.Sprintf("%v", t.TaskID))
+	builder.WriteString("uuid=")
+	builder.WriteString(fmt.Sprintf("%v", t.UUID))
 	builder.WriteString(", ")
 	builder.WriteString("name=")
 	builder.WriteString(t.Name)

--- a/internal/persistence/ent/db/task/task.go
+++ b/internal/persistence/ent/db/task/task.go
@@ -12,8 +12,8 @@ const (
 	Label = "task"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
-	// FieldTaskID holds the string denoting the task_id field in the database.
-	FieldTaskID = "task_id"
+	// FieldUUID holds the string denoting the uuid field in the database.
+	FieldUUID = "uuid"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
 	// FieldStatus holds the string denoting the status field in the database.
@@ -42,7 +42,7 @@ const (
 // Columns holds all SQL columns for task fields.
 var Columns = []string{
 	FieldID,
-	FieldTaskID,
+	FieldUUID,
 	FieldName,
 	FieldStatus,
 	FieldStartedAt,
@@ -74,9 +74,9 @@ func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
-// ByTaskID orders the results by the task_id field.
-func ByTaskID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldTaskID, opts...).ToFunc()
+// ByUUID orders the results by the uuid field.
+func ByUUID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldUUID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.

--- a/internal/persistence/ent/db/task/where.go
+++ b/internal/persistence/ent/db/task/where.go
@@ -56,9 +56,9 @@ func IDLTE(id int) predicate.Task {
 	return predicate.Task(sql.FieldLTE(FieldID, id))
 }
 
-// TaskID applies equality check predicate on the "task_id" field. It's identical to TaskIDEQ.
-func TaskID(v uuid.UUID) predicate.Task {
-	return predicate.Task(sql.FieldEQ(FieldTaskID, v))
+// UUID applies equality check predicate on the "uuid" field. It's identical to UUIDEQ.
+func UUID(v uuid.UUID) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldUUID, v))
 }
 
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
@@ -91,44 +91,44 @@ func WorkflowID(v int) predicate.Task {
 	return predicate.Task(sql.FieldEQ(FieldWorkflowID, v))
 }
 
-// TaskIDEQ applies the EQ predicate on the "task_id" field.
-func TaskIDEQ(v uuid.UUID) predicate.Task {
-	return predicate.Task(sql.FieldEQ(FieldTaskID, v))
+// UUIDEQ applies the EQ predicate on the "uuid" field.
+func UUIDEQ(v uuid.UUID) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldUUID, v))
 }
 
-// TaskIDNEQ applies the NEQ predicate on the "task_id" field.
-func TaskIDNEQ(v uuid.UUID) predicate.Task {
-	return predicate.Task(sql.FieldNEQ(FieldTaskID, v))
+// UUIDNEQ applies the NEQ predicate on the "uuid" field.
+func UUIDNEQ(v uuid.UUID) predicate.Task {
+	return predicate.Task(sql.FieldNEQ(FieldUUID, v))
 }
 
-// TaskIDIn applies the In predicate on the "task_id" field.
-func TaskIDIn(vs ...uuid.UUID) predicate.Task {
-	return predicate.Task(sql.FieldIn(FieldTaskID, vs...))
+// UUIDIn applies the In predicate on the "uuid" field.
+func UUIDIn(vs ...uuid.UUID) predicate.Task {
+	return predicate.Task(sql.FieldIn(FieldUUID, vs...))
 }
 
-// TaskIDNotIn applies the NotIn predicate on the "task_id" field.
-func TaskIDNotIn(vs ...uuid.UUID) predicate.Task {
-	return predicate.Task(sql.FieldNotIn(FieldTaskID, vs...))
+// UUIDNotIn applies the NotIn predicate on the "uuid" field.
+func UUIDNotIn(vs ...uuid.UUID) predicate.Task {
+	return predicate.Task(sql.FieldNotIn(FieldUUID, vs...))
 }
 
-// TaskIDGT applies the GT predicate on the "task_id" field.
-func TaskIDGT(v uuid.UUID) predicate.Task {
-	return predicate.Task(sql.FieldGT(FieldTaskID, v))
+// UUIDGT applies the GT predicate on the "uuid" field.
+func UUIDGT(v uuid.UUID) predicate.Task {
+	return predicate.Task(sql.FieldGT(FieldUUID, v))
 }
 
-// TaskIDGTE applies the GTE predicate on the "task_id" field.
-func TaskIDGTE(v uuid.UUID) predicate.Task {
-	return predicate.Task(sql.FieldGTE(FieldTaskID, v))
+// UUIDGTE applies the GTE predicate on the "uuid" field.
+func UUIDGTE(v uuid.UUID) predicate.Task {
+	return predicate.Task(sql.FieldGTE(FieldUUID, v))
 }
 
-// TaskIDLT applies the LT predicate on the "task_id" field.
-func TaskIDLT(v uuid.UUID) predicate.Task {
-	return predicate.Task(sql.FieldLT(FieldTaskID, v))
+// UUIDLT applies the LT predicate on the "uuid" field.
+func UUIDLT(v uuid.UUID) predicate.Task {
+	return predicate.Task(sql.FieldLT(FieldUUID, v))
 }
 
-// TaskIDLTE applies the LTE predicate on the "task_id" field.
-func TaskIDLTE(v uuid.UUID) predicate.Task {
-	return predicate.Task(sql.FieldLTE(FieldTaskID, v))
+// UUIDLTE applies the LTE predicate on the "uuid" field.
+func UUIDLTE(v uuid.UUID) predicate.Task {
+	return predicate.Task(sql.FieldLTE(FieldUUID, v))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.

--- a/internal/persistence/ent/db/task_create.go
+++ b/internal/persistence/ent/db/task_create.go
@@ -22,9 +22,9 @@ type TaskCreate struct {
 	hooks    []Hook
 }
 
-// SetTaskID sets the "task_id" field.
-func (tc *TaskCreate) SetTaskID(u uuid.UUID) *TaskCreate {
-	tc.mutation.SetTaskID(u)
+// SetUUID sets the "uuid" field.
+func (tc *TaskCreate) SetUUID(u uuid.UUID) *TaskCreate {
+	tc.mutation.SetUUID(u)
 	return tc
 }
 
@@ -119,8 +119,8 @@ func (tc *TaskCreate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (tc *TaskCreate) check() error {
-	if _, ok := tc.mutation.TaskID(); !ok {
-		return &ValidationError{Name: "task_id", err: errors.New(`db: missing required field "Task.task_id"`)}
+	if _, ok := tc.mutation.UUID(); !ok {
+		return &ValidationError{Name: "uuid", err: errors.New(`db: missing required field "Task.uuid"`)}
 	}
 	if _, ok := tc.mutation.Name(); !ok {
 		return &ValidationError{Name: "name", err: errors.New(`db: missing required field "Task.name"`)}
@@ -168,9 +168,9 @@ func (tc *TaskCreate) createSpec() (*Task, *sqlgraph.CreateSpec) {
 		_node = &Task{config: tc.config}
 		_spec = sqlgraph.NewCreateSpec(task.Table, sqlgraph.NewFieldSpec(task.FieldID, field.TypeInt))
 	)
-	if value, ok := tc.mutation.TaskID(); ok {
-		_spec.SetField(task.FieldTaskID, field.TypeUUID, value)
-		_node.TaskID = value
+	if value, ok := tc.mutation.UUID(); ok {
+		_spec.SetField(task.FieldUUID, field.TypeUUID, value)
+		_node.UUID = value
 	}
 	if value, ok := tc.mutation.Name(); ok {
 		_spec.SetField(task.FieldName, field.TypeString, value)

--- a/internal/persistence/ent/db/task_query.go
+++ b/internal/persistence/ent/db/task_query.go
@@ -298,12 +298,12 @@ func (tq *TaskQuery) WithWorkflow(opts ...func(*WorkflowQuery)) *TaskQuery {
 // Example:
 //
 //	var v []struct {
-//		TaskID uuid.UUID `json:"task_id,omitempty"`
+//		UUID uuid.UUID `json:"uuid,omitempty"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
 //	client.Task.Query().
-//		GroupBy(task.FieldTaskID).
+//		GroupBy(task.FieldUUID).
 //		Aggregate(db.Count()).
 //		Scan(ctx, &v)
 func (tq *TaskQuery) GroupBy(field string, fields ...string) *TaskGroupBy {
@@ -321,11 +321,11 @@ func (tq *TaskQuery) GroupBy(field string, fields ...string) *TaskGroupBy {
 // Example:
 //
 //	var v []struct {
-//		TaskID uuid.UUID `json:"task_id,omitempty"`
+//		UUID uuid.UUID `json:"uuid,omitempty"`
 //	}
 //
 //	client.Task.Query().
-//		Select(task.FieldTaskID).
+//		Select(task.FieldUUID).
 //		Scan(ctx, &v)
 func (tq *TaskQuery) Select(fields ...string) *TaskSelect {
 	tq.ctx.Fields = append(tq.ctx.Fields, fields...)

--- a/internal/persistence/ent/db/task_update.go
+++ b/internal/persistence/ent/db/task_update.go
@@ -14,7 +14,6 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/persistence/ent/db/predicate"
 	"github.com/artefactual-sdps/enduro/internal/persistence/ent/db/task"
 	"github.com/artefactual-sdps/enduro/internal/persistence/ent/db/workflow"
-	"github.com/google/uuid"
 )
 
 // TaskUpdate is the builder for updating Task entities.
@@ -27,20 +26,6 @@ type TaskUpdate struct {
 // Where appends a list predicates to the TaskUpdate builder.
 func (tu *TaskUpdate) Where(ps ...predicate.Task) *TaskUpdate {
 	tu.mutation.Where(ps...)
-	return tu
-}
-
-// SetTaskID sets the "task_id" field.
-func (tu *TaskUpdate) SetTaskID(u uuid.UUID) *TaskUpdate {
-	tu.mutation.SetTaskID(u)
-	return tu
-}
-
-// SetNillableTaskID sets the "task_id" field if the given value is not nil.
-func (tu *TaskUpdate) SetNillableTaskID(u *uuid.UUID) *TaskUpdate {
-	if u != nil {
-		tu.SetTaskID(*u)
-	}
 	return tu
 }
 
@@ -215,9 +200,6 @@ func (tu *TaskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			}
 		}
 	}
-	if value, ok := tu.mutation.TaskID(); ok {
-		_spec.SetField(task.FieldTaskID, field.TypeUUID, value)
-	}
 	if value, ok := tu.mutation.Name(); ok {
 		_spec.SetField(task.FieldName, field.TypeString, value)
 	}
@@ -289,20 +271,6 @@ type TaskUpdateOne struct {
 	fields   []string
 	hooks    []Hook
 	mutation *TaskMutation
-}
-
-// SetTaskID sets the "task_id" field.
-func (tuo *TaskUpdateOne) SetTaskID(u uuid.UUID) *TaskUpdateOne {
-	tuo.mutation.SetTaskID(u)
-	return tuo
-}
-
-// SetNillableTaskID sets the "task_id" field if the given value is not nil.
-func (tuo *TaskUpdateOne) SetNillableTaskID(u *uuid.UUID) *TaskUpdateOne {
-	if u != nil {
-		tuo.SetTaskID(*u)
-	}
-	return tuo
 }
 
 // SetName sets the "name" field.
@@ -505,9 +473,6 @@ func (tuo *TaskUpdateOne) sqlSave(ctx context.Context) (_node *Task, err error) 
 				ps[i](selector)
 			}
 		}
-	}
-	if value, ok := tuo.mutation.TaskID(); ok {
-		_spec.SetField(task.FieldTaskID, field.TypeUUID, value)
 	}
 	if value, ok := tuo.mutation.Name(); ok {
 		_spec.SetField(task.FieldName, field.TypeString, value)

--- a/internal/persistence/ent/db/workflow.go
+++ b/internal/persistence/ent/db/workflow.go
@@ -12,6 +12,7 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/enums"
 	"github.com/artefactual-sdps/enduro/internal/persistence/ent/db/sip"
 	"github.com/artefactual-sdps/enduro/internal/persistence/ent/db/workflow"
+	"github.com/google/uuid"
 )
 
 // Workflow is the model entity for the Workflow schema.
@@ -19,6 +20,8 @@ type Workflow struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID int `json:"id,omitempty"`
+	// UUID holds the value of the "uuid" field.
+	UUID uuid.UUID `json:"uuid,omitempty"`
 	// TemporalID holds the value of the "temporal_id" field.
 	TemporalID string `json:"temporal_id,omitempty"`
 	// Type holds the value of the "type" field.
@@ -79,6 +82,8 @@ func (*Workflow) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullString)
 		case workflow.FieldStartedAt, workflow.FieldCompletedAt:
 			values[i] = new(sql.NullTime)
+		case workflow.FieldUUID:
+			values[i] = new(uuid.UUID)
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -100,6 +105,12 @@ func (w *Workflow) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field id", value)
 			}
 			w.ID = int(value.Int64)
+		case workflow.FieldUUID:
+			if value, ok := values[i].(*uuid.UUID); !ok {
+				return fmt.Errorf("unexpected type %T for field uuid", values[i])
+			} else if value != nil {
+				w.UUID = *value
+			}
 		case workflow.FieldTemporalID:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field temporal_id", values[i])
@@ -182,6 +193,9 @@ func (w *Workflow) String() string {
 	var builder strings.Builder
 	builder.WriteString("Workflow(")
 	builder.WriteString(fmt.Sprintf("id=%v, ", w.ID))
+	builder.WriteString("uuid=")
+	builder.WriteString(fmt.Sprintf("%v", w.UUID))
+	builder.WriteString(", ")
 	builder.WriteString("temporal_id=")
 	builder.WriteString(w.TemporalID)
 	builder.WriteString(", ")

--- a/internal/persistence/ent/db/workflow/where.go
+++ b/internal/persistence/ent/db/workflow/where.go
@@ -9,6 +9,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"github.com/artefactual-sdps/enduro/internal/enums"
 	"github.com/artefactual-sdps/enduro/internal/persistence/ent/db/predicate"
+	"github.com/google/uuid"
 )
 
 // ID filters vertices based on their ID field.
@@ -56,6 +57,11 @@ func IDLTE(id int) predicate.Workflow {
 	return predicate.Workflow(sql.FieldLTE(FieldID, id))
 }
 
+// UUID applies equality check predicate on the "uuid" field. It's identical to UUIDEQ.
+func UUID(v uuid.UUID) predicate.Workflow {
+	return predicate.Workflow(sql.FieldEQ(FieldUUID, v))
+}
+
 // TemporalID applies equality check predicate on the "temporal_id" field. It's identical to TemporalIDEQ.
 func TemporalID(v string) predicate.Workflow {
 	return predicate.Workflow(sql.FieldEQ(FieldTemporalID, v))
@@ -79,6 +85,46 @@ func CompletedAt(v time.Time) predicate.Workflow {
 // SipID applies equality check predicate on the "sip_id" field. It's identical to SipIDEQ.
 func SipID(v int) predicate.Workflow {
 	return predicate.Workflow(sql.FieldEQ(FieldSipID, v))
+}
+
+// UUIDEQ applies the EQ predicate on the "uuid" field.
+func UUIDEQ(v uuid.UUID) predicate.Workflow {
+	return predicate.Workflow(sql.FieldEQ(FieldUUID, v))
+}
+
+// UUIDNEQ applies the NEQ predicate on the "uuid" field.
+func UUIDNEQ(v uuid.UUID) predicate.Workflow {
+	return predicate.Workflow(sql.FieldNEQ(FieldUUID, v))
+}
+
+// UUIDIn applies the In predicate on the "uuid" field.
+func UUIDIn(vs ...uuid.UUID) predicate.Workflow {
+	return predicate.Workflow(sql.FieldIn(FieldUUID, vs...))
+}
+
+// UUIDNotIn applies the NotIn predicate on the "uuid" field.
+func UUIDNotIn(vs ...uuid.UUID) predicate.Workflow {
+	return predicate.Workflow(sql.FieldNotIn(FieldUUID, vs...))
+}
+
+// UUIDGT applies the GT predicate on the "uuid" field.
+func UUIDGT(v uuid.UUID) predicate.Workflow {
+	return predicate.Workflow(sql.FieldGT(FieldUUID, v))
+}
+
+// UUIDGTE applies the GTE predicate on the "uuid" field.
+func UUIDGTE(v uuid.UUID) predicate.Workflow {
+	return predicate.Workflow(sql.FieldGTE(FieldUUID, v))
+}
+
+// UUIDLT applies the LT predicate on the "uuid" field.
+func UUIDLT(v uuid.UUID) predicate.Workflow {
+	return predicate.Workflow(sql.FieldLT(FieldUUID, v))
+}
+
+// UUIDLTE applies the LTE predicate on the "uuid" field.
+func UUIDLTE(v uuid.UUID) predicate.Workflow {
+	return predicate.Workflow(sql.FieldLTE(FieldUUID, v))
 }
 
 // TemporalIDEQ applies the EQ predicate on the "temporal_id" field.

--- a/internal/persistence/ent/db/workflow/workflow.go
+++ b/internal/persistence/ent/db/workflow/workflow.go
@@ -15,6 +15,8 @@ const (
 	Label = "workflow"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
+	// FieldUUID holds the string denoting the uuid field in the database.
+	FieldUUID = "uuid"
 	// FieldTemporalID holds the string denoting the temporal_id field in the database.
 	FieldTemporalID = "temporal_id"
 	// FieldType holds the string denoting the type field in the database.
@@ -52,6 +54,7 @@ const (
 // Columns holds all SQL columns for workflow fields.
 var Columns = []string{
 	FieldID,
+	FieldUUID,
 	FieldTemporalID,
 	FieldType,
 	FieldStatus,
@@ -91,6 +94,11 @@ type OrderOption func(*sql.Selector)
 // ByID orders the results by the id field.
 func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByUUID orders the results by the uuid field.
+func ByUUID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldUUID, opts...).ToFunc()
 }
 
 // ByTemporalID orders the results by the temporal_id field.

--- a/internal/persistence/ent/db/workflow_query.go
+++ b/internal/persistence/ent/db/workflow_query.go
@@ -335,12 +335,12 @@ func (wq *WorkflowQuery) WithTasks(opts ...func(*TaskQuery)) *WorkflowQuery {
 // Example:
 //
 //	var v []struct {
-//		TemporalID string `json:"temporal_id,omitempty"`
+//		UUID uuid.UUID `json:"uuid,omitempty"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
 //	client.Workflow.Query().
-//		GroupBy(workflow.FieldTemporalID).
+//		GroupBy(workflow.FieldUUID).
 //		Aggregate(db.Count()).
 //		Scan(ctx, &v)
 func (wq *WorkflowQuery) GroupBy(field string, fields ...string) *WorkflowGroupBy {
@@ -358,11 +358,11 @@ func (wq *WorkflowQuery) GroupBy(field string, fields ...string) *WorkflowGroupB
 // Example:
 //
 //	var v []struct {
-//		TemporalID string `json:"temporal_id,omitempty"`
+//		UUID uuid.UUID `json:"uuid,omitempty"`
 //	}
 //
 //	client.Workflow.Query().
-//		Select(workflow.FieldTemporalID).
+//		Select(workflow.FieldUUID).
 //		Scan(ctx, &v)
 func (wq *WorkflowQuery) Select(fields ...string) *WorkflowSelect {
 	wq.ctx.Fields = append(wq.ctx.Fields, fields...)

--- a/internal/persistence/ent/schema/task.go
+++ b/internal/persistence/ent/schema/task.go
@@ -24,7 +24,9 @@ func (Task) Annotations() []schema.Annotation {
 // Fields of the Task.
 func (Task) Fields() []ent.Field {
 	return []ent.Field{
-		field.UUID("task_id", uuid.New()),
+		field.UUID("uuid", uuid.UUID{}).
+			Unique().
+			Immutable(),
 		field.String("name").
 			Annotations(entsql.Annotation{
 				Size: 2048,

--- a/internal/persistence/ent/schema/workflow.go
+++ b/internal/persistence/ent/schema/workflow.go
@@ -6,6 +6,7 @@ import (
 	"entgo.io/ent/schema"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"github.com/google/uuid"
 
 	"github.com/artefactual-sdps/enduro/internal/enums"
 )
@@ -25,6 +26,9 @@ func (Workflow) Annotations() []schema.Annotation {
 // Fields of the Workflow.
 func (Workflow) Fields() []ent.Field {
 	return []ent.Field{
+		field.UUID("uuid", uuid.UUID{}).
+			Unique().
+			Immutable(),
 		field.String("temporal_id").
 			Annotations(entsql.Annotation{
 				Size: 255,

--- a/internal/workflow/local_activities_test.go
+++ b/internal/workflow/local_activities_test.go
@@ -24,6 +24,7 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 	t.Parallel()
 
 	sipUUID := uuid.New()
+	workflowUUID := uuid.New()
 	startedAt := time.Date(2024, 6, 13, 17, 50, 13, 0, time.UTC)
 	completedAt := time.Date(2024, 6, 13, 17, 50, 14, 0, time.UTC)
 
@@ -38,6 +39,7 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 		{
 			name: "Creates a workflow",
 			params: &createWorkflowLocalActivityParams{
+				UUID:        workflowUUID,
 				TemporalID:  "workflow-id",
 				Type:        enums.WorkflowTypeCreateAip,
 				Status:      enums.WorkflowStatusDone,
@@ -47,6 +49,7 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 			},
 			mockCalls: func(m *ingest_fake.MockServiceMockRecorder) {
 				m.CreateWorkflow(mockutil.Context(), &datatypes.Workflow{
+					UUID:        workflowUUID,
 					TemporalID:  "workflow-id",
 					Type:        enums.WorkflowTypeCreateAip,
 					Status:      enums.WorkflowStatusDone,
@@ -63,6 +66,7 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 		{
 			name: "Does not pass zero dates",
 			params: &createWorkflowLocalActivityParams{
+				UUID:       workflowUUID,
 				TemporalID: "workflow-id",
 				Type:       enums.WorkflowTypeCreateAip,
 				Status:     enums.WorkflowStatusDone,
@@ -70,6 +74,7 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 			},
 			mockCalls: func(m *ingest_fake.MockServiceMockRecorder) {
 				m.CreateWorkflow(mockutil.Context(), &datatypes.Workflow{
+					UUID:       workflowUUID,
 					TemporalID: "workflow-id",
 					Type:       enums.WorkflowTypeCreateAip,
 					Status:     enums.WorkflowStatusDone,
@@ -84,6 +89,7 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 		{
 			name: "Fails if there is a persistence error",
 			params: &createWorkflowLocalActivityParams{
+				UUID:       workflowUUID,
 				TemporalID: "workflow-id",
 				Type:       enums.WorkflowTypeCreateAip,
 				Status:     enums.WorkflowStatusDone,
@@ -91,6 +97,7 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 			},
 			mockCalls: func(m *ingest_fake.MockServiceMockRecorder) {
 				m.CreateWorkflow(mockutil.Context(), &datatypes.Workflow{
+					UUID:       workflowUUID,
 					TemporalID: "workflow-id",
 					Type:       enums.WorkflowTypeCreateAip,
 					Status:     enums.WorkflowStatusDone,

--- a/internal/workflow/localact/save_preprocessing_tasks.go
+++ b/internal/workflow/localact/save_preprocessing_tasks.go
@@ -22,8 +22,8 @@ type SavePreprocessingTasksActivityParams struct {
 	// RNG is a random number generator source.
 	RNG io.Reader
 
-	// WorkflowID is the primary key of the parent Workflow.
-	WorkflowID int
+	// WorkflowUUID is the UUID of the parent Workflow.
+	WorkflowUUID uuid.UUID
 
 	// Tasks is a list of preprocessing tasks to save as Tasks.
 	Tasks []preprocessing.Task
@@ -41,13 +41,9 @@ func SavePreprocessingTasksActivity(
 	var res SavePreprocessingTasksActivityResult
 	for _, t := range params.Tasks {
 		task := preprocTaskToTask(t)
-		task.WorkflowID = params.WorkflowID
-
-		u, err := uuid.NewRandomFromReader(params.RNG)
-		if err != nil {
-			return &res, fmt.Errorf("SavePreprocessingTasksActivity: generate UUID: %v", err)
-		}
-		task.TaskID = u.String()
+		task.WorkflowUUID = params.WorkflowUUID
+		// TODO: Create deterministic UUIDs and make activities idempotent.
+		task.UUID = uuid.Must(uuid.NewRandomFromReader(params.RNG))
 
 		if err := params.Ingestsvc.CreateTask(ctx, &task); err != nil {
 			return &res, fmt.Errorf("SavePreprocessingTasksActivity: %v", err)

--- a/internal/workflow/localact/save_preprocessing_tasks_test.go
+++ b/internal/workflow/localact/save_preprocessing_tasks_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"go.artefactual.dev/tools/mockutil"
 	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
 	"go.uber.org/mock/gomock"
@@ -22,6 +23,8 @@ import (
 func TestSavePreprocessingTasksActivity(t *testing.T) {
 	t.Parallel()
 
+	wUUID := uuid.New()
+	taskUUID := uuid.MustParse("52fdfc07-2182-454f-963f-5f0f9a621d72")
 	startedAt := time.Date(2024, 6, 13, 17, 50, 13, 0, time.UTC)
 	completedAt := time.Date(2024, 6, 13, 17, 50, 14, 0, time.UTC)
 
@@ -36,7 +39,7 @@ func TestSavePreprocessingTasksActivity(t *testing.T) {
 		{
 			name: "Saves a preprocessing task",
 			params: localact.SavePreprocessingTasksActivityParams{
-				WorkflowID: 101,
+				WorkflowUUID: wUUID,
 				Tasks: []preprocessing.Task{
 					{
 						Name:        "Validate SIP structure",
@@ -49,13 +52,13 @@ func TestSavePreprocessingTasksActivity(t *testing.T) {
 			},
 			mockCalls: func(m *ingest_fake.MockServiceMockRecorder) {
 				m.CreateTask(mockutil.Context(), &datatypes.Task{
-					TaskID:      "52fdfc07-2182-454f-963f-5f0f9a621d72",
-					Name:        "Validate SIP structure",
-					Status:      enums.TaskStatusDone,
-					StartedAt:   sql.NullTime{Time: startedAt, Valid: true},
-					CompletedAt: sql.NullTime{Time: completedAt, Valid: true},
-					Note:        "SIP structure matches validation criteria",
-					WorkflowID:  101,
+					UUID:         taskUUID,
+					Name:         "Validate SIP structure",
+					Status:       enums.TaskStatusDone,
+					StartedAt:    sql.NullTime{Time: startedAt, Valid: true},
+					CompletedAt:  sql.NullTime{Time: completedAt, Valid: true},
+					Note:         "SIP structure matches validation criteria",
+					WorkflowUUID: wUUID,
 				}).Return(nil)
 			},
 			want: &localact.SavePreprocessingTasksActivityResult{
@@ -65,7 +68,7 @@ func TestSavePreprocessingTasksActivity(t *testing.T) {
 		{
 			name: "Errors when a required value is missing",
 			params: localact.SavePreprocessingTasksActivityParams{
-				WorkflowID: 101,
+				WorkflowUUID: wUUID,
 				Tasks: []preprocessing.Task{
 					{
 						Message:     "SIP structure matches validation criteria",
@@ -77,12 +80,12 @@ func TestSavePreprocessingTasksActivity(t *testing.T) {
 			},
 			mockCalls: func(m *ingest_fake.MockServiceMockRecorder) {
 				m.CreateTask(mockutil.Context(), &datatypes.Task{
-					TaskID:      "52fdfc07-2182-454f-963f-5f0f9a621d72",
-					Status:      enums.TaskStatusDone,
-					StartedAt:   sql.NullTime{Time: startedAt, Valid: true},
-					CompletedAt: sql.NullTime{Time: completedAt, Valid: true},
-					Note:        "SIP structure matches validation criteria",
-					WorkflowID:  101,
+					UUID:         taskUUID,
+					Status:       enums.TaskStatusDone,
+					StartedAt:    sql.NullTime{Time: startedAt, Valid: true},
+					CompletedAt:  sql.NullTime{Time: completedAt, Valid: true},
+					Note:         "SIP structure matches validation criteria",
+					WorkflowUUID: wUUID,
 				}).Return(errors.New(
 					"task: create: invalid data error: field Name is required",
 				))

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -29,6 +29,9 @@ type workflowState struct {
 	// It is populated by createWorkflowLocalActivity.
 	workflowID int
 
+	// UUID of the persisted workflow.
+	workflowUUID uuid.UUID
+
 	// sip and aip track the state of the respective packages.
 	sip *sipInfo
 	aip *aipInfo


### PR DESCRIPTION
- Add UUID columns to ingest workflows and tasks.
- Use workflow UUID and a transaction to create tasks.
- Replace workflow and task IDs by UUIDs in API design.
- Update dashboard API client and use UUIDs instead of IDs.

Refs #1209.