### PR TITLE
Update event package for different event types

### DIFF
--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -134,10 +134,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Set up the event service.
-	evsvc, err := event.NewEventServiceRedis(logger.WithName("events"), tp, &cfg.Event)
+	// Set up the ingest event service.
+	ingestEventSvc, err := event.NewIngestEventServiceRedis(logger.WithName("ingest-events"), tp, &cfg.Event)
 	if err != nil {
-		logger.Error(err, "Error creating Event service.")
+		logger.Error(err, "Error creating Ingest Event service.")
 		os.Exit(1)
 	}
 
@@ -181,7 +181,7 @@ func main() {
 			logger.WithName("ingest"),
 			enduroDatabase,
 			temporalClient,
-			evsvc,
+			ingestEventSvc,
 			perSvc,
 			&auth.NoopTokenVerifier{},
 			nil,

--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -150,10 +150,10 @@ func main() {
 		}
 	}
 
-	// Set up the event service.
-	evsvc, err := event.NewEventServiceRedis(logger.WithName("events"), tp, &cfg.Event)
+	// Set up the ingest event service.
+	ingestEventSvc, err := event.NewIngestEventServiceRedis(logger.WithName("ingest-events"), tp, &cfg.Event)
 	if err != nil {
-		logger.Error(err, "Error creating Event service.")
+		logger.Error(err, "Error creating Ingest Event service.")
 		os.Exit(1)
 	}
 
@@ -197,7 +197,7 @@ func main() {
 			logger.WithName("ingest"),
 			enduroDatabase,
 			temporalClient,
-			evsvc,
+			ingestEventSvc,
 			perSvc,
 			&auth.NoopTokenVerifier{},
 			nil,

--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -151,10 +151,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Set up the event service.
-	evsvc, err := event.NewEventServiceRedis(logger.WithName("events"), tp, &cfg.Event)
+	// Set up the ingest event service.
+	ingestEventSvc, err := event.NewIngestEventServiceRedis(logger.WithName("ingest-events"), tp, &cfg.Event)
 	if err != nil {
-		logger.Error(err, "Error creating Event service.")
+		logger.Error(err, "Error creating Ingest Event service.")
 		os.Exit(1)
 	}
 
@@ -232,7 +232,7 @@ func main() {
 			logger.WithName("ingest"),
 			enduroDatabase,
 			temporalClient,
-			evsvc,
+			ingestEventSvc,
 			perSvc,
 			tokenVerifier,
 			ticketProvider,
@@ -325,7 +325,7 @@ func main() {
 			logger.WithName("internal-ingest"),
 			enduroDatabase,
 			temporalClient,
-			evsvc,
+			ingestEventSvc,
 			perSvc,
 			&auth.NoopTokenVerifier{},
 			ticketProvider,

--- a/enduro.toml
+++ b/enduro.toml
@@ -78,7 +78,8 @@ migrate = true
 
 [event]
 redisAddress = "redis://redis.enduro-sdps:6379"
-redisChannel = "enduro-events"
+ingestRedisChannel = "enduro-ingest-events"
+storageRedisChannel = "enduro-storage-events"
 
 [extractActivity]
 dirMode = "0o700"

--- a/internal/event/config.go
+++ b/internal/event/config.go
@@ -1,6 +1,7 @@
 package event
 
 type Config struct {
-	RedisAddress string
-	RedisChannel string
+	RedisAddress        string
+	IngestRedisChannel  string
+	StorageRedisChannel string
 }

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -2,43 +2,30 @@ package event
 
 import (
 	"context"
-
-	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
 )
 
 const (
 	// EventBufferSize is the buffer size of the channel for each subscription.
-	EventBufferSize = 16
+	EventBufferSize = 256
 )
 
-// EventService represents a service for managing event dispatch and event
+// Service represents a generic service for managing event dispatch and event
 // listeners (aka subscriptions).
-type EventService interface {
-	// Publishes an event to a user's event listeners.
+type Service[T any] interface {
+	// PublishEvent publishes an event to a user's event listeners.
 	// If the user is not currently subscribed then this is a no-op.
-	PublishEvent(ctx context.Context, event *goaingest.IngestEvent)
+	PublishEvent(ctx context.Context, event T)
 
-	// Creates a subscription. Caller must call Subscription.Close() when done
+	// Subscribe creates a subscription. Caller must call Subscription.Close() when done
 	// with the subscription.
-	Subscribe(ctx context.Context) (Subscription, error)
-}
-
-// NopEventService returns an event service that does nothing.
-func NopEventService() EventService { return &nopEventService{} }
-
-type nopEventService struct{}
-
-func (*nopEventService) PublishEvent(ctx context.Context, event *goaingest.IngestEvent) {}
-
-func (*nopEventService) Subscribe(ctx context.Context) (Subscription, error) {
-	panic("not implemented")
+	Subscribe(ctx context.Context) (Subscription[T], error)
 }
 
 // Subscription represents a stream of events for a single user.
-type Subscription interface {
-	// Event stream for all user's event.
-	C() <-chan *goaingest.IngestEvent
+type Subscription[T any] interface {
+	// C returns the event stream for all user's events.
+	C() <-chan T
 
-	// Closes the event stream channel and disconnects from the event service.
+	// Close closes the event stream channel and disconnects from the event service.
 	Close() error
 }

--- a/internal/event/helpers.go
+++ b/internal/event/helpers.go
@@ -1,0 +1,69 @@
+package event
+
+import (
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/trace"
+
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
+)
+
+// Type aliases for convenience.
+type (
+	IngestEventService  = Service[*goaingest.IngestEvent]
+	StorageEventService = Service[*goastorage.StorageEvent]
+	IngestSubscription  = Subscription[*goaingest.IngestEvent]
+	StorageSubscription = Subscription[*goastorage.StorageEvent]
+)
+
+// Compile-time interface compliance checks.
+var (
+	_ IngestEventService  = (*serviceInMemImpl[*goaingest.IngestEvent])(nil)
+	_ StorageEventService = (*serviceInMemImpl[*goastorage.StorageEvent])(nil)
+	_ IngestSubscription  = (*subscriptionInMemImpl[*goaingest.IngestEvent])(nil)
+	_ StorageSubscription = (*subscriptionInMemImpl[*goastorage.StorageEvent])(nil)
+	_ IngestEventService  = (*nopService[*goaingest.IngestEvent])(nil)
+	_ StorageEventService = (*nopService[*goastorage.StorageEvent])(nil)
+	_ IngestEventService  = (*serviceRedisImpl[*goaingest.IngestEvent])(nil)
+	_ StorageEventService = (*serviceRedisImpl[*goastorage.StorageEvent])(nil)
+	_ IngestSubscription  = (*subscriptionRedisImpl[*goaingest.IngestEvent])(nil)
+	_ StorageSubscription = (*subscriptionRedisImpl[*goastorage.StorageEvent])(nil)
+)
+
+// NewIngestEventServiceInMem returns a new instance of an in-memory ingest event service.
+func NewIngestEventServiceInMem() IngestEventService {
+	return newServiceInMem[*goaingest.IngestEvent]()
+}
+
+// NewStorageEventServiceInMem returns a new instance of an in-memory storage event service.
+func NewStorageEventServiceInMem() StorageEventService {
+	return newServiceInMem[*goastorage.StorageEvent]()
+}
+
+// NewIngestEventServiceNop returns an ingest event service that does nothing.
+func NewIngestEventServiceNop() IngestEventService {
+	return &nopService[*goaingest.IngestEvent]{}
+}
+
+// NewStorageEventServiceNop returns a storage event service that does nothing.
+func NewStorageEventServiceNop() StorageEventService {
+	return &nopService[*goastorage.StorageEvent]{}
+}
+
+// NewIngestEventServiceRedis returns a new instance of a Redis ingest event service.
+func NewIngestEventServiceRedis(
+	logger logr.Logger,
+	tp trace.TracerProvider,
+	cfg *Config,
+) (IngestEventService, error) {
+	return newServiceRedis(logger, tp, cfg.RedisAddress, cfg.IngestRedisChannel, &ingestEventSerializer{})
+}
+
+// NewStorageEventServiceRedis returns a new instance of a Redis storage event service.
+func NewStorageEventServiceRedis(
+	logger logr.Logger,
+	tp trace.TracerProvider,
+	cfg *Config,
+) (StorageEventService, error) {
+	return newServiceRedis(logger, tp, cfg.RedisAddress, cfg.StorageRedisChannel, &storageEventSerializer{})
+}

--- a/internal/event/inmem_test.go
+++ b/internal/event/inmem_test.go
@@ -1,17 +1,19 @@
 package event_test
 
 import (
-	"context"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
 	"github.com/artefactual-sdps/enduro/internal/event"
 )
 
-func TestEventService(t *testing.T) {
+func TestIngestEventService(t *testing.T) {
 	t.Run("Subscribe", func(t *testing.T) {
-		ctx := context.Background()
-		s := event.NewEventServiceInMemImpl()
+		ctx := t.Context()
+		s := event.NewIngestEventServiceInMem()
 
 		subA, err := s.Subscribe(ctx)
 		if err != nil {
@@ -23,53 +25,199 @@ func TestEventService(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Publish event to both users
+		// Publish event to both users.
 		s.PublishEvent(ctx, &goaingest.IngestEvent{})
 
 		// Verify both subscribers received the update.
 		select {
 		case <-subA.C():
 		default:
-			t.Fatal("expected event")
+			t.Fatal("expected an event")
 		}
 
 		select {
 		case <-subB.C():
 		default:
-			t.Fatal("expected event")
+			t.Fatal("expected an event")
 		}
 	})
 
 	t.Run("Unsubscribe", func(t *testing.T) {
-		ctx := context.Background()
-		s := event.NewEventServiceInMemImpl()
+		ctx := t.Context()
+		s := event.NewIngestEventServiceInMem()
 
 		sub, err := s.Subscribe(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		// Publish event & close.
-		s.PublishEvent(ctx, &goaingest.IngestEvent{})
 		if err := sub.Close(); err != nil {
 			t.Fatal(err)
 		}
 
-		// Verify event is still received.
+		// Publish event after unsubscribe.
+		s.PublishEvent(ctx, &goaingest.IngestEvent{})
+
+		// Verify subscriber did not receive the update.
 		select {
-		case <-sub.C():
+		case _, ok := <-sub.C():
+			if ok {
+				t.Fatal("unexpected event")
+			}
+		default:
+			t.Fatal("expected channel to be closed")
+		}
+	})
+}
+
+func TestStorageEventService(t *testing.T) {
+	t.Run("Subscribe", func(t *testing.T) {
+		ctx := t.Context()
+		s := event.NewStorageEventServiceInMem()
+
+		subA, err := s.Subscribe(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		subB, err := s.Subscribe(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Publish event to both users.
+		s.PublishEvent(ctx, &goastorage.StorageEvent{})
+
+		// Verify both subscribers received the update.
+		select {
+		case <-subA.C():
+		default:
+			t.Fatal("expected an event")
+		}
+
+		select {
+		case <-subB.C():
+		default:
+			t.Fatal("expected an event")
+		}
+	})
+
+	t.Run("Unsubscribe", func(t *testing.T) {
+		ctx := t.Context()
+		s := event.NewStorageEventServiceInMem()
+
+		sub, err := s.Subscribe(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := sub.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Publish event after unsubscribe.
+		s.PublishEvent(ctx, &goastorage.StorageEvent{})
+
+		// Verify subscriber did not receive the update.
+		select {
+		case _, ok := <-sub.C():
+			if ok {
+				t.Fatal("unexpected event")
+			}
+		default:
+			t.Fatal("expected channel to be closed")
+		}
+	})
+}
+
+func TestPublishHelpers(t *testing.T) {
+	t.Run("PublishIngestEvent", func(t *testing.T) {
+		ctx := t.Context()
+		s := event.NewIngestEventServiceInMem()
+
+		sub, err := s.Subscribe(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		event.PublishIngestEvent(ctx, s, &goaingest.SIPCreatedEvent{})
+
+		// Verify subscriber received the event.
+		select {
+		case event := <-sub.C():
+			if event.IngestValue == nil {
+				t.Fatal("expected event to contain data")
+			}
+		default:
+			t.Fatal("expected an event")
+		}
+	})
+
+	t.Run("PublishStorageEvent", func(t *testing.T) {
+		ctx := t.Context()
+		s := event.NewStorageEventServiceInMem()
+
+		sub, err := s.Subscribe(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		event.PublishStorageEvent(ctx, s, &goastorage.AIPCreatedEvent{})
+
+		// Verify subscriber received the event.
+		select {
+		case event := <-sub.C():
+			if event.StorageValue == nil {
+				t.Fatal("expected event to contain data")
+			}
 		default:
 			t.Fatal("expected event")
 		}
-
-		// Ensure channel is now closed.
-		if _, ok := <-sub.C(); ok {
-			t.Fatal("expected closed channel")
-		}
-
-		// Ensure unsubscribing twice is ok.
-		if err := sub.Close(); err != nil {
-			t.Fatal(err)
-		}
 	})
+}
+
+func TestInMemEventBufferOverflow(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	s := event.NewIngestEventServiceInMem()
+
+	sub, err := s.Subscribe(ctx)
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		sub.Close()
+	})
+
+	// Fill the buffer beyond its capacity without reading from it.
+	// This should not cause the subscription to hang or disconnect.
+	for range event.EventBufferSize + 5 {
+		event.PublishIngestEvent(ctx, s, &goaingest.IngestPingEvent{})
+	}
+
+	// Verify subscriber is still connected by checking that we can
+	// read events from the buffer (it should contain EventBufferSize events).
+	eventsReceived := 0
+loop:
+	for range event.EventBufferSize {
+		select {
+		case <-sub.C():
+			eventsReceived++
+		default:
+			break loop
+		}
+	}
+
+	if eventsReceived != event.EventBufferSize {
+		t.Fatalf("expected %d events in buffer, got %d", event.EventBufferSize, eventsReceived)
+	}
+
+	// Verify subscriber can still receive new events after buffer overflow.
+	event.PublishIngestEvent(ctx, s, &goaingest.IngestPingEvent{})
+
+	select {
+	case <-sub.C():
+		// Successfully received new event after overflow.
+	default:
+		t.Fatal("subscriber should still be able to receive events after buffer overflow")
+	}
 }

--- a/internal/event/nop.go
+++ b/internal/event/nop.go
@@ -1,0 +1,14 @@
+package event
+
+import (
+	"context"
+	"errors"
+)
+
+type nopService[T any] struct{}
+
+func (*nopService[T]) PublishEvent(ctx context.Context, event T) {}
+
+func (*nopService[T]) Subscribe(ctx context.Context) (Subscription[T], error) {
+	return nil, errors.New("Subscribe not supported by nop service")
+}

--- a/internal/event/nop_test.go
+++ b/internal/event/nop_test.go
@@ -1,0 +1,67 @@
+package event_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
+	"github.com/artefactual-sdps/enduro/internal/event"
+)
+
+func TestIngestEventServiceNopPublishEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	svc := event.NewIngestEventServiceNop()
+
+	svc.PublishEvent(ctx, &goaingest.IngestEvent{})
+}
+
+func TestStorageEventServiceNopPublishEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	svc := event.NewStorageEventServiceNop()
+
+	svc.PublishEvent(ctx, &goastorage.StorageEvent{})
+}
+
+func TestIngestEventServiceNopSubscribe(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	svc := event.NewIngestEventServiceNop()
+
+	_, err := svc.Subscribe(ctx)
+	assert.ErrorContains(t, err, "Subscribe not supported by nop service")
+}
+
+func TestStorageEventServiceNopSubscribe(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	svc := event.NewStorageEventServiceNop()
+
+	_, err := svc.Subscribe(ctx)
+	assert.ErrorContains(t, err, "Subscribe not supported by nop service")
+}
+
+func TestIngestEventServiceNopWithPublishHelper(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	svc := event.NewIngestEventServiceNop()
+
+	event.PublishIngestEvent(ctx, svc, &goaingest.IngestPingEvent{})
+}
+
+func TestStorageEventServiceNopWithPublishHelper(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	svc := event.NewStorageEventServiceNop()
+
+	event.PublishStorageEvent(ctx, svc, &goastorage.StoragePingEvent{})
+}

--- a/internal/event/publish.go
+++ b/internal/event/publish.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
 )
 
-func PublishEvent(ctx context.Context, events EventService, event any) {
+// PublishIngestEvent publishes an ingest event with type safety.
+func PublishIngestEvent(ctx context.Context, svc IngestEventService, event any) {
 	update := &goaingest.IngestEvent{}
 
 	switch v := event.(type) {
@@ -30,5 +32,35 @@ func PublishEvent(ctx context.Context, events EventService, event any) {
 		panic("tried to publish unexpected event")
 	}
 
-	events.PublishEvent(ctx, update)
+	svc.PublishEvent(ctx, update)
+}
+
+// PublishStorageEvent publishes a storage event with type safety.
+func PublishStorageEvent(ctx context.Context, svc StorageEventService, event any) {
+	update := &goastorage.StorageEvent{}
+
+	switch v := event.(type) {
+	case *goastorage.StoragePingEvent:
+		update.StorageValue = v
+	case *goastorage.LocationCreatedEvent:
+		update.StorageValue = v
+	case *goastorage.LocationUpdatedEvent:
+		update.StorageValue = v
+	case *goastorage.AIPCreatedEvent:
+		update.StorageValue = v
+	case *goastorage.AIPUpdatedEvent:
+		update.StorageValue = v
+	case *goastorage.AIPWorkflowCreatedEvent:
+		update.StorageValue = v
+	case *goastorage.AIPWorkflowUpdatedEvent:
+		update.StorageValue = v
+	case *goastorage.AIPTaskCreatedEvent:
+		update.StorageValue = v
+	case *goastorage.AIPTaskUpdatedEvent:
+		update.StorageValue = v
+	default:
+		panic("tried to publish unexpected event")
+	}
+
+	svc.PublishEvent(ctx, update)
 }

--- a/internal/event/publish_test.go
+++ b/internal/event/publish_test.go
@@ -1,0 +1,84 @@
+package event_test
+
+import (
+	"testing"
+
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
+	"github.com/artefactual-sdps/enduro/internal/event"
+)
+
+func TestPublishIngestEventTypes(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	svc := event.NewIngestEventServiceInMem()
+
+	for _, tt := range []struct {
+		name   string
+		event  any
+		panics bool
+	}{
+		{"IngestPingEvent", &goaingest.IngestPingEvent{}, false},
+		{"SIPCreatedEvent", &goaingest.SIPCreatedEvent{}, false},
+		{"SIPUpdatedEvent", &goaingest.SIPUpdatedEvent{}, false},
+		{"SIPStatusUpdatedEvent", &goaingest.SIPStatusUpdatedEvent{}, false},
+		{"SIPWorkflowCreatedEvent", &goaingest.SIPWorkflowCreatedEvent{}, false},
+		{"SIPWorkflowUpdatedEvent", &goaingest.SIPWorkflowUpdatedEvent{}, false},
+		{"SIPTaskCreatedEvent", &goaingest.SIPTaskCreatedEvent{}, false},
+		{"SIPTaskUpdatedEvent", &goaingest.SIPTaskUpdatedEvent{}, false},
+		{"UnexpectedEvent", &goastorage.StoragePingEvent{}, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.panics {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Fatal("Expected panic but none occurred")
+					}
+				}()
+			}
+
+			event.PublishIngestEvent(ctx, svc, tt.event)
+		})
+	}
+}
+
+func TestPublishStorageEventTypes(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	svc := event.NewStorageEventServiceInMem()
+
+	for _, tt := range []struct {
+		name   string
+		event  any
+		panics bool
+	}{
+		{"StoragePingEvent", &goastorage.StoragePingEvent{}, false},
+		{"LocationCreatedEvent", &goastorage.LocationCreatedEvent{}, false},
+		{"LocationUpdatedEvent", &goastorage.LocationUpdatedEvent{}, false},
+		{"AIPCreatedEvent", &goastorage.AIPCreatedEvent{}, false},
+		{"AIPUpdatedEvent", &goastorage.AIPUpdatedEvent{}, false},
+		{"AIPWorkflowCreatedEvent", &goastorage.AIPWorkflowCreatedEvent{}, false},
+		{"AIPWorkflowUpdatedEvent", &goastorage.AIPWorkflowUpdatedEvent{}, false},
+		{"AIPTaskCreatedEvent", &goastorage.AIPTaskCreatedEvent{}, false},
+		{"AIPTaskUpdatedEvent", &goastorage.AIPTaskUpdatedEvent{}, false},
+		{"UnexpectedEvent", &goastorage.IngestPingEvent{}, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.panics {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Fatal("Expected panic but none occurred")
+					}
+				}()
+			}
+
+			event.PublishStorageEvent(ctx, svc, tt.event)
+		})
+	}
+}

--- a/internal/event/redis_test.go
+++ b/internal/event/redis_test.go
@@ -1,7 +1,6 @@
 package event_test
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -14,18 +13,18 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/artefactual-sdps/enduro/internal/api/gen/http/ingest/server"
+	storageserver "github.com/artefactual-sdps/enduro/internal/api/gen/http/storage/server"
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
 	"github.com/artefactual-sdps/enduro/internal/event"
 )
 
-// Confirm that PublishEvent is streaming events via Redis.
-func TestEventServiceRedisPublish(t *testing.T) {
+func TestIngestEventServiceRedisPublish(t *testing.T) {
 	t.Parallel()
 
-	const channel = "enduro-events"
-
-	ctx := context.Background()
+	ctx := t.Context()
 	s := miniredis.RunT(t)
+	channel := "enduro-ingest-events"
 
 	c := redis.NewClient(&redis.Options{
 		Addr: s.Addr(),
@@ -34,6 +33,7 @@ func TestEventServiceRedisPublish(t *testing.T) {
 	t.Cleanup(func() {
 		sub.Close()
 	})
+
 	// Call Receive to force the connection to wait a response from
 	// Redis so the subscription is active immediately.
 	_, err := sub.Receive(ctx)
@@ -50,16 +50,14 @@ func TestEventServiceRedisPublish(t *testing.T) {
 	}()
 
 	cfg := event.Config{
-		RedisAddress: "redis://" + s.Addr(),
-		RedisChannel: channel,
+		RedisAddress:       "redis://" + s.Addr(),
+		IngestRedisChannel: channel,
 	}
-	svc, err := event.NewEventServiceRedis(testr.New(t), noop.NewTracerProvider(), &cfg)
+	svc, err := event.NewIngestEventServiceRedis(testr.New(t), noop.NewTracerProvider(), &cfg)
 	assert.NilError(t, err)
 
-	svc.PublishEvent(ctx, &goaingest.IngestEvent{
-		IngestValue: &goaingest.IngestPingEvent{
-			Message: ref.New("hello"),
-		},
+	event.PublishIngestEvent(ctx, svc, &goaingest.IngestPingEvent{
+		Message: ref.New("hello"),
 	})
 
 	select {
@@ -74,18 +72,17 @@ func TestEventServiceRedisPublish(t *testing.T) {
 	}
 }
 
-// Confirm that Subscribe is capturing events received via Redis.
-func TestEventServiceRedisSubscribe(t *testing.T) {
+func TestIngestEventServiceRedisSubscribe(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	s := miniredis.RunT(t)
 
 	cfg := event.Config{
-		RedisAddress: "redis://" + s.Addr(),
-		RedisChannel: "enduro-events",
+		RedisAddress:       "redis://" + s.Addr(),
+		IngestRedisChannel: "enduro-ingest-events",
 	}
-	svc, err := event.NewEventServiceRedis(testr.New(t), noop.NewTracerProvider(), &cfg)
+	svc, err := event.NewIngestEventServiceRedis(testr.New(t), noop.NewTracerProvider(), &cfg)
 	assert.NilError(t, err)
 
 	sub, err := svc.Subscribe(ctx)
@@ -105,7 +102,7 @@ func TestEventServiceRedisSubscribe(t *testing.T) {
 	blob, err := json.Marshal(server.NewMonitorResponseBody(&ev))
 	assert.NilError(t, err)
 
-	err = c.Publish(ctx, cfg.RedisChannel, blob).Err()
+	err = c.Publish(ctx, cfg.IngestRedisChannel, blob).Err()
 	assert.NilError(t, err)
 
 	select {
@@ -113,5 +110,164 @@ func TestEventServiceRedisSubscribe(t *testing.T) {
 		assert.DeepEqual(t, ret, &ev)
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout!")
+	}
+}
+
+func TestStorageEventServiceRedisPublish(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	s := miniredis.RunT(t)
+	channel := "enduro-storage-events"
+
+	c := redis.NewClient(&redis.Options{
+		Addr: s.Addr(),
+	})
+	sub := c.Subscribe(ctx, channel)
+	t.Cleanup(func() {
+		sub.Close()
+	})
+
+	// Call Receive to force the connection to wait a response from
+	// Redis so the subscription is active immediately.
+	_, err := sub.Receive(ctx)
+	assert.NilError(t, err)
+
+	input := make(chan *redis.Message)
+
+	go func() {
+		ch := sub.Channel()
+		for message := range ch {
+			input <- message
+			break
+		}
+	}()
+
+	cfg := event.Config{
+		RedisAddress:        "redis://" + s.Addr(),
+		StorageRedisChannel: channel,
+	}
+	svc, err := event.NewStorageEventServiceRedis(testr.New(t), noop.NewTracerProvider(), &cfg)
+	assert.NilError(t, err)
+
+	event.PublishStorageEvent(ctx, svc, &goastorage.StoragePingEvent{
+		Message: ref.New("hello"),
+	})
+
+	select {
+	case ret := <-input:
+		assert.DeepEqual(
+			t,
+			ret.Payload,
+			`{"storage_value":{"Type":"storage_ping_event","Value":"{\"Message\":\"hello\"}"}}`,
+		)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout!")
+	}
+}
+
+func TestStorageEventServiceRedisSubscribe(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	s := miniredis.RunT(t)
+
+	cfg := event.Config{
+		RedisAddress:        "redis://" + s.Addr(),
+		StorageRedisChannel: "enduro-storage-events",
+	}
+	svc, err := event.NewStorageEventServiceRedis(testr.New(t), noop.NewTracerProvider(), &cfg)
+	assert.NilError(t, err)
+
+	sub, err := svc.Subscribe(ctx)
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		sub.Close()
+	})
+
+	c := redis.NewClient(&redis.Options{
+		Addr: s.Addr(),
+	})
+
+	ev := goastorage.StorageEvent{
+		StorageValue: &goastorage.StoragePingEvent{
+			Message: ref.New("hello"),
+		},
+	}
+
+	blob, err := json.Marshal(storageserver.NewMonitorResponseBody(&ev))
+	assert.NilError(t, err)
+
+	err = c.Publish(ctx, cfg.StorageRedisChannel, blob).Err()
+	assert.NilError(t, err)
+
+	select {
+	case ret := <-sub.C():
+		assert.DeepEqual(t, ret, &ev)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout!")
+	}
+}
+
+func TestRedisEventBufferOverflow(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	s := miniredis.RunT(t)
+
+	cfg := event.Config{
+		RedisAddress:       "redis://" + s.Addr(),
+		IngestRedisChannel: "enduro-ingest-events",
+	}
+	svc, err := event.NewIngestEventServiceRedis(testr.New(t), noop.NewTracerProvider(), &cfg)
+	assert.NilError(t, err)
+
+	sub, err := svc.Subscribe(ctx)
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		sub.Close()
+	})
+
+	// Fill the buffer beyond its capacity without reading from it.
+	// This should not cause the subscription to hang or disconnect.
+	for range event.EventBufferSize + 5 {
+		event.PublishIngestEvent(ctx, svc, &goaingest.IngestPingEvent{})
+	}
+
+	// Give some time for events to be processed.
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify subscriber is still connected by reading available events from the buffer.
+	// Due to Redis async nature, we may not get exactly EventBufferSize events,
+	// but we should get a substantial number if the subscriber remained connected.
+	eventsReceived := 0
+loop:
+	for eventsReceived < event.EventBufferSize {
+		select {
+		case <-sub.C():
+			eventsReceived++
+		case <-time.After(2 * time.Second):
+			break loop
+		default:
+			break loop
+		}
+	}
+
+	// We should have received a significant number of events (at least half the buffer)
+	// to prove the subscriber remained connected during overflow.
+	minExpected := event.EventBufferSize / 2
+	if eventsReceived < minExpected {
+		t.Fatalf("expected at least %d events in buffer, got %d", minExpected, eventsReceived)
+	}
+
+	// Verify subscriber can still receive new events after buffer overflow.
+	event.PublishIngestEvent(ctx, svc, &goaingest.IngestPingEvent{})
+
+	// Wait for the new event.
+	select {
+	case <-sub.C():
+		// Successfully received new event after overflow.
+	case <-time.After(1 * time.Second):
+		t.Fatal("subscriber should still be able to receive events after buffer overflow")
 	}
 }

--- a/internal/event/serializer.go
+++ b/internal/event/serializer.go
@@ -1,0 +1,59 @@
+package event
+
+import (
+	"encoding/json"
+
+	ingestclient "github.com/artefactual-sdps/enduro/internal/api/gen/http/ingest/client"
+	ingestserver "github.com/artefactual-sdps/enduro/internal/api/gen/http/ingest/server"
+	storageclient "github.com/artefactual-sdps/enduro/internal/api/gen/http/storage/client"
+	storageserver "github.com/artefactual-sdps/enduro/internal/api/gen/http/storage/server"
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
+)
+
+// eventSerializer handles serialization/deserialization of events.
+type eventSerializer[T any] interface {
+	marshal(event T) ([]byte, error)
+	unmarshal(data []byte) (T, error)
+}
+
+var (
+	_ eventSerializer[*goaingest.IngestEvent]   = (*ingestEventSerializer)(nil)
+	_ eventSerializer[*goastorage.StorageEvent] = (*storageEventSerializer)(nil)
+)
+
+// ingestEventSerializer handles ingest events.
+type ingestEventSerializer struct{}
+
+func (s *ingestEventSerializer) marshal(event *goaingest.IngestEvent) ([]byte, error) {
+	return json.Marshal(ingestserver.NewMonitorResponseBody(event))
+}
+
+func (s *ingestEventSerializer) unmarshal(data []byte) (*goaingest.IngestEvent, error) {
+	payload := ingestclient.MonitorResponseBody{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, err
+	}
+	if err := ingestclient.ValidateMonitorResponseBody(&payload); err != nil {
+		return nil, err
+	}
+	return ingestclient.NewMonitorIngestEventOK(&payload), nil
+}
+
+// storageEventSerializer handles storage events.
+type storageEventSerializer struct{}
+
+func (s *storageEventSerializer) marshal(event *goastorage.StorageEvent) ([]byte, error) {
+	return json.Marshal(storageserver.NewMonitorResponseBody(event))
+}
+
+func (s *storageEventSerializer) unmarshal(data []byte) (*goastorage.StorageEvent, error) {
+	payload := storageclient.MonitorResponseBody{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, err
+	}
+	if err := storageclient.ValidateMonitorResponseBody(&payload); err != nil {
+		return nil, err
+	}
+	return storageclient.NewMonitorStorageEventOK(&payload), nil
+}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -63,7 +63,7 @@ type ingestImpl struct {
 	logger          logr.Logger
 	db              *sqlx.DB
 	tc              temporalsdk_client.Client
-	evsvc           event.EventService
+	evsvc           event.IngestEventService
 	perSvc          persistence.Service
 	tokenVerifier   auth.TokenVerifier
 	ticketProvider  auth.TicketProvider
@@ -80,7 +80,7 @@ func NewService(
 	logger logr.Logger,
 	db *sql.DB,
 	tc temporalsdk_client.Client,
-	evsvc event.EventService,
+	evsvc event.IngestEventService,
 	psvc persistence.Service,
 	tokenVerifier auth.TokenVerifier,
 	ticketProvider auth.TicketProvider,
@@ -120,7 +120,7 @@ func (svc *ingestImpl) CreateSIP(ctx context.Context, s *datatypes.SIP) error {
 		return fmt.Errorf("ingest: create SIP: %v", err)
 	}
 
-	event.PublishEvent(ctx, svc.evsvc, sipToCreatedEvent(s))
+	event.PublishIngestEvent(ctx, svc.evsvc, sipToCreatedEvent(s))
 
 	return nil
 }
@@ -136,7 +136,7 @@ func (svc *ingestImpl) UpdateSIP(
 	}
 
 	ev := &goaingest.SIPUpdatedEvent{UUID: id, Item: s.Goa()}
-	event.PublishEvent(ctx, svc.evsvc, ev)
+	event.PublishIngestEvent(ctx, svc.evsvc, ev)
 
 	return s, nil
 }
@@ -153,7 +153,7 @@ func (svc *ingestImpl) SetStatus(ctx context.Context, id uuid.UUID, status enums
 	}
 
 	ev := &goaingest.SIPStatusUpdatedEvent{UUID: id, Status: status.String()}
-	event.PublishEvent(ctx, svc.evsvc, ev)
+	event.PublishIngestEvent(ctx, svc.evsvc, ev)
 
 	return nil
 }
@@ -174,7 +174,7 @@ func (svc *ingestImpl) SetStatusInProgress(ctx context.Context, id uuid.UUID, st
 		return err
 	}
 
-	event.PublishEvent(ctx, svc.evsvc, &goaingest.SIPStatusUpdatedEvent{
+	event.PublishIngestEvent(ctx, svc.evsvc, &goaingest.SIPStatusUpdatedEvent{
 		UUID:   id,
 		Status: enums.SIPStatusProcessing.String(),
 	})

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -37,7 +37,7 @@ func testSvc(t *testing.T, internalBucket *blob.Bucket, uploadMaxSize int64) (
 		logr.Discard(),
 		&sql.DB{},
 		temporalClient,
-		event.NopEventService(),
+		event.NewIngestEventServiceNop(),
 		psvc,
 		&auth.NoopTokenVerifier{},
 		auth.NewTicketProvider(t.Context(), nil, nil),

--- a/internal/ingest/monitor.go
+++ b/internal/ingest/monitor.go
@@ -78,7 +78,7 @@ func (w *goaWrapper) Monitor(
 			}
 
 		case event, ok := <-sub.C():
-			if !ok {
+			if !ok || event == nil {
 				return nil
 			}
 

--- a/internal/ingest/monitor_test.go
+++ b/internal/ingest/monitor_test.go
@@ -208,7 +208,7 @@ func TestMonitor(t *testing.T) {
 			t.Parallel()
 
 			tpMock := authfake.NewMockTicketProvider(gomock.NewController(t))
-			evsvc := event.NewEventServiceInMemImpl()
+			evsvc := event.NewIngestEventServiceInMem()
 			stream := &mockMonitorServerStream{}
 
 			gw := &goaWrapper{

--- a/internal/ingest/task.go
+++ b/internal/ingest/task.go
@@ -18,7 +18,7 @@ func (svc *ingestImpl) CreateTask(ctx context.Context, task *datatypes.Task) err
 		return fmt.Errorf("task: create: %v", err)
 	}
 
-	event.PublishEvent(ctx, svc.evsvc, &goaingest.SIPTaskCreatedEvent{
+	event.PublishIngestEvent(ctx, svc.evsvc, &goaingest.SIPTaskCreatedEvent{
 		UUID: task.UUID,
 		Item: taskToGoa(task),
 	})
@@ -57,7 +57,7 @@ func (svc *ingestImpl) CompleteTask(
 		return fmt.Errorf("error updating task: %v", err)
 	}
 
-	event.PublishEvent(ctx, svc.evsvc, &goaingest.SIPTaskUpdatedEvent{
+	event.PublishIngestEvent(ctx, svc.evsvc, &goaingest.SIPTaskUpdatedEvent{
 		UUID: task.UUID,
 		Item: taskToGoa(task),
 	})

--- a/internal/ingest/upload.go
+++ b/internal/ingest/upload.go
@@ -137,7 +137,7 @@ func (w *goaWrapper) initSIP(
 		return errors.Join(err, w.perSvc.DeleteSIP(ctx, s.ID))
 	}
 
-	event.PublishEvent(ctx, w.evsvc, sipToCreatedEvent(s))
+	event.PublishIngestEvent(ctx, w.evsvc, sipToCreatedEvent(s))
 
 	return nil
 }

--- a/internal/ingest/workflow.go
+++ b/internal/ingest/workflow.go
@@ -24,7 +24,7 @@ func (svc *ingestImpl) CreateWorkflow(
 		UUID: w.UUID,
 		Item: workflowToGoa(w),
 	}
-	event.PublishEvent(ctx, svc.evsvc, ev)
+	event.PublishIngestEvent(ctx, svc.evsvc, ev)
 
 	return nil
 }
@@ -46,7 +46,7 @@ func (svc *ingestImpl) SetWorkflowStatus(
 	}
 
 	if item, err := svc.readWorkflow(ctx, ID); err == nil {
-		event.PublishEvent(
+		event.PublishIngestEvent(
 			ctx,
 			svc.evsvc,
 			&goaingest.SIPWorkflowUpdatedEvent{UUID: item.UUID, Item: item},
@@ -75,7 +75,7 @@ func (svc *ingestImpl) CompleteWorkflow(
 	}
 
 	if item, err := svc.readWorkflow(ctx, ID); err == nil {
-		event.PublishEvent(
+		event.PublishIngestEvent(
 			ctx,
 			svc.evsvc,
 			&goaingest.SIPWorkflowUpdatedEvent{UUID: item.UUID, Item: item},


### PR DESCRIPTION
- Add generic Service[T] interface supporting type-safe event handling.
- Add IngestEventService and StorageEventService with type aliases.
- Add Serializer interface for ingest/storage events serialization.
- Support separate Redis channels for ingest and storage via config.
- Send Redis events without blocking and consider stop channel.
- Skip events when the buffer is fills up.
- Increase buffer size to 256.
- Add storage publish helper.

Refs #1222, depends on #1301.