### PR TITLE
Fix uploader creation on SIP upload

### DIFF
--- a/internal/datatypes/sip.go
+++ b/internal/datatypes/sip.go
@@ -12,12 +12,6 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/enums"
 )
 
-type Uploader struct {
-	UUID  uuid.UUID
-	Email string
-	Name  string
-}
-
 // SIP represents a SIP.
 type SIP struct {
 	ID     int
@@ -42,7 +36,7 @@ type SIP struct {
 	FailedKey string
 
 	// Uploader is the user that uploaded the SIP.
-	Uploader *Uploader
+	Uploader *User
 }
 
 // Goa returns the API representation of the SIP.

--- a/internal/ingest/goa_test.go
+++ b/internal/ingest/goa_test.go
@@ -148,7 +148,7 @@ var (
 				Time:  time.Date(2024, 9, 25, 9, 31, 12, 0, time.UTC),
 				Valid: true,
 			},
-			Uploader: &datatypes.Uploader{
+			Uploader: &datatypes.User{
 				UUID:  uuid.MustParse("0b075937-458c-43d9-b46c-222a072d62a9"),
 				Email: "uploader@example.com",
 				Name:  "Test Uploader",

--- a/internal/persistence/ent/client/client_test.go
+++ b/internal/persistence/ent/client/client_test.go
@@ -3,6 +3,7 @@ package entclient_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -58,6 +59,9 @@ func createUser(
 		SetUUID(uuid).
 		SetEmail("nobody@example.com").
 		SetName("Test User").
+		SetCreatedAt(time.Now()).
+		SetOidcIss("https://example.com/oidc").
+		SetOidcSub("1234567890").
 		Save(t.Context())
 }
 

--- a/internal/persistence/ent/client/convert.go
+++ b/internal/persistence/ent/client/convert.go
@@ -34,12 +34,8 @@ func convertSIP(sip *db.SIP) *datatypes.SIP {
 	if sip.AipID != uuid.Nil {
 		s.AIPID = uuid.NullUUID{UUID: sip.AipID, Valid: true}
 	}
-	if sip.UploaderID != 0 && sip.Edges.User != nil {
-		s.Uploader = &datatypes.Uploader{
-			UUID:  sip.Edges.User.UUID,
-			Email: sip.Edges.User.Email,
-			Name:  sip.Edges.User.Name,
-		}
+	if sip.Edges.Uploader != nil {
+		s.Uploader = convertUser(sip.Edges.Uploader)
 	}
 
 	return &s

--- a/internal/persistence/ent/client/user_test.go
+++ b/internal/persistence/ent/client/user_test.go
@@ -86,7 +86,7 @@ func TestCreateUser(t *testing.T) {
 			assert.NilError(t, err)
 
 			assert.DeepEqual(t, &user, tt.want,
-				cmpopts.EquateApproxTime(time.Millisecond*100),
+				cmpopts.EquateApproxTime(time.Second),
 				cmpopts.IgnoreUnexported(db.User{}, db.UserEdges{}),
 			)
 		})

--- a/internal/persistence/ent/db/client.go
+++ b/internal/persistence/ent/db/client.go
@@ -351,15 +351,15 @@ func (c *SIPClient) QueryWorkflows(s *SIP) *WorkflowQuery {
 	return query
 }
 
-// QueryUser queries the user edge of a SIP.
-func (c *SIPClient) QueryUser(s *SIP) *UserQuery {
+// QueryUploader queries the uploader edge of a SIP.
+func (c *SIPClient) QueryUploader(s *SIP) *UserQuery {
 	query := (&UserClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := s.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(sip.Table, sip.FieldID, id),
 			sqlgraph.To(user.Table, user.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, sip.UserTable, sip.UserColumn),
+			sqlgraph.Edge(sqlgraph.M2O, true, sip.UploaderTable, sip.UploaderColumn),
 		)
 		fromV = sqlgraph.Neighbors(s.driver.Dialect(), step)
 		return fromV, nil

--- a/internal/persistence/ent/db/mutation.go
+++ b/internal/persistence/ent/db/mutation.go
@@ -54,8 +54,8 @@ type SIPMutation struct {
 	workflows        map[int]struct{}
 	removedworkflows map[int]struct{}
 	clearedworkflows bool
-	user             *int
-	cleareduser      bool
+	uploader         *int
+	cleareduploader  bool
 	done             bool
 	oldValue         func(context.Context) (*SIP, error)
 	predicates       []predicate.SIP
@@ -550,12 +550,12 @@ func (m *SIPMutation) ResetFailedKey() {
 
 // SetUploaderID sets the "uploader_id" field.
 func (m *SIPMutation) SetUploaderID(i int) {
-	m.user = &i
+	m.uploader = &i
 }
 
 // UploaderID returns the value of the "uploader_id" field in the mutation.
 func (m *SIPMutation) UploaderID() (r int, exists bool) {
-	v := m.user
+	v := m.uploader
 	if v == nil {
 		return
 	}
@@ -581,7 +581,7 @@ func (m *SIPMutation) OldUploaderID(ctx context.Context) (v int, err error) {
 
 // ClearUploaderID clears the value of the "uploader_id" field.
 func (m *SIPMutation) ClearUploaderID() {
-	m.user = nil
+	m.uploader = nil
 	m.clearedFields[sip.FieldUploaderID] = struct{}{}
 }
 
@@ -593,7 +593,7 @@ func (m *SIPMutation) UploaderIDCleared() bool {
 
 // ResetUploaderID resets all changes to the "uploader_id" field.
 func (m *SIPMutation) ResetUploaderID() {
-	m.user = nil
+	m.uploader = nil
 	delete(m.clearedFields, sip.FieldUploaderID)
 }
 
@@ -651,44 +651,31 @@ func (m *SIPMutation) ResetWorkflows() {
 	m.removedworkflows = nil
 }
 
-// SetUserID sets the "user" edge to the User entity by id.
-func (m *SIPMutation) SetUserID(id int) {
-	m.user = &id
-}
-
-// ClearUser clears the "user" edge to the User entity.
-func (m *SIPMutation) ClearUser() {
-	m.cleareduser = true
+// ClearUploader clears the "uploader" edge to the User entity.
+func (m *SIPMutation) ClearUploader() {
+	m.cleareduploader = true
 	m.clearedFields[sip.FieldUploaderID] = struct{}{}
 }
 
-// UserCleared reports if the "user" edge to the User entity was cleared.
-func (m *SIPMutation) UserCleared() bool {
-	return m.UploaderIDCleared() || m.cleareduser
+// UploaderCleared reports if the "uploader" edge to the User entity was cleared.
+func (m *SIPMutation) UploaderCleared() bool {
+	return m.UploaderIDCleared() || m.cleareduploader
 }
 
-// UserID returns the "user" edge ID in the mutation.
-func (m *SIPMutation) UserID() (id int, exists bool) {
-	if m.user != nil {
-		return *m.user, true
-	}
-	return
-}
-
-// UserIDs returns the "user" edge IDs in the mutation.
+// UploaderIDs returns the "uploader" edge IDs in the mutation.
 // Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// UserID instead. It exists only for internal usage by the builders.
-func (m *SIPMutation) UserIDs() (ids []int) {
-	if id := m.user; id != nil {
+// UploaderID instead. It exists only for internal usage by the builders.
+func (m *SIPMutation) UploaderIDs() (ids []int) {
+	if id := m.uploader; id != nil {
 		ids = append(ids, *id)
 	}
 	return
 }
 
-// ResetUser resets all changes to the "user" edge.
-func (m *SIPMutation) ResetUser() {
-	m.user = nil
-	m.cleareduser = false
+// ResetUploader resets all changes to the "uploader" edge.
+func (m *SIPMutation) ResetUploader() {
+	m.uploader = nil
+	m.cleareduploader = false
 }
 
 // Where appends a list predicates to the SIPMutation builder.
@@ -753,7 +740,7 @@ func (m *SIPMutation) Fields() []string {
 	if m.failed_key != nil {
 		fields = append(fields, sip.FieldFailedKey)
 	}
-	if m.user != nil {
+	if m.uploader != nil {
 		fields = append(fields, sip.FieldUploaderID)
 	}
 	return fields
@@ -1023,8 +1010,8 @@ func (m *SIPMutation) AddedEdges() []string {
 	if m.workflows != nil {
 		edges = append(edges, sip.EdgeWorkflows)
 	}
-	if m.user != nil {
-		edges = append(edges, sip.EdgeUser)
+	if m.uploader != nil {
+		edges = append(edges, sip.EdgeUploader)
 	}
 	return edges
 }
@@ -1039,8 +1026,8 @@ func (m *SIPMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
-	case sip.EdgeUser:
-		if id := m.user; id != nil {
+	case sip.EdgeUploader:
+		if id := m.uploader; id != nil {
 			return []ent.Value{*id}
 		}
 	}
@@ -1076,8 +1063,8 @@ func (m *SIPMutation) ClearedEdges() []string {
 	if m.clearedworkflows {
 		edges = append(edges, sip.EdgeWorkflows)
 	}
-	if m.cleareduser {
-		edges = append(edges, sip.EdgeUser)
+	if m.cleareduploader {
+		edges = append(edges, sip.EdgeUploader)
 	}
 	return edges
 }
@@ -1088,8 +1075,8 @@ func (m *SIPMutation) EdgeCleared(name string) bool {
 	switch name {
 	case sip.EdgeWorkflows:
 		return m.clearedworkflows
-	case sip.EdgeUser:
-		return m.cleareduser
+	case sip.EdgeUploader:
+		return m.cleareduploader
 	}
 	return false
 }
@@ -1098,8 +1085,8 @@ func (m *SIPMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *SIPMutation) ClearEdge(name string) error {
 	switch name {
-	case sip.EdgeUser:
-		m.ClearUser()
+	case sip.EdgeUploader:
+		m.ClearUploader()
 		return nil
 	}
 	return fmt.Errorf("unknown SIP unique edge %s", name)
@@ -1112,8 +1099,8 @@ func (m *SIPMutation) ResetEdge(name string) error {
 	case sip.EdgeWorkflows:
 		m.ResetWorkflows()
 		return nil
-	case sip.EdgeUser:
-		m.ResetUser()
+	case sip.EdgeUploader:
+		m.ResetUploader()
 		return nil
 	}
 	return fmt.Errorf("unknown SIP edge %s", name)

--- a/internal/persistence/ent/db/sip.go
+++ b/internal/persistence/ent/db/sip.go
@@ -50,8 +50,8 @@ type SIP struct {
 type SIPEdges struct {
 	// Workflows holds the value of the workflows edge.
 	Workflows []*Workflow `json:"workflows,omitempty"`
-	// User holds the value of the user edge.
-	User *User `json:"user,omitempty"`
+	// Uploader holds the value of the uploader edge.
+	Uploader *User `json:"uploader,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
 	loadedTypes [2]bool
@@ -66,15 +66,15 @@ func (e SIPEdges) WorkflowsOrErr() ([]*Workflow, error) {
 	return nil, &NotLoadedError{edge: "workflows"}
 }
 
-// UserOrErr returns the User value or an error if the edge
+// UploaderOrErr returns the Uploader value or an error if the edge
 // was not loaded in eager-loading, or loaded but was not found.
-func (e SIPEdges) UserOrErr() (*User, error) {
-	if e.User != nil {
-		return e.User, nil
+func (e SIPEdges) UploaderOrErr() (*User, error) {
+	if e.Uploader != nil {
+		return e.Uploader, nil
 	} else if e.loadedTypes[1] {
 		return nil, &NotFoundError{label: user.Label}
 	}
-	return nil, &NotLoadedError{edge: "user"}
+	return nil, &NotLoadedError{edge: "uploader"}
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -189,9 +189,9 @@ func (s *SIP) QueryWorkflows() *WorkflowQuery {
 	return NewSIPClient(s.config).QueryWorkflows(s)
 }
 
-// QueryUser queries the "user" edge of the SIP entity.
-func (s *SIP) QueryUser() *UserQuery {
-	return NewSIPClient(s.config).QueryUser(s)
+// QueryUploader queries the "uploader" edge of the SIP entity.
+func (s *SIP) QueryUploader() *UserQuery {
+	return NewSIPClient(s.config).QueryUploader(s)
 }
 
 // Update returns a builder for updating this SIP.

--- a/internal/persistence/ent/db/sip/sip.go
+++ b/internal/persistence/ent/db/sip/sip.go
@@ -38,8 +38,8 @@ const (
 	FieldUploaderID = "uploader_id"
 	// EdgeWorkflows holds the string denoting the workflows edge name in mutations.
 	EdgeWorkflows = "workflows"
-	// EdgeUser holds the string denoting the user edge name in mutations.
-	EdgeUser = "user"
+	// EdgeUploader holds the string denoting the uploader edge name in mutations.
+	EdgeUploader = "uploader"
 	// Table holds the table name of the sip in the database.
 	Table = "sip"
 	// WorkflowsTable is the table that holds the workflows relation/edge.
@@ -49,13 +49,13 @@ const (
 	WorkflowsInverseTable = "workflow"
 	// WorkflowsColumn is the table column denoting the workflows relation/edge.
 	WorkflowsColumn = "sip_id"
-	// UserTable is the table that holds the user relation/edge.
-	UserTable = "sip"
-	// UserInverseTable is the table name for the User entity.
+	// UploaderTable is the table that holds the uploader relation/edge.
+	UploaderTable = "sip"
+	// UploaderInverseTable is the table name for the User entity.
 	// It exists in this package in order to avoid circular dependency with the "user" package.
-	UserInverseTable = "user"
-	// UserColumn is the table column denoting the user relation/edge.
-	UserColumn = "uploader_id"
+	UploaderInverseTable = "user"
+	// UploaderColumn is the table column denoting the uploader relation/edge.
+	UploaderColumn = "uploader_id"
 )
 
 // Columns holds all SQL columns for sip fields.
@@ -182,10 +182,10 @@ func ByWorkflows(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	}
 }
 
-// ByUserField orders the results by user field.
-func ByUserField(field string, opts ...sql.OrderTermOption) OrderOption {
+// ByUploaderField orders the results by uploader field.
+func ByUploaderField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
+		sqlgraph.OrderByNeighborTerms(s, newUploaderStep(), sql.OrderByField(field, opts...))
 	}
 }
 func newWorkflowsStep() *sqlgraph.Step {
@@ -195,10 +195,10 @@ func newWorkflowsStep() *sqlgraph.Step {
 		sqlgraph.Edge(sqlgraph.O2M, false, WorkflowsTable, WorkflowsColumn),
 	)
 }
-func newUserStep() *sqlgraph.Step {
+func newUploaderStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(UserInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, true, UserTable, UserColumn),
+		sqlgraph.To(UploaderInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, UploaderTable, UploaderColumn),
 	)
 }

--- a/internal/persistence/ent/db/sip/where.go
+++ b/internal/persistence/ent/db/sip/where.go
@@ -590,21 +590,21 @@ func HasWorkflowsWith(preds ...predicate.Workflow) predicate.SIP {
 	})
 }
 
-// HasUser applies the HasEdge predicate on the "user" edge.
-func HasUser() predicate.SIP {
+// HasUploader applies the HasEdge predicate on the "uploader" edge.
+func HasUploader() predicate.SIP {
 	return predicate.SIP(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, UserTable, UserColumn),
+			sqlgraph.Edge(sqlgraph.M2O, true, UploaderTable, UploaderColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
 
-// HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
-func HasUserWith(preds ...predicate.User) predicate.SIP {
+// HasUploaderWith applies the HasEdge predicate on the "uploader" edge with a given conditions (other predicates).
+func HasUploaderWith(preds ...predicate.User) predicate.SIP {
 	return predicate.SIP(func(s *sql.Selector) {
-		step := newUserStep()
+		step := newUploaderStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/persistence/ent/db/sip_create.go
+++ b/internal/persistence/ent/db/sip_create.go
@@ -155,23 +155,9 @@ func (sc *SIPCreate) AddWorkflows(w ...*Workflow) *SIPCreate {
 	return sc.AddWorkflowIDs(ids...)
 }
 
-// SetUserID sets the "user" edge to the User entity by ID.
-func (sc *SIPCreate) SetUserID(id int) *SIPCreate {
-	sc.mutation.SetUserID(id)
-	return sc
-}
-
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (sc *SIPCreate) SetNillableUserID(id *int) *SIPCreate {
-	if id != nil {
-		sc = sc.SetUserID(*id)
-	}
-	return sc
-}
-
-// SetUser sets the "user" edge to the User entity.
-func (sc *SIPCreate) SetUser(u *User) *SIPCreate {
-	return sc.SetUserID(u.ID)
+// SetUploader sets the "uploader" edge to the User entity.
+func (sc *SIPCreate) SetUploader(u *User) *SIPCreate {
+	return sc.SetUploaderID(u.ID)
 }
 
 // Mutation returns the SIPMutation object of the builder.
@@ -322,12 +308,12 @@ func (sc *SIPCreate) createSpec() (*SIP, *sqlgraph.CreateSpec) {
 		}
 		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if nodes := sc.mutation.UserIDs(); len(nodes) > 0 {
+	if nodes := sc.mutation.UploaderIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
 			Inverse: true,
-			Table:   sip.UserTable,
-			Columns: []string{sip.UserColumn},
+			Table:   sip.UploaderTable,
+			Columns: []string{sip.UploaderColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),

--- a/internal/persistence/ent/db/sip_update.go
+++ b/internal/persistence/ent/db/sip_update.go
@@ -195,23 +195,9 @@ func (su *SIPUpdate) AddWorkflows(w ...*Workflow) *SIPUpdate {
 	return su.AddWorkflowIDs(ids...)
 }
 
-// SetUserID sets the "user" edge to the User entity by ID.
-func (su *SIPUpdate) SetUserID(id int) *SIPUpdate {
-	su.mutation.SetUserID(id)
-	return su
-}
-
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (su *SIPUpdate) SetNillableUserID(id *int) *SIPUpdate {
-	if id != nil {
-		su = su.SetUserID(*id)
-	}
-	return su
-}
-
-// SetUser sets the "user" edge to the User entity.
-func (su *SIPUpdate) SetUser(u *User) *SIPUpdate {
-	return su.SetUserID(u.ID)
+// SetUploader sets the "uploader" edge to the User entity.
+func (su *SIPUpdate) SetUploader(u *User) *SIPUpdate {
+	return su.SetUploaderID(u.ID)
 }
 
 // Mutation returns the SIPMutation object of the builder.
@@ -240,9 +226,9 @@ func (su *SIPUpdate) RemoveWorkflows(w ...*Workflow) *SIPUpdate {
 	return su.RemoveWorkflowIDs(ids...)
 }
 
-// ClearUser clears the "user" edge to the User entity.
-func (su *SIPUpdate) ClearUser() *SIPUpdate {
-	su.mutation.ClearUser()
+// ClearUploader clears the "uploader" edge to the User entity.
+func (su *SIPUpdate) ClearUploader() *SIPUpdate {
+	su.mutation.ClearUploader()
 	return su
 }
 
@@ -386,12 +372,12 @@ func (su *SIPUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if su.mutation.UserCleared() {
+	if su.mutation.UploaderCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
 			Inverse: true,
-			Table:   sip.UserTable,
-			Columns: []string{sip.UserColumn},
+			Table:   sip.UploaderTable,
+			Columns: []string{sip.UploaderColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
@@ -399,12 +385,12 @@ func (su *SIPUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := su.mutation.UserIDs(); len(nodes) > 0 {
+	if nodes := su.mutation.UploaderIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
 			Inverse: true,
-			Table:   sip.UserTable,
-			Columns: []string{sip.UserColumn},
+			Table:   sip.UploaderTable,
+			Columns: []string{sip.UploaderColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
@@ -598,23 +584,9 @@ func (suo *SIPUpdateOne) AddWorkflows(w ...*Workflow) *SIPUpdateOne {
 	return suo.AddWorkflowIDs(ids...)
 }
 
-// SetUserID sets the "user" edge to the User entity by ID.
-func (suo *SIPUpdateOne) SetUserID(id int) *SIPUpdateOne {
-	suo.mutation.SetUserID(id)
-	return suo
-}
-
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (suo *SIPUpdateOne) SetNillableUserID(id *int) *SIPUpdateOne {
-	if id != nil {
-		suo = suo.SetUserID(*id)
-	}
-	return suo
-}
-
-// SetUser sets the "user" edge to the User entity.
-func (suo *SIPUpdateOne) SetUser(u *User) *SIPUpdateOne {
-	return suo.SetUserID(u.ID)
+// SetUploader sets the "uploader" edge to the User entity.
+func (suo *SIPUpdateOne) SetUploader(u *User) *SIPUpdateOne {
+	return suo.SetUploaderID(u.ID)
 }
 
 // Mutation returns the SIPMutation object of the builder.
@@ -643,9 +615,9 @@ func (suo *SIPUpdateOne) RemoveWorkflows(w ...*Workflow) *SIPUpdateOne {
 	return suo.RemoveWorkflowIDs(ids...)
 }
 
-// ClearUser clears the "user" edge to the User entity.
-func (suo *SIPUpdateOne) ClearUser() *SIPUpdateOne {
-	suo.mutation.ClearUser()
+// ClearUploader clears the "uploader" edge to the User entity.
+func (suo *SIPUpdateOne) ClearUploader() *SIPUpdateOne {
+	suo.mutation.ClearUploader()
 	return suo
 }
 
@@ -819,12 +791,12 @@ func (suo *SIPUpdateOne) sqlSave(ctx context.Context) (_node *SIP, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if suo.mutation.UserCleared() {
+	if suo.mutation.UploaderCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
 			Inverse: true,
-			Table:   sip.UserTable,
-			Columns: []string{sip.UserColumn},
+			Table:   sip.UploaderTable,
+			Columns: []string{sip.UploaderColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),
@@ -832,12 +804,12 @@ func (suo *SIPUpdateOne) sqlSave(ctx context.Context) (_node *SIP, err error) {
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := suo.mutation.UserIDs(); len(nodes) > 0 {
+	if nodes := suo.mutation.UploaderIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
 			Inverse: true,
-			Table:   sip.UserTable,
-			Columns: []string{sip.UserColumn},
+			Table:   sip.UploaderTable,
+			Columns: []string{sip.UploaderColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt),

--- a/internal/persistence/ent/schema/sip.go
+++ b/internal/persistence/ent/schema/sip.go
@@ -66,7 +66,7 @@ func (SIP) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("workflows", Workflow.Type).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
-		edge.From("user", User.Type).
+		edge.From("uploader", User.Type).
 			Field("uploader_id").
 			Ref("uploaded_sips").
 			Unique(),


### PR DESCRIPTION
Use a single transaction to find or create the user and create the SIP. Reuse the User datatype for the SIP Uploader to be able to pass the OIDC fields on SIP creation. Also, check user claims before streaming the upload and rename SIP edge in the DB schema from to uploader.

Refs #1291.