### PR TITLE
Add an ingest event audit logger

### DIFF
--- a/enduro.toml
+++ b/enduro.toml
@@ -80,6 +80,23 @@ migrate = true
 redisAddress = "redis://redis.enduro-sdps:6379"
 redisChannel = "enduro-ingest-events"
 
+[auditlog]
+# filePath is the absolute path to the ingest audit log. The enduro user will
+# need write access to the given directory. Rotated logs will use the same
+# directory and filename, but with a timestamp appended. If filePath is not set,
+# or set to an empty string, audit logging will be disabled.
+filePath = "/home/enduro/logs/enduro_ingest_audit.log"
+# maxSize is the maximum size, in megabytes, of the audit log file. When the
+# log file reaches maxSize or greater it will be rotated (default: 100 MB).
+maxSize = 100
+# compress determines if the rotated log files are compressed using gzip
+# (default: false).
+compress = false
+# verbosity determines the minimum level threshold for a log message to be
+# recorded. Currently supported levels are: -4 = DEBUG, 0 = INFO (default),
+# 4 = WARN, 8 = ERROR.
+verbosity = 0
+
 [extractActivity]
 dirMode = "0o700"
 fileMode = "0o600"
@@ -143,26 +160,26 @@ shareDir = "/home/a3m/.local/share/a3m/share"
 capacity = 1
 
 [a3m.processing]
-AssignUuidsToDirectories                     = true
-ExamineContents                              = true
-GenerateTransferStructureReport              = true
-DocumentEmptyDirectories                     = true
-ExtractPackages                              = true
-DeletePackagesAfterExtraction                = true
-IdentifyTransfer                             = true
-IdentifySubmissionAndMetadata                = true
-IdentifyBeforeNormalization                  = true
-Normalize                                    = true
-TranscribeFiles                              = true
-PerformPolicyChecksOnOriginals               = true
+AssignUuidsToDirectories = true
+ExamineContents = true
+GenerateTransferStructureReport = true
+DocumentEmptyDirectories = true
+ExtractPackages = true
+DeletePackagesAfterExtraction = true
+IdentifyTransfer = true
+IdentifySubmissionAndMetadata = true
+IdentifyBeforeNormalization = true
+Normalize = true
+TranscribeFiles = true
+PerformPolicyChecksOnOriginals = true
 PerformPolicyChecksOnPreservationDerivatives = true
-AipCompressionLevel                          = 1
-AipCompressionAlgorithm                      = 6
+AipCompressionLevel = 1
+AipCompressionAlgorithm = 6
 
 [am]
 address = ""
-user = "" # Secret: set with env var ENDURO_AM_USER.
-apiKey = "" # Secret: set with env var ENDURO_AM_APIKEY.
+user = ""                      # Secret: set with env var ENDURO_AM_USER.
+apiKey = ""                    # Secret: set with env var ENDURO_AM_APIKEY.
 processingConfig = "automated"
 
 # capacity limits the number of transfers a worker can process at one time

--- a/go.mod
+++ b/go.mod
@@ -207,6 +207,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250324211829-b45e905df463 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1691,6 +1691,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -1,0 +1,76 @@
+package auditlog
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/artefactual-sdps/enduro/internal/event"
+)
+
+type EventHandler[T any] func(T) *Event
+
+type Auditlog[T any] struct {
+	logger  *slog.Logger
+	w       io.WriteCloser
+	sub     event.Subscription[T]
+	handler EventHandler[T]
+	stopCh  chan struct{}
+}
+
+// New creates a new Auditlog instance with the provided logger and event
+// handler.  It is the caller's responsibility to close any writers used by the
+// logger when done logging.
+func New[T any](l *slog.Logger, h EventHandler[T]) *Auditlog[T] {
+	return &Auditlog[T]{
+		logger:  l,
+		handler: h,
+		stopCh:  make(chan struct{}),
+	}
+}
+
+// Listen subscribes to the provided event service and starts listening for
+// events to log.  If the subscription fails, an error is returned immediately.
+// When done logging `Close()` should be called to stop the listener and close
+// any open resources.
+func (a *Auditlog[T]) Listen(ctx context.Context, svc event.Service[T]) error {
+	sub, err := svc.Subscribe(ctx)
+	if err != nil {
+		return fmt.Errorf("audit log: subscribe: %w", err)
+	}
+	a.sub = sub
+
+	go func() {
+		for {
+			select {
+			case <-a.stopCh:
+				return
+			case r, ok := <-a.sub.C():
+				if !ok {
+					return
+				}
+
+				ev := a.handler(r)
+				if ev != nil {
+					a.logger.Log(ctx, ev.Level, ev.Msg, ev.Args()...)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Close stops the audit log listener and closes any open resources.
+func (a *Auditlog[T]) Close() error {
+	close(a.stopCh)
+	a.sub.Close()
+
+	// Close the log writer if we control it.
+	if a.w != nil {
+		a.w.Close()
+	}
+
+	return nil
+}

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -1,0 +1,95 @@
+package auditlog_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/auditlog"
+	"github.com/artefactual-sdps/enduro/internal/event"
+)
+
+func testLogger(w io.Writer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			// Set time to a deterministic value for testing.
+			if a.Key == slog.TimeKey {
+				a.Value = slog.TimeValue(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+				return a
+			}
+			return a
+		},
+	}))
+}
+
+func TestAuditLog(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		name    string
+		evsvc   event.Service[*auditlog.Event]
+		handler auditlog.EventHandler[*auditlog.Event]
+		want    string
+		wantErr string
+	}
+	for _, tc := range []test{
+		{
+			name:  "Logs an event",
+			evsvc: event.NewServiceInMem[*auditlog.Event](),
+			handler: func(e *auditlog.Event) *auditlog.Event {
+				return e
+			},
+			want: `{"time":"2025-01-01T00:00:00Z","level":"INFO","msg":"SIP created","type":"sip.created","objectID":"sip-123","userID":"user-456"}
+`,
+		},
+		{
+			name:  "Returns error when subscription fails",
+			evsvc: event.NewServiceNop[*auditlog.Event](),
+			handler: func(e *auditlog.Event) *auditlog.Event {
+				return e
+			},
+			wantErr: "audit log: subscribe: Subscribe not supported by nop service",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Use a pipe as a thread-safe read/write buffer.
+			r, w := io.Pipe()
+			al := auditlog.New(testLogger(w), tc.handler)
+
+			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			defer cancel()
+
+			// Start the audit log listener.
+			err := al.Listen(ctx, tc.evsvc)
+			if tc.wantErr != "" {
+				assert.Error(t, err, tc.wantErr)
+				return
+			}
+			defer al.Close()
+
+			tc.evsvc.PublishEvent(ctx, &auditlog.Event{
+				Level:    0,
+				Msg:      "SIP created",
+				Type:     "sip.created",
+				ObjectID: "sip-123",
+				UserID:   "user-456",
+			})
+
+			// Wait 10ms for the event to publish, then close the writer end of
+			// the pipe to send an EOF to the reader end.
+			time.AfterFunc(10*time.Millisecond, func() {
+				w.Close()
+			})
+
+			b, err := io.ReadAll(r)
+			assert.NilError(t, err)
+			assert.Equal(t, string(b), tc.want)
+		})
+	}
+}

--- a/internal/auditlog/config.go
+++ b/internal/auditlog/config.go
@@ -1,0 +1,57 @@
+package auditlog
+
+import (
+	"io"
+	"log/slog"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+type Config struct {
+	// Filepath specifies the location of the audit log file. If Filepath is
+	// not set, audit logging will be disabled.
+	Filepath string
+
+	// MaxSize sets the maximum size of the audit log file in megabytes before
+	// it is rotated (default: 100 MB).
+	MaxSize int
+
+	// Compress determines if the rotated log files are compressed using gzip
+	// (default: false).
+	Compress bool
+
+	// Verbosity sets the minimum log level that will be logged. Valid levels
+	// are: -4 = DEBUG, 0 = INFO (default), 4 = WARN, 8 = ERROR.
+	Verbosity int
+}
+
+// NewFromConfig creates a new Auditlog instance from the given config, using
+// lumberjack for log rotation.  If the Filepath in the config is not set,
+// a nil Auditlog will be returned.
+func NewFromConfig[T any](cfg Config, h EventHandler[T]) *Auditlog[T] {
+	if cfg.Filepath == "" {
+		return nil
+	}
+
+	logger, w := loggerFromConfig(cfg)
+	return &Auditlog[T]{
+		logger:  logger,
+		w:       w,
+		handler: h,
+		stopCh:  make(chan struct{}),
+	}
+}
+
+func loggerFromConfig(cfg Config) (*slog.Logger, io.WriteCloser) {
+	w := &lumberjack.Logger{
+		Filename: cfg.Filepath,
+		MaxSize:  cfg.MaxSize,
+		Compress: cfg.Compress,
+	}
+
+	logger := slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{
+		Level: slog.Level(cfg.Verbosity),
+	}))
+
+	return logger, w
+}

--- a/internal/auditlog/config_test.go
+++ b/internal/auditlog/config_test.go
@@ -1,0 +1,56 @@
+package auditlog_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+
+	"github.com/artefactual-sdps/enduro/internal/auditlog"
+	"github.com/artefactual-sdps/enduro/internal/event"
+)
+
+func TestNewFromConfig(t *testing.T) {
+	t.Parallel()
+
+	td := fs.NewDir(t, "auditlog_test")
+	al := auditlog.NewFromConfig(auditlog.Config{
+		Filepath:  td.Join("test.log"),
+		MaxSize:   5, // 5 MB
+		Compress:  true,
+		Verbosity: 0, // INFO
+	}, func(e *auditlog.Event) *auditlog.Event {
+		return e
+	})
+
+	evsvc := event.NewServiceInMem[*auditlog.Event]()
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	// Start the audit log listener.
+	err := al.Listen(ctx, evsvc)
+	assert.NilError(t, err)
+
+	evsvc.PublishEvent(ctx, &auditlog.Event{
+		Level:    0,
+		Msg:      "SIP created",
+		Type:     "sip.created",
+		ObjectID: "sip-123",
+		UserID:   "user-456",
+	})
+
+	// Wait 10ms for the event to publish, then check that the log file was
+	// created. We can't check the contents of the log because the time field
+	// is non-deterministic.
+	time.AfterFunc(10*time.Millisecond, func() {
+		assert.Assert(t, fs.Equal(
+			td.Path(),
+			fs.Expected(t, fs.WithMode(0o755),
+				fs.WithFile("test.log", "", fs.MatchAnyFileContent, fs.WithMode(0o600)),
+			),
+		))
+		al.Close()
+	})
+}

--- a/internal/auditlog/event.go
+++ b/internal/auditlog/event.go
@@ -1,0 +1,19 @@
+package auditlog
+
+import "log/slog"
+
+type Event struct {
+	Level    slog.Level
+	Msg      string
+	Type     string
+	ObjectID string
+	UserID   string
+}
+
+func (e Event) Args() []any {
+	return []any{
+		"type", e.Type,
+		"objectID", e.ObjectID,
+		"userID", e.UserID,
+	}
+}

--- a/internal/auditlog/event_test.go
+++ b/internal/auditlog/event_test.go
@@ -1,0 +1,26 @@
+package auditlog
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestEvent(t *testing.T) {
+	t.Parallel()
+
+	ev := Event{
+		Msg:      "SIP created",
+		Type:     "sip.created",
+		ObjectID: "sip-123",
+		UserID:   "user-456",
+	}
+
+	got := ev.Args()
+	want := []any{
+		"type", "sip.created",
+		"objectID", "sip-123",
+		"userID", "user-456",
+	}
+	assert.DeepEqual(t, got, want)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/a3m"
 	"github.com/artefactual-sdps/enduro/internal/am"
 	"github.com/artefactual-sdps/enduro/internal/api"
+	"github.com/artefactual-sdps/enduro/internal/auditlog"
 	"github.com/artefactual-sdps/enduro/internal/db"
 	"github.com/artefactual-sdps/enduro/internal/event"
 	"github.com/artefactual-sdps/enduro/internal/ingest"
@@ -58,6 +59,7 @@ type Configuration struct {
 
 	A3m             a3m.Config
 	AM              am.Config
+	AuditLog        auditlog.Config
 	InternalAPI     api.Config
 	API             api.Config
 	BagIt           bagcreate.Config

--- a/internal/ingest/convert.go
+++ b/internal/ingest/convert.go
@@ -9,6 +9,7 @@ import (
 	"go.artefactual.dev/tools/ref"
 
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	"github.com/artefactual-sdps/enduro/internal/auditlog"
 	"github.com/artefactual-sdps/enduro/internal/datatypes"
 	"github.com/artefactual-sdps/enduro/internal/db"
 	"github.com/artefactual-sdps/enduro/internal/entfilter"
@@ -176,4 +177,23 @@ func sipSourceObjectsToGoa(objects []*sipsource.Object) goaingest.SIPSourceObjec
 	}
 
 	return r
+}
+
+func HandleAuditEvent(ev *goaingest.IngestEvent) *auditlog.Event {
+	switch e := ev.IngestValue.(type) {
+	case *goaingest.SIPCreatedEvent:
+		var userID string
+		if e.Item.UploaderUUID != nil {
+			userID = e.Item.UploaderUUID.String()
+		}
+		return &auditlog.Event{
+			Msg:      "SIP created",
+			Type:     "sip.created",
+			ObjectID: e.UUID.String(),
+			UserID:   userID,
+		}
+	default:
+		// Ignore unsupported event types.
+		return nil
+	}
 }

--- a/internal/ingest/convert_test.go
+++ b/internal/ingest/convert_test.go
@@ -1,0 +1,75 @@
+package ingest_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"go.artefactual.dev/tools/ref"
+	"gotest.tools/v3/assert"
+
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	"github.com/artefactual-sdps/enduro/internal/auditlog"
+	"github.com/artefactual-sdps/enduro/internal/ingest"
+)
+
+func TestHandleAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	sipID := uuid.MustParse("6592dbe2-a2db-4cfb-a73b-0e620da1053f")
+	userID := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+
+	type test struct {
+		name  string
+		event *goaingest.IngestEvent
+		want  *auditlog.Event
+	}
+	for _, tc := range []test{
+		{
+			name: "Handle a SIP created event",
+			event: &goaingest.IngestEvent{
+				IngestValue: &goaingest.SIPCreatedEvent{
+					UUID: sipID,
+					Item: &goaingest.SIP{UUID: sipID, UploaderUUID: &userID},
+				},
+			},
+			want: &auditlog.Event{
+				Level:    slog.LevelInfo,
+				Msg:      "SIP created",
+				Type:     "sip.created",
+				ObjectID: "6592dbe2-a2db-4cfb-a73b-0e620da1053f",
+				UserID:   userID.String(),
+			},
+		},
+		{
+			name: "Handle a SIP created event with no uploader",
+			event: &goaingest.IngestEvent{
+				IngestValue: &goaingest.SIPCreatedEvent{
+					UUID: sipID,
+					Item: &goaingest.SIP{UUID: sipID},
+				},
+			},
+			want: &auditlog.Event{
+				Level:    slog.LevelInfo,
+				Msg:      "SIP created",
+				Type:     "sip.created",
+				ObjectID: "6592dbe2-a2db-4cfb-a73b-0e620da1053f",
+				UserID:   "",
+			},
+		},
+		{
+			name: "Ignore unsupported event types",
+			event: &goaingest.IngestEvent{
+				IngestValue: &goaingest.IngestPingEvent{Message: ref.New("ping")},
+			},
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ingest.HandleAuditEvent(tc.event)
+			assert.DeepEqual(t, got, tc.want)
+		})
+	}
+}


### PR DESCRIPTION
Refs #1282.

- Add an ingest audit logger that subscribes to the ingest event service and writes "SIP deposited" events to an audit log file
- Configure the development environment to do audit logging