### PR TITLE
Add audit log rotation (refs #1282)

### DIFF
--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -252,6 +252,7 @@ func main() {
 		if err != nil {
 			logger.Error(err, "Error opening audit log file.")
 		} else {
+			logger.V(1).Info("Starting audit log", "path", cfg.AuditLog.Filepath)
 			auditLogger = slog.New(slog.NewJSONHandler(f, &slog.HandlerOptions{
 				Level: slog.Level(cfg.AuditLog.Verbosity),
 			}))

--- a/enduro.toml
+++ b/enduro.toml
@@ -279,4 +279,18 @@ workflowName = "preprocessing"
 # workflowName = "poststorage"
 
 [auditlog]
+# filePath is the absolute path where the audit log will be written. The enduro
+# user will need write access to the given directory. Rotated logs will use the 
+# same directory and filename, but with a timestamp appended. If filePath is not
+# set, or set to an empty string, audit logging will be disabled.
 filePath = "/home/enduro/logs/enduro_audit.log"
+# maxSize is the maximum size in megabytes of the audit log file before it gets 
+# rotated (default: 100 MB). 
+maxSize = 100
+# compress determines if the rotated log files are compressed using gzip
+# (default: false).
+compress = false
+# verbosity determines the minimum level threshold for a log message to be 
+# recorded (default: INFO). Current levels are: -4 = DEBUG, 0 = INFO, 4 = WARN, 
+# 8 = ERROR.
+verbosity = 0

--- a/enduro.toml
+++ b/enduro.toml
@@ -277,3 +277,6 @@ workflowName = "preprocessing"
 # namespace = "default"
 # taskQueue = "poststorage"
 # workflowName = "poststorage"
+
+[auditlog]
+filePath = "/home/enduro/logs/enduro_audit.log"

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	golang.org/x/exp v0.0.0-20231219180239-dc181d75b848
 	google.golang.org/grpc v1.71.0
 	google.golang.org/protobuf v1.36.6
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gotest.tools/v3 v3.5.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1691,6 +1691,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/auditlog/config.go
+++ b/internal/auditlog/config.go
@@ -1,0 +1,10 @@
+package auditlog
+
+type Config struct {
+	// Filepath specifies the location of the audit log file.  If Filepath is
+	// not set, audit logging will be disabled.
+	Filepath string
+
+	// Verbosity sets the minimum log level that will be logged (Default: INFO).
+	Verbosity int
+}

--- a/internal/auditlog/config.go
+++ b/internal/auditlog/config.go
@@ -1,10 +1,19 @@
 package auditlog
 
 type Config struct {
-	// Filepath specifies the location of the audit log file.  If Filepath is
+	// Filepath specifies the location of the audit log file. If Filepath is
 	// not set, audit logging will be disabled.
 	Filepath string
 
-	// Verbosity sets the minimum log level that will be logged (Default: INFO).
+	// MaxSize sets the maximum size of the audit log file in megabytes before
+	// it is rotated (default: 100 MB).
+	MaxSize int
+
+	// compress determines if the rotated log files are compressed using gzip
+	// (default: false).
+	Compress bool
+
+	// Verbosity sets the minimum log level that will be logged (default: INFO).
+	// Valid levels are: -4 = DEBUG, 0 = INFO, 4 = WARN, 8 = ERROR.
 	Verbosity int
 }

--- a/internal/auditlog/logger.go
+++ b/internal/auditlog/logger.go
@@ -1,0 +1,27 @@
+package auditlog
+
+import (
+	"log/slog"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// NewFromConfig creates a new *slog.Logger from the specified configuration
+// that writes logs in JSON format to cfg.Filepath and does log rotation. If
+// cfg.Filepath is not set, a nil Logger is returned.
+func NewFromConfig(cfg Config) *slog.Logger {
+	if cfg.Filepath == "" {
+		return nil
+	}
+
+	// Use lumberjack.Logger for log rotation.
+	l := &lumberjack.Logger{
+		Filename: cfg.Filepath,
+		MaxSize:  cfg.MaxSize,
+		Compress: cfg.Compress,
+	}
+
+	return slog.New(slog.NewJSONHandler(l, &slog.HandlerOptions{
+		Level: slog.Level(cfg.Verbosity),
+	}))
+}

--- a/internal/auditlog/logger_test.go
+++ b/internal/auditlog/logger_test.go
@@ -1,0 +1,70 @@
+package auditlog_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+
+	auditlog "github.com/artefactual-sdps/enduro/internal/auditlog"
+)
+
+type entry struct {
+	// Ignore the time field because it's non-deterministic.
+
+	Level string `json:"level"`
+	Msg   string `json:"msg"`
+	Key   string `json:"key"`
+}
+
+func TestNewFromConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates a logger with the given config", func(t *testing.T) {
+		t.Parallel()
+
+		d := fs.NewDir(t, "enduro-test")
+		cfg := auditlog.Config{
+			Filepath: d.Join("enduro_audit.log"),
+			MaxSize:  10,
+		}
+
+		logger := auditlog.NewFromConfig(cfg)
+		if logger == nil {
+			t.Fatal("Expected logger to be created")
+		}
+
+		logger.Info("Test audit log entry", "key", "value")
+
+		r, err := os.Open(d.Join("enduro_audit.log"))
+		if err != nil {
+			if os.IsNotExist(err) {
+				t.Fatalf("Missing expected file: %s", d.Join("enduro_audit.log"))
+			}
+			t.Fatal(err)
+		}
+		defer r.Close()
+
+		var e entry
+		if err := json.NewDecoder(r).Decode(&e); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.DeepEqual(t, e, entry{
+			Level: "INFO",
+			Msg:   "Test audit log entry",
+			Key:   "value",
+		})
+	})
+
+	t.Run("returns nil if Filepath is empty", func(t *testing.T) {
+		t.Parallel()
+
+		logger := auditlog.NewFromConfig(auditlog.Config{})
+		if logger != nil {
+			t.Fatal("Expected logger to be nil")
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/a3m"
 	"github.com/artefactual-sdps/enduro/internal/am"
 	"github.com/artefactual-sdps/enduro/internal/api"
+	"github.com/artefactual-sdps/enduro/internal/auditlog"
 	"github.com/artefactual-sdps/enduro/internal/db"
 	"github.com/artefactual-sdps/enduro/internal/event"
 	"github.com/artefactual-sdps/enduro/internal/ingest"
@@ -58,6 +59,7 @@ type Configuration struct {
 
 	A3m             a3m.Config
 	AM              am.Config
+	AuditLog        auditlog.Config
 	InternalAPI     api.Config
 	API             api.Config
 	BagIt           bagcreate.Config

--- a/internal/ingest/auditlog.go
+++ b/internal/ingest/auditlog.go
@@ -1,0 +1,64 @@
+package ingest
+
+import (
+	"context"
+	"log/slog"
+
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+)
+
+// WithAuditLogger configures and starts an audit logger that subscribes to the
+// event service and logs published events to the specified logger.
+func (svc *ingestImpl) WithAuditLogger(ctx context.Context, logger *slog.Logger) {
+	if logger == nil {
+		return
+	}
+
+	svc.auditLogger = logger
+	svc.logAuditEvents(ctx)
+}
+
+func (svc *ingestImpl) logAuditEvents(ctx context.Context) {
+	sub, err := svc.evsvc.Subscribe(ctx)
+	if err != nil {
+		svc.logger.Error(err, "audit log: failed to subscribe to event service")
+		return
+	}
+
+	go func() {
+	loop:
+		for {
+			select {
+			case <-ctx.Done():
+				if err := ctx.Err(); err != nil {
+					svc.logger.Error(err, "audit log: context canceled")
+				}
+				break loop
+			case event, ok := <-sub.C():
+				if !ok || event == nil {
+					break loop
+				}
+
+				if ev, ok := event.IngestValue.(*goaingest.SIPCreatedEvent); ok {
+					svc.logSIPCreatedEvent(ev)
+				}
+			}
+		}
+
+		sub.Close()
+	}()
+}
+
+func (svc *ingestImpl) logSIPCreatedEvent(e *goaingest.SIPCreatedEvent) {
+	var userID string
+	if e.Item.UploaderUUID != nil {
+		userID = e.Item.UploaderUUID.String()
+	}
+
+	svc.auditLogger.Info(
+		"SIP deposited",
+		"type", "SIP.deposit",
+		"objectID", e.UUID.String(),
+		"userID", userID,
+	)
+}

--- a/internal/ingest/auditlog_test.go
+++ b/internal/ingest/auditlog_test.go
@@ -1,0 +1,139 @@
+package ingest_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"gotest.tools/v3/assert"
+
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	"github.com/artefactual-sdps/enduro/internal/event"
+	"github.com/artefactual-sdps/enduro/internal/ingest"
+)
+
+func setupIngestSvc(t *testing.T, evsvc event.Service[*goaingest.IngestEvent]) ingest.Service {
+	t.Helper()
+
+	ingestSvc := ingest.NewService(
+		logr.Discard(), // logger
+		nil,            // db
+		nil,            // temporal client
+		evsvc,          // event service
+		nil,            // persistence service
+		nil,            // token verifier
+		nil,            // ticket provider
+		"test",         // taskQueue
+		nil,            // internal bucket
+		1024,           // upload max size (1 KiB)
+		nil,            // random number generator
+		nil,            // sipSource
+	)
+
+	return ingestSvc
+}
+
+func testLogger(w io.Writer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			// Set time to a deterministic value for testing.
+			if a.Key == slog.TimeKey {
+				a.Value = slog.TimeValue(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+				return a
+			}
+			return a
+		},
+	}))
+}
+
+func TestSIPCreatedLogger(t *testing.T) {
+	t.Parallel()
+
+	var (
+		sipID  = uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+		userID = uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+	)
+
+	type test struct {
+		name   string
+		evsvc  event.Service[*goaingest.IngestEvent]
+		event  *goaingest.SIPCreatedEvent
+		logger func(w io.Writer) *slog.Logger
+		want   string
+	}
+	for _, tt := range []test{
+		{
+			name:  "Log SIP created event",
+			evsvc: event.NewServiceInMem[*goaingest.IngestEvent](),
+			event: &goaingest.SIPCreatedEvent{
+				UUID: sipID,
+				Item: &goaingest.SIP{
+					UUID:         sipID,
+					UploaderUUID: &userID,
+				},
+			},
+			logger: func(w io.Writer) *slog.Logger { return testLogger(w) },
+			want: `{"time":"2025-01-01T00:00:00Z","level":"INFO","msg":"SIP deposited","type":"SIP.deposit","objectID":"` + sipID.String() + `","userID":"` + userID.String() + `"}
+`,
+		},
+		{
+			name:  "Log SIP created event with no uploader ID",
+			evsvc: event.NewServiceInMem[*goaingest.IngestEvent](),
+			event: &goaingest.SIPCreatedEvent{
+				UUID: sipID,
+				Item: &goaingest.SIP{UUID: sipID},
+			},
+			logger: func(w io.Writer) *slog.Logger { return testLogger(w) },
+			want: `{"time":"2025-01-01T00:00:00Z","level":"INFO","msg":"SIP deposited","type":"SIP.deposit","objectID":"` + sipID.String() + `","userID":""}
+`,
+		},
+		{
+			name:  "Logger disabled",
+			evsvc: event.NewServiceInMem[*goaingest.IngestEvent](),
+			event: &goaingest.SIPCreatedEvent{
+				UUID: sipID,
+				Item: &goaingest.SIP{UUID: sipID},
+			},
+			logger: func(w io.Writer) *slog.Logger { return nil },
+			want:   "",
+		},
+		{
+			name:  "Can't subscribe to event service",
+			evsvc: event.NewServiceNop[*goaingest.IngestEvent](),
+			event: &goaingest.SIPCreatedEvent{
+				UUID: sipID,
+				Item: &goaingest.SIP{UUID: sipID},
+			},
+			logger: func(w io.Writer) *slog.Logger { return testLogger(w) },
+			want:   "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Use a pipe as a thread-safe read/write buffer.
+			r, w := io.Pipe()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			defer cancel()
+
+			ingestSvc := setupIngestSvc(t, tt.evsvc)
+			ingestSvc.WithAuditLogger(ctx, tt.logger(w))
+			ingest.PublishEvent(ctx, tt.evsvc, tt.event)
+
+			// Wait 10ms for the event to publish, then close the writer end of
+			// the pipe to send an EOF to the reader end.
+			time.AfterFunc(10*time.Millisecond, func() {
+				w.Close()
+			})
+
+			b, err := io.ReadAll(r)
+			assert.NilError(t, err)
+			assert.Equal(t, string(b), tt.want)
+		})
+	}
+}

--- a/internal/ingest/fake/mock_ingest.go
+++ b/internal/ingest/fake/mock_ingest.go
@@ -11,6 +11,7 @@ package fake
 
 import (
 	context "context"
+	slog "log/slog"
 	reflect "reflect"
 	time "time"
 
@@ -422,6 +423,42 @@ func (c *MockServiceUpdateSIPCall) Do(f func(context.Context, uuid.UUID, persist
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockServiceUpdateSIPCall) DoAndReturn(f func(context.Context, uuid.UUID, persistence.SIPUpdater) (*datatypes.SIP, error)) *MockServiceUpdateSIPCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// WithAuditLogger mocks base method.
+func (m *MockService) WithAuditLogger(arg0 context.Context, arg1 *slog.Logger) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "WithAuditLogger", arg0, arg1)
+}
+
+// WithAuditLogger indicates an expected call of WithAuditLogger.
+func (mr *MockServiceMockRecorder) WithAuditLogger(arg0, arg1 any) *MockServiceWithAuditLoggerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithAuditLogger", reflect.TypeOf((*MockService)(nil).WithAuditLogger), arg0, arg1)
+	return &MockServiceWithAuditLoggerCall{Call: call}
+}
+
+// MockServiceWithAuditLoggerCall wrap *gomock.Call
+type MockServiceWithAuditLoggerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockServiceWithAuditLoggerCall) Return() *MockServiceWithAuditLoggerCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockServiceWithAuditLoggerCall) Do(f func(context.Context, *slog.Logger)) *MockServiceWithAuditLoggerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockServiceWithAuditLoggerCall) DoAndReturn(f func(context.Context, *slog.Logger)) *MockServiceWithAuditLoggerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -57,6 +58,7 @@ type Service interface {
 		completedAt time.Time,
 		note *string,
 	) error
+	WithAuditLogger(ctx context.Context, logger *slog.Logger)
 }
 
 type ingestImpl struct {
@@ -72,6 +74,10 @@ type ingestImpl struct {
 	uploadMaxSize   int64
 	rander          io.Reader
 	sipSource       sipsource.SIPSource
+
+	// auditLogger configures an audit event logger. By default audit logging is
+	// disabled, use WithAuditLogger() to enable it.
+	auditLogger *slog.Logger
 }
 
 var _ Service = (*ingestImpl)(nil)


### PR DESCRIPTION
Add an audit log rotator that will rotate the log file when it reaches the configured "maxSize". The rotator also supports compressing the rotated log files with gzip.