### PR TITLE
Add an AIP deletion request creation event

### DIFF
--- a/docs/src/dev-manual/api/openapi3.json
+++ b/docs/src/dev-manual/api/openapi3.json
@@ -45,6 +45,34 @@
         ],
         "type": "object"
       },
+      "AIPDeletionRequestCreatedEvent": {
+        "example": {
+          "item": {
+            "aip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "reason": "abc123",
+            "requested_at": "1970-01-01T00:00:01Z",
+            "reviewed_at": "1970-01-01T00:00:01Z",
+            "status": "approved",
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+          },
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+        },
+        "properties": {
+          "item": {
+            "$ref": "#/components/schemas/EnduroStorageAipDeletionRequest"
+          },
+          "uuid": {
+            "description": "Identifier of deletion request",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "item"
+        ],
+        "type": "object"
+      },
       "AIPLocationUpdatedEvent": {
         "example": {
           "location_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
@@ -1142,6 +1170,65 @@
         ],
         "type": "object"
       },
+      "EnduroStorageAipDeletionRequest": {
+        "description": "AIPDeletionRequest describes a request to delete an AIP.",
+        "example": {
+          "aip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+          "reason": "abc123",
+          "requested_at": "1970-01-01T00:00:01Z",
+          "reviewed_at": "1970-01-01T00:00:01Z",
+          "status": "approved",
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+        },
+        "properties": {
+          "aip_uuid": {
+            "description": "Identifier of related AIP",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
+          },
+          "reason": {
+            "description": "Reason for deletion",
+            "example": "abc123",
+            "type": "string"
+          },
+          "requested_at": {
+            "description": "Time request was made",
+            "example": "1970-01-01T00:00:01Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "reviewed_at": {
+            "description": "Time request was reviewed",
+            "example": "1970-01-01T00:00:01Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "description": "Status of request",
+            "enum": [
+              "pending",
+              "approved",
+              "rejected",
+              "canceled"
+            ],
+            "example": "approved",
+            "type": "string"
+          },
+          "uuid": {
+            "description": "Identifier of deletion request",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "aip_uuid",
+          "reason",
+          "status",
+          "requested_at"
+        ],
+        "type": "object"
+      },
       "EnduroStorageAipTask": {
         "description": "AIPTask describes an AIP workflow task.",
         "example": {
@@ -2199,7 +2286,7 @@
             },
             "properties": {
               "Type": {
-                "description": "Union type name, one of:\n- \"storage_ping_event\"\n- \"location_created_event\"\n- \"aip_created_event\"\n- \"aip_status_updated_event\"\n- \"aip_location_updated_event\"\n- \"aip_workflow_created_event\"\n- \"aip_workflow_updated_event\"\n- \"aip_task_created_event\"\n- \"aip_task_updated_event\"",
+                "description": "Union type name, one of:\n- \"storage_ping_event\"\n- \"location_created_event\"\n- \"aip_created_event\"\n- \"aip_status_updated_event\"\n- \"aip_location_updated_event\"\n- \"aip_workflow_created_event\"\n- \"aip_workflow_updated_event\"\n- \"aip_task_created_event\"\n- \"aip_task_updated_event\"\n- \"aip_deletion_request_created_event\"",
                 "enum": [
                   "storage_ping_event",
                   "location_created_event",
@@ -2209,7 +2296,8 @@
                   "aip_workflow_created_event",
                   "aip_workflow_updated_event",
                   "aip_task_created_event",
-                  "aip_task_updated_event"
+                  "aip_task_updated_event",
+                  "aip_deletion_request_created_event"
                 ],
                 "example": "location_created_event",
                 "type": "string"

--- a/internal/api/design/storage.go
+++ b/internal/api/design/storage.go
@@ -729,3 +729,25 @@ var AIPTask = ResultType("application/vnd.enduro.storage.aip.task", func() {
 	})
 	Required("uuid", "name", "status", "workflow_uuid")
 })
+
+var EnumDeletionRequestStatus = func() {
+	Enum(enums.DeletionRequestStatusInterfaces()...)
+}
+
+var AIPDeletionRequest = ResultType("application/vnd.enduro.storage.aip.deletion_request", func() {
+	Description("AIPDeletionRequest describes a request to delete an AIP.")
+	TypeName("AIPDeletionRequest")
+	TypedAttributeUUID("uuid", "Identifier of deletion request")
+	TypedAttributeUUID("aip_uuid", "Identifier of related AIP")
+	Attribute("reason", String, "Reason for deletion")
+	Attribute("status", String, "Status of request", func() {
+		EnumDeletionRequestStatus()
+	})
+	Attribute("requested_at", String, "Time request was made", func() {
+		Format(FormatDateTime)
+	})
+	Attribute("reviewed_at", String, "Time request was reviewed", func() {
+		Format(FormatDateTime)
+	})
+	Required("uuid", "aip_uuid", "reason", "status", "requested_at")
+})

--- a/internal/api/design/storage_monitor.go
+++ b/internal/api/design/storage_monitor.go
@@ -34,6 +34,7 @@ var StorageEvent = Type("StorageEvent", func() {
 		Attribute("aip_workflow_updated_event", AIPWorkflowUpdatedEvent)
 		Attribute("aip_task_created_event", AIPTaskCreatedEvent)
 		Attribute("aip_task_updated_event", AIPTaskUpdatedEvent)
+		Attribute("aip_deletion_request_created_event", AIPDeletionRequestCreatedEvent)
 	})
 })
 
@@ -116,4 +117,13 @@ var AIPTaskUpdatedEvent = Type("AIPTaskUpdatedEvent", func() {
 
 	Meta("type:generate:force")
 	Meta("openapi:typename", "AIPTaskUpdatedEvent")
+})
+
+var AIPDeletionRequestCreatedEvent = Type("AIPDeletionRequestCreatedEvent", func() {
+	TypedAttributeUUID("uuid", "Identifier of deletion request")
+	Attribute("item", AIPDeletionRequest)
+	Required("uuid", "item")
+
+	Meta("type:generate:force")
+	Meta("openapi:typename", "AIPDeletionRequestCreatedEvent")
 })

--- a/internal/api/gen/about/service.go
+++ b/internal/api/gen/about/service.go
@@ -63,6 +63,28 @@ type AIPCreatedEvent struct {
 	Item *AIP
 }
 
+// AIPDeletionRequest describes a request to delete an AIP.
+type AIPDeletionRequest struct {
+	// Identifier of deletion request
+	UUID uuid.UUID
+	// Identifier of related AIP
+	AipUUID uuid.UUID
+	// Reason for deletion
+	Reason string
+	// Status of request
+	Status string
+	// Time request was made
+	RequestedAt string
+	// Time request was reviewed
+	ReviewedAt *string
+}
+
+type AIPDeletionRequestCreatedEvent struct {
+	// Identifier of deletion request
+	UUID uuid.UUID
+	Item *AIPDeletionRequest
+}
+
 type AIPLocationUpdatedEvent struct {
 	// Identifier of AIP
 	UUID uuid.UUID

--- a/internal/api/gen/http/openapi.json
+++ b/internal/api/gen/http/openapi.json
@@ -3579,7 +3579,7 @@
           },
           "properties": {
             "Type": {
-              "description": "Union type name, one of:\n- \"storage_ping_event\"\n- \"location_created_event\"\n- \"aip_created_event\"\n- \"aip_status_updated_event\"\n- \"aip_location_updated_event\"\n- \"aip_workflow_created_event\"\n- \"aip_workflow_updated_event\"\n- \"aip_task_created_event\"\n- \"aip_task_updated_event\"",
+              "description": "Union type name, one of:\n- \"storage_ping_event\"\n- \"location_created_event\"\n- \"aip_created_event\"\n- \"aip_status_updated_event\"\n- \"aip_location_updated_event\"\n- \"aip_workflow_created_event\"\n- \"aip_workflow_updated_event\"\n- \"aip_task_created_event\"\n- \"aip_task_updated_event\"\n- \"aip_deletion_request_created_event\"",
               "enum": [
                 "storage_ping_event",
                 "location_created_event",
@@ -3589,7 +3589,8 @@
                 "aip_workflow_created_event",
                 "aip_workflow_updated_event",
                 "aip_task_created_event",
-                "aip_task_updated_event"
+                "aip_task_updated_event",
+                "aip_deletion_request_created_event"
               ],
               "example": "location_created_event",
               "type": "string"

--- a/internal/api/gen/http/openapi.yaml
+++ b/internal/api/gen/http/openapi.yaml
@@ -4534,6 +4534,7 @@ definitions:
                             - "aip_workflow_updated_event"
                             - "aip_task_created_event"
                             - "aip_task_updated_event"
+                            - "aip_deletion_request_created_event"
                         example: location_created_event
                         enum:
                             - storage_ping_event
@@ -4545,6 +4546,7 @@ definitions:
                             - aip_workflow_updated_event
                             - aip_task_created_event
                             - aip_task_updated_event
+                            - aip_deletion_request_created_event
                     Value:
                         type: string
                         description: JSON encoded union value

--- a/internal/api/gen/http/openapi3.json
+++ b/internal/api/gen/http/openapi3.json
@@ -45,6 +45,34 @@
         ],
         "type": "object"
       },
+      "AIPDeletionRequestCreatedEvent": {
+        "example": {
+          "item": {
+            "aip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "reason": "abc123",
+            "requested_at": "1970-01-01T00:00:01Z",
+            "reviewed_at": "1970-01-01T00:00:01Z",
+            "status": "approved",
+            "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+          },
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+        },
+        "properties": {
+          "item": {
+            "$ref": "#/components/schemas/EnduroStorageAipDeletionRequest"
+          },
+          "uuid": {
+            "description": "Identifier of deletion request",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "item"
+        ],
+        "type": "object"
+      },
       "AIPLocationUpdatedEvent": {
         "example": {
           "location_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
@@ -1142,6 +1170,65 @@
         ],
         "type": "object"
       },
+      "EnduroStorageAipDeletionRequest": {
+        "description": "AIPDeletionRequest describes a request to delete an AIP.",
+        "example": {
+          "aip_uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+          "reason": "abc123",
+          "requested_at": "1970-01-01T00:00:01Z",
+          "reviewed_at": "1970-01-01T00:00:01Z",
+          "status": "approved",
+          "uuid": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5"
+        },
+        "properties": {
+          "aip_uuid": {
+            "description": "Identifier of related AIP",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
+          },
+          "reason": {
+            "description": "Reason for deletion",
+            "example": "abc123",
+            "type": "string"
+          },
+          "requested_at": {
+            "description": "Time request was made",
+            "example": "1970-01-01T00:00:01Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "reviewed_at": {
+            "description": "Time request was reviewed",
+            "example": "1970-01-01T00:00:01Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "description": "Status of request",
+            "enum": [
+              "pending",
+              "approved",
+              "rejected",
+              "canceled"
+            ],
+            "example": "approved",
+            "type": "string"
+          },
+          "uuid": {
+            "description": "Identifier of deletion request",
+            "example": "d1845cb6-a5ea-474a-9ab8-26f9bcd919f5",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "aip_uuid",
+          "reason",
+          "status",
+          "requested_at"
+        ],
+        "type": "object"
+      },
       "EnduroStorageAipTask": {
         "description": "AIPTask describes an AIP workflow task.",
         "example": {
@@ -2199,7 +2286,7 @@
             },
             "properties": {
               "Type": {
-                "description": "Union type name, one of:\n- \"storage_ping_event\"\n- \"location_created_event\"\n- \"aip_created_event\"\n- \"aip_status_updated_event\"\n- \"aip_location_updated_event\"\n- \"aip_workflow_created_event\"\n- \"aip_workflow_updated_event\"\n- \"aip_task_created_event\"\n- \"aip_task_updated_event\"",
+                "description": "Union type name, one of:\n- \"storage_ping_event\"\n- \"location_created_event\"\n- \"aip_created_event\"\n- \"aip_status_updated_event\"\n- \"aip_location_updated_event\"\n- \"aip_workflow_created_event\"\n- \"aip_workflow_updated_event\"\n- \"aip_task_created_event\"\n- \"aip_task_updated_event\"\n- \"aip_deletion_request_created_event\"",
                 "enum": [
                   "storage_ping_event",
                   "location_created_event",
@@ -2209,7 +2296,8 @@
                   "aip_workflow_created_event",
                   "aip_workflow_updated_event",
                   "aip_task_created_event",
-                  "aip_task_updated_event"
+                  "aip_task_updated_event",
+                  "aip_deletion_request_created_event"
                 ],
                 "example": "location_created_event",
                 "type": "string"

--- a/internal/api/gen/http/openapi3.yaml
+++ b/internal/api/gen/http/openapi3.yaml
@@ -2296,6 +2296,27 @@ components:
             required:
                 - uuid
                 - item
+        AIPDeletionRequestCreatedEvent:
+            type: object
+            properties:
+                item:
+                    $ref: '#/components/schemas/EnduroStorageAipDeletionRequest'
+                uuid:
+                    type: string
+                    description: Identifier of deletion request
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+            example:
+                item:
+                    aip_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                    reason: abc123
+                    requested_at: "1970-01-01T00:00:01Z"
+                    reviewed_at: "1970-01-01T00:00:01Z"
+                    status: approved
+                    uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+            required:
+                - uuid
+                - item
         AIPLocationUpdatedEvent:
             type: object
             properties:
@@ -3141,6 +3162,54 @@ components:
                 - status
                 - object_key
                 - created_at
+        EnduroStorageAipDeletionRequest:
+            type: object
+            properties:
+                aip_uuid:
+                    type: string
+                    description: Identifier of related AIP
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                reason:
+                    type: string
+                    description: Reason for deletion
+                    example: abc123
+                requested_at:
+                    type: string
+                    description: Time request was made
+                    example: "1970-01-01T00:00:01Z"
+                    format: date-time
+                reviewed_at:
+                    type: string
+                    description: Time request was reviewed
+                    example: "1970-01-01T00:00:01Z"
+                    format: date-time
+                status:
+                    type: string
+                    description: Status of request
+                    example: approved
+                    enum:
+                        - pending
+                        - approved
+                        - rejected
+                        - canceled
+                uuid:
+                    type: string
+                    description: Identifier of deletion request
+                    example: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+            description: AIPDeletionRequest describes a request to delete an AIP.
+            example:
+                aip_uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+                reason: abc123
+                requested_at: "1970-01-01T00:00:01Z"
+                reviewed_at: "1970-01-01T00:00:01Z"
+                status: approved
+                uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
+            required:
+                - uuid
+                - aip_uuid
+                - reason
+                - status
+                - requested_at
         EnduroStorageAipTask:
             type: object
             properties:
@@ -3959,6 +4028,7 @@ components:
                                 - "aip_workflow_updated_event"
                                 - "aip_task_created_event"
                                 - "aip_task_updated_event"
+                                - "aip_deletion_request_created_event"
                             example: location_created_event
                             enum:
                                 - storage_ping_event
@@ -3970,6 +4040,7 @@ components:
                                 - aip_workflow_updated_event
                                 - aip_task_created_event
                                 - aip_task_updated_event
+                                - aip_deletion_request_created_event
                         Value:
                             type: string
                             description: JSON encoded union value

--- a/internal/api/gen/http/storage/client/types.go
+++ b/internal/api/gen/http/storage/client/types.go
@@ -98,6 +98,7 @@ type MonitorResponseBody struct {
 		// - "aip_workflow_updated_event"
 		// - "aip_task_created_event"
 		// - "aip_task_updated_event"
+		// - "aip_deletion_request_created_event"
 		Type *string `form:"Type" json:"Type" xml:"Type"`
 		// JSON encoded union value
 		Value *string `form:"Value" json:"Value" xml:"Value"`
@@ -945,6 +946,10 @@ func NewMonitorStorageEventOK(body *MonitorResponseBody) *storage.StorageEvent {
 			v.StorageValue = val
 		case "aip_task_updated_event":
 			var val *storage.AIPTaskUpdatedEvent
+			json.Unmarshal([]byte(*body.StorageValue.Value), &val)
+			v.StorageValue = val
+		case "aip_deletion_request_created_event":
+			var val *storage.AIPDeletionRequestCreatedEvent
 			json.Unmarshal([]byte(*body.StorageValue.Value), &val)
 			v.StorageValue = val
 		}
@@ -1849,8 +1854,8 @@ func ValidateMonitorResponseBody(body *MonitorResponseBody) (err error) {
 			err = goa.MergeErrors(err, goa.MissingFieldError("Value", "body.storage_value"))
 		}
 		if body.StorageValue.Type != nil {
-			if !(*body.StorageValue.Type == "storage_ping_event" || *body.StorageValue.Type == "location_created_event" || *body.StorageValue.Type == "aip_created_event" || *body.StorageValue.Type == "aip_status_updated_event" || *body.StorageValue.Type == "aip_location_updated_event" || *body.StorageValue.Type == "aip_workflow_created_event" || *body.StorageValue.Type == "aip_workflow_updated_event" || *body.StorageValue.Type == "aip_task_created_event" || *body.StorageValue.Type == "aip_task_updated_event") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.storage_value.Type", *body.StorageValue.Type, []any{"storage_ping_event", "location_created_event", "aip_created_event", "aip_status_updated_event", "aip_location_updated_event", "aip_workflow_created_event", "aip_workflow_updated_event", "aip_task_created_event", "aip_task_updated_event"}))
+			if !(*body.StorageValue.Type == "storage_ping_event" || *body.StorageValue.Type == "location_created_event" || *body.StorageValue.Type == "aip_created_event" || *body.StorageValue.Type == "aip_status_updated_event" || *body.StorageValue.Type == "aip_location_updated_event" || *body.StorageValue.Type == "aip_workflow_created_event" || *body.StorageValue.Type == "aip_workflow_updated_event" || *body.StorageValue.Type == "aip_task_created_event" || *body.StorageValue.Type == "aip_task_updated_event" || *body.StorageValue.Type == "aip_deletion_request_created_event") {
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.storage_value.Type", *body.StorageValue.Type, []any{"storage_ping_event", "location_created_event", "aip_created_event", "aip_status_updated_event", "aip_location_updated_event", "aip_workflow_created_event", "aip_workflow_updated_event", "aip_task_created_event", "aip_task_updated_event", "aip_deletion_request_created_event"}))
 			}
 		}
 	}

--- a/internal/api/gen/http/storage/server/types.go
+++ b/internal/api/gen/http/storage/server/types.go
@@ -98,6 +98,7 @@ type MonitorResponseBody struct {
 		// - "aip_workflow_updated_event"
 		// - "aip_task_created_event"
 		// - "aip_task_updated_event"
+		// - "aip_deletion_request_created_event"
 		Type string `form:"Type" json:"Type" xml:"Type"`
 		// JSON encoded union value
 		Value string `form:"Value" json:"Value" xml:"Value"`
@@ -768,6 +769,8 @@ func NewMonitorResponseBody(res *storage.StorageEvent) *MonitorResponseBody {
 			name = "aip_task_created_event"
 		case *storage.AIPTaskUpdatedEvent:
 			name = "aip_task_updated_event"
+		case *storage.AIPDeletionRequestCreatedEvent:
+			name = "aip_deletion_request_created_event"
 		}
 		body.StorageValue = &struct {
 			// Union type name, one of:
@@ -780,6 +783,7 @@ func NewMonitorResponseBody(res *storage.StorageEvent) *MonitorResponseBody {
 			// - "aip_workflow_updated_event"
 			// - "aip_task_created_event"
 			// - "aip_task_updated_event"
+			// - "aip_deletion_request_created_event"
 			Type string `form:"Type" json:"Type" xml:"Type"`
 			// JSON encoded union value
 			Value string `form:"Value" json:"Value" xml:"Value"`

--- a/internal/api/gen/ingest/service.go
+++ b/internal/api/gen/ingest/service.go
@@ -106,6 +106,28 @@ type AIPCreatedEvent struct {
 	Item *AIP
 }
 
+// AIPDeletionRequest describes a request to delete an AIP.
+type AIPDeletionRequest struct {
+	// Identifier of deletion request
+	UUID uuid.UUID
+	// Identifier of related AIP
+	AipUUID uuid.UUID
+	// Reason for deletion
+	Reason string
+	// Status of request
+	Status string
+	// Time request was made
+	RequestedAt string
+	// Time request was reviewed
+	ReviewedAt *string
+}
+
+type AIPDeletionRequestCreatedEvent struct {
+	// Identifier of deletion request
+	UUID uuid.UUID
+	Item *AIPDeletionRequest
+}
+
 type AIPLocationUpdatedEvent struct {
 	// Identifier of AIP
 	UUID uuid.UUID

--- a/internal/api/gen/storage/service.go
+++ b/internal/api/gen/storage/service.go
@@ -123,6 +123,28 @@ type AIPCreatedEvent struct {
 	Item *AIP
 }
 
+// AIPDeletionRequest describes a request to delete an AIP.
+type AIPDeletionRequest struct {
+	// Identifier of deletion request
+	UUID uuid.UUID
+	// Identifier of related AIP
+	AipUUID uuid.UUID
+	// Reason for deletion
+	Reason string
+	// Status of request
+	Status string
+	// Time request was made
+	RequestedAt string
+	// Time request was reviewed
+	ReviewedAt *string
+}
+
+type AIPDeletionRequestCreatedEvent struct {
+	// Identifier of deletion request
+	UUID uuid.UUID
+	Item *AIPDeletionRequest
+}
+
 type AIPLocationUpdatedEvent struct {
 	// Identifier of AIP
 	UUID uuid.UUID
@@ -685,19 +707,20 @@ func (e Unauthorized) ErrorName() string {
 func (e Unauthorized) GoaErrorName() string {
 	return "unauthorized"
 }
-func (*AIPCreatedEvent) storageValueVal()         {}
-func (*AIPLocationUpdatedEvent) storageValueVal() {}
-func (*AIPStatusUpdatedEvent) storageValueVal()   {}
-func (*AIPTaskCreatedEvent) storageValueVal()     {}
-func (*AIPTaskUpdatedEvent) storageValueVal()     {}
-func (*AIPWorkflowCreatedEvent) storageValueVal() {}
-func (*AIPWorkflowUpdatedEvent) storageValueVal() {}
-func (*AMSSConfig) configVal()                    {}
-func (*LocationCreatedEvent) storageValueVal()    {}
-func (*S3Config) configVal()                      {}
-func (*SFTPConfig) configVal()                    {}
-func (*StoragePingEvent) storageValueVal()        {}
-func (*URLConfig) configVal()                     {}
+func (*AIPCreatedEvent) storageValueVal()                {}
+func (*AIPDeletionRequestCreatedEvent) storageValueVal() {}
+func (*AIPLocationUpdatedEvent) storageValueVal()        {}
+func (*AIPStatusUpdatedEvent) storageValueVal()          {}
+func (*AIPTaskCreatedEvent) storageValueVal()            {}
+func (*AIPTaskUpdatedEvent) storageValueVal()            {}
+func (*AIPWorkflowCreatedEvent) storageValueVal()        {}
+func (*AIPWorkflowUpdatedEvent) storageValueVal()        {}
+func (*AMSSConfig) configVal()                           {}
+func (*LocationCreatedEvent) storageValueVal()           {}
+func (*S3Config) configVal()                             {}
+func (*SFTPConfig) configVal()                           {}
+func (*StoragePingEvent) storageValueVal()               {}
+func (*URLConfig) configVal()                            {}
 
 // MakeInternalError builds a goa.ServiceError from an error.
 func MakeInternalError(err error) *goa.ServiceError {

--- a/internal/storage/convert.go
+++ b/internal/storage/convert.go
@@ -59,3 +59,19 @@ func (svc *serviceImpl) taskToGoa(t *types.Task) *goastorage.AIPTask {
 		WorkflowUUID: t.WorkflowUUID,
 	}
 }
+
+func (svc *serviceImpl) deletionRequestToGoa(dr *types.DeletionRequest) *goastorage.AIPDeletionRequest {
+	var reviewedAt *string
+	if !dr.ReviewedAt.IsZero() {
+		reviewedAt = ref.New(dr.ReviewedAt.Format(time.RFC3339))
+	}
+
+	return &goastorage.AIPDeletionRequest{
+		UUID:        dr.UUID,
+		AipUUID:     dr.AIPUUID,
+		Reason:      dr.Reason,
+		Status:      dr.Status.String(),
+		RequestedAt: dr.RequestedAt.Format(time.RFC3339),
+		ReviewedAt:  reviewedAt,
+	}
+}

--- a/internal/storage/event.go
+++ b/internal/storage/event.go
@@ -40,7 +40,8 @@ type Event interface {
 		*goastorage.AIPWorkflowCreatedEvent |
 		*goastorage.AIPWorkflowUpdatedEvent |
 		*goastorage.AIPTaskCreatedEvent |
-		*goastorage.AIPTaskUpdatedEvent
+		*goastorage.AIPTaskUpdatedEvent |
+		*goastorage.AIPDeletionRequestCreatedEvent
 }
 
 // PublishEvent publishes a storage event with type safety.

--- a/internal/storage/event_test.go
+++ b/internal/storage/event_test.go
@@ -27,6 +27,7 @@ func TestPublishEventTypes(t *testing.T) {
 	storage.PublishEvent(ctx, svc, &goastorage.AIPWorkflowUpdatedEvent{})
 	storage.PublishEvent(ctx, svc, &goastorage.AIPTaskCreatedEvent{})
 	storage.PublishEvent(ctx, svc, &goastorage.AIPTaskUpdatedEvent{})
+	storage.PublishEvent(ctx, svc, &goastorage.AIPDeletionRequestCreatedEvent{})
 }
 
 func TestEventSerializer(t *testing.T) {

--- a/internal/storage/service.go
+++ b/internal/storage/service.go
@@ -627,7 +627,16 @@ func (svc *serviceImpl) UpdateTask(
 }
 
 func (svc *serviceImpl) CreateDeletionRequest(ctx context.Context, dr *types.DeletionRequest) error {
-	return svc.storagePersistence.CreateDeletionRequest(ctx, dr)
+	if err := svc.storagePersistence.CreateDeletionRequest(ctx, dr); err != nil {
+		return err
+	}
+
+	PublishEvent(ctx, svc.evsvc, &goastorage.AIPDeletionRequestCreatedEvent{
+		UUID: dr.UUID,
+		Item: svc.deletionRequestToGoa(dr),
+	})
+
+	return nil
 }
 
 func (svc *serviceImpl) UpdateDeletionRequest(


### PR DESCRIPTION
Refs #1282.

- Add an AIP deletion request creation event type to the Goa API
- Publish an event to the storage event service when an AIP deletion request is created