### PR TITLE
Fix code coverage CI action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ on:
   pull_request:
   push:
     branches:
-    - main
+      - main
 name: Test
 jobs:
   test:
@@ -10,34 +10,34 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - name: Install Go
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-      with:
-        go-version-file: go.mod
-    - name: Check mod tidy
-      run: make mod-tidy-check
-    - name: Test
-      run: make test-ci
-    - name: Determine skip-codecov
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-      id: skip-codecov
-      with:
-        script: |
-          // Sets `ref` to the SHA of the current pull request's head commit,
-          // or, if not present, to the SHA of the commit that triggered the
-          // event.
-          const ref = '${{ github.event.pull_request.head.sha || github.event.after }}';
-          const { repo, owner } = context.repo;
-          const { data: commit } = await github.rest.repos.getCommit({ owner, repo, ref });
-          const commitMessage = commit.commit.message;
-          const skip = commitMessage.includes("[skip codecov]") || commitMessage.includes("[skip-codecov]");
-          core.setOutput("skip", skip);
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
-      if: ${{ steps.skip-codecov.outputs.skip != 'true' }}
-      with:
-        file: covreport
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Install Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+      - name: Check mod tidy
+        run: make mod-tidy-check
+      - name: Test
+        run: make test-ci
+      - name: Determine skip-codecov
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        id: skip-codecov
+        with:
+          script: |
+            // Sets `ref` to the SHA of the current pull request's head commit,
+            // or, if not present, to the SHA of the commit that triggered the
+            // event.
+            const ref = '${{ github.event.pull_request.head.sha || github.event.after }}';
+            const { repo, owner } = context.repo;
+            const { data: commit } = await github.rest.repos.getCommit({ owner, repo, ref });
+            const commitMessage = commit.commit.message;
+            const skip = commitMessage.includes("[skip codecov]") || commitMessage.includes("[skip-codecov]");
+            core.setOutput("skip", skip);
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
+        if: ${{ steps.skip-codecov.outputs.skip != 'true' }}
+        with:
+          files: covreport
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Update codecov action to change "file" argument to "files" — the "file" argument has been deprecated as of version 5 of https://github.com/codecov/codecov-action.