### PR TITLE
Add audit logging for SIP ingest events

### DIFF
--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -183,20 +183,20 @@ func main() {
 	// Set up the ingest service.
 	var ingestsvc ingest.Service
 	{
-		ingestsvc = ingest.NewService(
-			logger.WithName("ingest"),
-			enduroDatabase,
-			temporalClient,
-			ingestEventSvc,
-			perSvc,
-			&auth.NoopTokenVerifier{},
-			nil,
-			cfg.Temporal.TaskQueue,
-			internalStorage,
-			0,
-			rand.Reader,
-			sipSource,
-		)
+		ingestsvc = ingest.NewService(ingest.ServiceParams{
+			Logger:             logger.WithName("ingest"),
+			DB:                 enduroDatabase,
+			TemporalClient:     temporalClient,
+			EventService:       ingestEventSvc,
+			PersistenceService: perSvc,
+			TokenVerifier:      &auth.NoopTokenVerifier{},
+			TicketProvider:     nil,
+			TaskQueue:          cfg.Temporal.TaskQueue,
+			InternalStorage:    internalStorage,
+			UploadMaxSize:      0,
+			Rander:             rand.Reader,
+			SIPSource:          sipSource,
+		})
 	}
 
 	// Set up the watcher service.

--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -199,20 +199,20 @@ func main() {
 	// Set up the ingest service.
 	var ingestsvc ingest.Service
 	{
-		ingestsvc = ingest.NewService(
-			logger.WithName("ingest"),
-			enduroDatabase,
-			temporalClient,
-			ingestEventSvc,
-			perSvc,
-			&auth.NoopTokenVerifier{},
-			nil,
-			cfg.Temporal.TaskQueue,
-			internalStorage,
-			0,
-			rand.Reader,
-			sipSource,
-		)
+		ingestsvc = ingest.NewService(ingest.ServiceParams{
+			Logger:             logger.WithName("ingest"),
+			DB:                 enduroDatabase,
+			TemporalClient:     temporalClient,
+			EventService:       ingestEventSvc,
+			PersistenceService: perSvc,
+			TokenVerifier:      &auth.NoopTokenVerifier{},
+			TicketProvider:     nil,
+			TaskQueue:          cfg.Temporal.TaskQueue,
+			InternalStorage:    internalStorage,
+			UploadMaxSize:      0,
+			Rander:             rand.Reader,
+			SIPSource:          sipSource,
+		})
 	}
 
 	var g run.Group

--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -247,20 +247,20 @@ func main() {
 	// Set up the ingest service.
 	var ingestsvc ingest.Service
 	{
-		ingestsvc = ingest.NewService(
-			logger.WithName("ingest"),
-			enduroDatabase,
-			temporalClient,
-			ingestEventSvc,
-			perSvc,
-			tokenVerifier,
-			ticketProvider,
-			cfg.Temporal.TaskQueue,
-			internalStorage,
-			cfg.Upload.MaxSize,
-			rand.Reader,
-			sipSource,
-		)
+		ingestsvc = ingest.NewService(ingest.ServiceParams{
+			Logger:             logger.WithName("ingest"),
+			DB:                 enduroDatabase,
+			TemporalClient:     temporalClient,
+			EventService:       ingestEventSvc,
+			PersistenceService: perSvc,
+			TokenVerifier:      tokenVerifier,
+			TicketProvider:     ticketProvider,
+			TaskQueue:          cfg.Temporal.TaskQueue,
+			InternalStorage:    internalStorage,
+			UploadMaxSize:      cfg.Upload.MaxSize,
+			Rander:             rand.Reader,
+			SIPSource:          sipSource,
+		})
 	}
 
 	// Set up the storage persistence layer.
@@ -341,20 +341,20 @@ func main() {
 	// Recreate ingest and storage services with different
 	// logger names and using &auth.NoopTokenVerifier{}.
 	{
-		ips := ingest.NewService(
-			logger.WithName("internal-ingest"),
-			enduroDatabase,
-			temporalClient,
-			ingestEventSvc,
-			perSvc,
-			&auth.NoopTokenVerifier{},
-			ticketProvider,
-			cfg.Temporal.TaskQueue,
-			internalStorage,
-			cfg.Upload.MaxSize,
-			rand.Reader,
-			sipSource,
-		)
+		ips := ingest.NewService(ingest.ServiceParams{
+			Logger:             logger.WithName("internal-ingest"),
+			DB:                 enduroDatabase,
+			TemporalClient:     temporalClient,
+			EventService:       ingestEventSvc,
+			PersistenceService: perSvc,
+			TokenVerifier:      &auth.NoopTokenVerifier{},
+			TicketProvider:     ticketProvider,
+			TaskQueue:          cfg.Temporal.TaskQueue,
+			InternalStorage:    internalStorage,
+			UploadMaxSize:      cfg.Upload.MaxSize,
+			Rander:             rand.Reader,
+			SIPSource:          sipSource,
+		})
 
 		iss, err := storage.NewService(
 			logger.WithName("internal-storage"),

--- a/enduro.toml
+++ b/enduro.toml
@@ -71,6 +71,19 @@ rolesMapping = ""
 address = "redis://redis.enduro-sdps:6379"
 prefix = "enduro"
 
+[auditlog]
+# filePath is the absolute path to the audit log. The enduro user will need
+# write access to the given directory. Rotated logs will use the same directory
+# and filename, but with a timestamp appended. If filePath is not set, or set to
+# an empty string, audit logging will be disabled.
+filepath = "/home/enduro/logs/enduro_audit.log"
+# maxSize is the maximum size, in megabytes, of the audit log file. When the
+# log file reaches maxSize or greater it will be rotated (default: 100 MB).
+maxSize = 100
+# compress determines if the rotated log files are compressed using gzip
+# (default: false).
+compress = false
+
 [database]
 driver = "mysql"
 dsn = "enduro:enduro123@tcp(mysql.enduro-sdps:3306)/enduro"
@@ -143,26 +156,26 @@ shareDir = "/home/a3m/.local/share/a3m/share"
 capacity = 1
 
 [a3m.processing]
-AssignUuidsToDirectories                     = true
-ExamineContents                              = true
-GenerateTransferStructureReport              = true
-DocumentEmptyDirectories                     = true
-ExtractPackages                              = true
-DeletePackagesAfterExtraction                = true
-IdentifyTransfer                             = true
-IdentifySubmissionAndMetadata                = true
-IdentifyBeforeNormalization                  = true
-Normalize                                    = true
-TranscribeFiles                              = true
-PerformPolicyChecksOnOriginals               = true
+AssignUuidsToDirectories = true
+ExamineContents = true
+GenerateTransferStructureReport = true
+DocumentEmptyDirectories = true
+ExtractPackages = true
+DeletePackagesAfterExtraction = true
+IdentifyTransfer = true
+IdentifySubmissionAndMetadata = true
+IdentifyBeforeNormalization = true
+Normalize = true
+TranscribeFiles = true
+PerformPolicyChecksOnOriginals = true
 PerformPolicyChecksOnPreservationDerivatives = true
-AipCompressionLevel                          = 1
-AipCompressionAlgorithm                      = 6
+AipCompressionLevel = 1
+AipCompressionAlgorithm = 6
 
 [am]
 address = ""
-user = "" # Secret: set with env var ENDURO_AM_USER.
-apiKey = "" # Secret: set with env var ENDURO_AM_APIKEY.
+user = ""                      # Secret: set with env var ENDURO_AM_USER.
+apiKey = ""                    # Secret: set with env var ENDURO_AM_APIKEY.
 processingConfig = "automated"
 
 # capacity limits the number of transfers a worker can process at one time

--- a/go.mod
+++ b/go.mod
@@ -207,6 +207,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250324211829-b45e905df463 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1691,6 +1691,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -1,0 +1,79 @@
+package auditlog
+
+import (
+	"context"
+	"io"
+	"log/slog"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// Logger represents a structured audit event logger.
+type Logger struct {
+	l *slog.Logger
+	w io.WriteCloser
+}
+
+// New creates a new audit logger using the provided writer w and logger l.
+func New(w io.WriteCloser, l *slog.Logger) *Logger {
+	return &Logger{l: l, w: w}
+}
+
+// NewFromConfig creates a new audit logger from the provided config. The
+// logger writes JSON entries to cfg.Filepath and does log rotation. If
+// cfg.Filepath is not set, a no-op logger will be returned.
+func NewFromConfig(cfg Config) *Logger {
+	if cfg.Filepath == "" {
+		return &Logger{}
+	}
+
+	w := rotatingWriter(cfg)
+
+	return New(w, slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{})))
+}
+
+// Close releases any resources held by the logger.
+func (l *Logger) Close() error {
+	if l.w == nil {
+		return nil
+	}
+	return l.w.Close()
+}
+
+// Log logs an audit event.
+func (l *Logger) Log(ctx context.Context, ev *Event) {
+	if l.l == nil {
+		return
+	}
+	l.l.Log(ctx, ev.Level, ev.Msg, ev.args()...)
+}
+
+// rotatingWriter creates a new io.WriteCloser that writes to a log file that is
+// rotated after reaching MaxSize.
+func rotatingWriter(cfg Config) io.WriteCloser {
+	w := &lumberjack.Logger{
+		Filename: cfg.Filepath,
+		MaxSize:  cfg.MaxSize,
+		Compress: cfg.Compress,
+	}
+
+	return w
+}
+
+// Event represents a audit log event.
+type Event struct {
+	Level      slog.Level
+	Msg        string
+	Type       string
+	ResourceID string
+	User       string
+}
+
+// args returns a slice of key/value pairs to be written to the audit log.
+func (e Event) args() []any {
+	return []any{
+		"type", e.Type,
+		"resourceID", e.ResourceID,
+		"user", e.User,
+	}
+}

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -1,0 +1,81 @@
+package auditlog_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/auditlog"
+)
+
+func TestNewFromConfig(t *testing.T) {
+	t.Parallel()
+
+	resID := uuid.MustParse("e8d32bd5-faa4-4ce1-bb50-55d9c28b306d")
+
+	type test struct {
+		name    string
+		cfg     auditlog.Config
+		event   *auditlog.Event
+		want    string
+		wantErr error
+	}
+	for _, tc := range []test{
+		{
+			name: "audit log disabled when no filepath is configured",
+			cfg:  auditlog.Config{},
+			event: &auditlog.Event{
+				Level:      slog.LevelInfo,
+				Msg:        "SIP ingest started",
+				Type:       "SIP.ingest",
+				ResourceID: resID.String(),
+				User:       "test@example.com",
+			},
+			want:    "",
+			wantErr: os.ErrNotExist,
+		},
+		{
+			name: "writes audit log",
+			cfg: auditlog.Config{
+				Filepath: filepath.Join(t.TempDir(), "audit.log"),
+				MaxSize:  1, // 1 MB
+				Compress: true,
+			},
+			event: &auditlog.Event{
+				Level:      slog.LevelInfo,
+				Msg:        "SIP ingest started",
+				Type:       "SIP.ingest",
+				ResourceID: resID.String(),
+				User:       "test@example.com",
+			},
+			want: `"level":"INFO","msg":"SIP ingest started","type":"SIP.ingest","resourceID":"e8d32bd5-faa4-4ce1-bb50-55d9c28b306d","user":"test@example.com"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			al := auditlog.NewFromConfig(tc.cfg)
+			al.Log(context.Background(), tc.event)
+			al.Close()
+
+			got, err := os.ReadFile(tc.cfg.Filepath)
+			if tc.wantErr != nil {
+				assert.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+
+			assert.Assert(t,
+				strings.Contains(string(got), tc.want),
+				fmt.Sprintf("expected %s to contain %s", string(got), tc.want),
+			)
+		})
+	}
+}

--- a/internal/auditlog/config.go
+++ b/internal/auditlog/config.go
@@ -1,0 +1,15 @@
+package auditlog
+
+type Config struct {
+	// Filepath specifies the location of the audit log file. If Filepath is
+	// not set, audit logging will be disabled.
+	Filepath string
+
+	// MaxSize sets the maximum size of the audit log file in megabytes before
+	// it is rotated (default: 100 MB).
+	MaxSize int
+
+	// Compress determines if the rotated log files are compressed using gzip
+	// (default: false).
+	Compress bool
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/a3m"
 	"github.com/artefactual-sdps/enduro/internal/am"
 	"github.com/artefactual-sdps/enduro/internal/api"
+	"github.com/artefactual-sdps/enduro/internal/auditlog"
 	"github.com/artefactual-sdps/enduro/internal/db"
 	"github.com/artefactual-sdps/enduro/internal/event"
 	"github.com/artefactual-sdps/enduro/internal/ingest"
@@ -75,6 +76,7 @@ type Configuration struct {
 	Watcher         watcher.Config
 	Telemetry       telemetry.Config
 	ValidatePREMIS  premis.Config
+	Auditlog        auditlog.Config
 }
 
 func (c *Configuration) Validate() error {

--- a/internal/ingest/convert.go
+++ b/internal/ingest/convert.go
@@ -3,12 +3,14 @@ package ingest
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
 	"go.artefactual.dev/tools/ref"
 
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	"github.com/artefactual-sdps/enduro/internal/auditlog"
 	"github.com/artefactual-sdps/enduro/internal/datatypes"
 	"github.com/artefactual-sdps/enduro/internal/db"
 	"github.com/artefactual-sdps/enduro/internal/entfilter"
@@ -24,6 +26,21 @@ func sipToCreatedEvent(s *datatypes.SIP) *goaingest.SIPCreatedEvent {
 		UUID: s.UUID,
 		Item: s.Goa(),
 	}
+}
+
+// sipIngestAuditEvent returns a SIP ingest audit log event for SIP s.
+func sipIngestAuditEvent(s *datatypes.SIP) *auditlog.Event {
+	e := &auditlog.Event{
+		Level:      slog.LevelInfo,
+		Msg:        "SIP ingest started",
+		Type:       "SIP.ingest",
+		ResourceID: s.UUID.String(),
+	}
+	if s.Uploader != nil {
+		e.User = s.Uploader.Email
+	}
+
+	return e
 }
 
 // workflowToGoa returns the API representation of a workflow.

--- a/internal/ingest/download_sip_test.go
+++ b/internal/ingest/download_sip_test.go
@@ -153,20 +153,12 @@ func TestDownloadSipRequest(t *testing.T) {
 
 			rander := rand.New(rand.NewSource(1)) // #nosec
 			ticketProvider := auth.NewTicketProvider(ctx, ticketStoreMock, rander)
-			svc := ingest.NewService(
-				logr.Discard(),
-				nil,
-				nil,
-				nil,
-				psvcMock,
-				nil,
-				ticketProvider,
-				"",
-				bucket,
-				0,
-				nil,
-				nil,
-			)
+			svc := ingest.NewService(ingest.ServiceParams{
+				Logger:             logr.Discard(),
+				PersistenceService: psvcMock,
+				TicketProvider:     ticketProvider,
+				InternalStorage:    bucket,
+			})
 
 			res, err := svc.Goa().DownloadSipRequest(ctx, tt.payload)
 			if tt.wantErr != "" {
@@ -304,20 +296,12 @@ func TestDownloadSip(t *testing.T) {
 			}
 
 			ticketProvider := auth.NewTicketProvider(ctx, ticketStoreMock, nil)
-			svc := ingest.NewService(
-				logr.Discard(),
-				nil,
-				nil,
-				nil,
-				psvcMock,
-				nil,
-				ticketProvider,
-				"",
-				bucket,
-				0,
-				nil,
-				nil,
-			)
+			svc := ingest.NewService(ingest.ServiceParams{
+				Logger:             logr.Discard(),
+				PersistenceService: psvcMock,
+				TicketProvider:     ticketProvider,
+				InternalStorage:    bucket,
+			})
 
 			res, body, err := svc.Goa().DownloadSip(ctx, tt.payload)
 			if tt.wantErr != "" {

--- a/internal/ingest/goa.go
+++ b/internal/ingest/goa.go
@@ -110,6 +110,7 @@ func (w *goaWrapper) AddSip(ctx context.Context, payload *goaingest.AddSipPayloa
 	}
 
 	PublishEvent(ctx, w.evsvc, sipToCreatedEvent(s))
+	w.auditLogger.Log(ctx, sipIngestAuditEvent(s))
 
 	w.logger.V(1).Info(
 		"Add SIP: started processing workflow from SIP source.",

--- a/internal/ingest/goa_test.go
+++ b/internal/ingest/goa_test.go
@@ -718,20 +718,11 @@ func TestListSIPSourceObjects(t *testing.T) {
 				tt.mockRecorder(src.EXPECT())
 			}
 
-			svc := NewService(
-				logr.Discard(),
-				nil,               // SQL DB
-				nil,               // Temporal client
-				nil,               // Event service
-				nil,               // Persistence service
-				nil,               // Token verifier
-				nil,               // Ticket provider
-				"test-task-queue", // Task queue
-				nil,               // Internal storage bucket
-				1000000,           // Upload max size
-				nil,               // Mocked random reader
-				src,               // Mocked SIP source
-			)
+			svc := NewService(ServiceParams{
+				Logger:        logr.Discard(),
+				UploadMaxSize: 1000000,
+				SIPSource:     src,
+			})
 
 			got, err := svc.Goa().ListSipSourceObjects(t.Context(), tt.payload)
 			if tt.wantErr != "" {

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/artefactual-sdps/enduro/internal/api/auth"
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	"github.com/artefactual-sdps/enduro/internal/auditlog"
 	"github.com/artefactual-sdps/enduro/internal/datatypes"
 	"github.com/artefactual-sdps/enduro/internal/enums"
 	"github.com/artefactual-sdps/enduro/internal/event"
@@ -72,6 +73,7 @@ type ingestImpl struct {
 	uploadMaxSize   int64
 	rander          io.Reader
 	sipSource       sipsource.SIPSource
+	auditLogger     *auditlog.Logger
 }
 
 var _ Service = (*ingestImpl)(nil)
@@ -89,6 +91,7 @@ type ServiceParams struct {
 	UploadMaxSize      int64
 	Rander             io.Reader
 	SIPSource          sipsource.SIPSource
+	AuditLogger        *auditlog.Logger
 }
 
 func NewService(params ServiceParams) *ingestImpl {
@@ -105,6 +108,7 @@ func NewService(params ServiceParams) *ingestImpl {
 		uploadMaxSize:   params.UploadMaxSize,
 		rander:          params.Rander,
 		sipSource:       params.SIPSource,
+		auditLogger:     params.AuditLogger,
 	}
 }
 
@@ -123,6 +127,7 @@ func (svc *ingestImpl) CreateSIP(ctx context.Context, s *datatypes.SIP) error {
 	}
 
 	PublishEvent(ctx, svc.evsvc, sipToCreatedEvent(s))
+	svc.auditLogger.Log(ctx, sipIngestAuditEvent(s))
 
 	return nil
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -76,33 +76,35 @@ type ingestImpl struct {
 
 var _ Service = (*ingestImpl)(nil)
 
-func NewService(
-	logger logr.Logger,
-	db *sql.DB,
-	tc temporalsdk_client.Client,
-	evsvc event.Service[*goaingest.IngestEvent],
-	psvc persistence.Service,
-	tokenVerifier auth.TokenVerifier,
-	ticketProvider auth.TicketProvider,
-	taskQueue string,
-	internalBucket *blob.Bucket,
-	uploadMaxSize int64,
-	rander io.Reader,
-	sipSource sipsource.SIPSource,
-) *ingestImpl {
+type ServiceParams struct {
+	Logger             logr.Logger
+	DB                 *sql.DB
+	TemporalClient     temporalsdk_client.Client
+	EventService       event.Service[*goaingest.IngestEvent]
+	PersistenceService persistence.Service
+	TokenVerifier      auth.TokenVerifier
+	TicketProvider     auth.TicketProvider
+	TaskQueue          string
+	InternalStorage    *blob.Bucket
+	UploadMaxSize      int64
+	Rander             io.Reader
+	SIPSource          sipsource.SIPSource
+}
+
+func NewService(params ServiceParams) *ingestImpl {
 	return &ingestImpl{
-		logger:          logger,
-		db:              sqlx.NewDb(db, "mysql"),
-		tc:              tc,
-		evsvc:           evsvc,
-		perSvc:          psvc,
-		tokenVerifier:   tokenVerifier,
-		ticketProvider:  ticketProvider,
-		taskQueue:       taskQueue,
-		internalStorage: internalBucket,
-		uploadMaxSize:   uploadMaxSize,
-		rander:          rander,
-		sipSource:       sipSource,
+		logger:          params.Logger,
+		db:              sqlx.NewDb(params.DB, "mysql"),
+		tc:              params.TemporalClient,
+		evsvc:           params.EventService,
+		perSvc:          params.PersistenceService,
+		tokenVerifier:   params.TokenVerifier,
+		ticketProvider:  params.TicketProvider,
+		taskQueue:       params.TaskQueue,
+		internalStorage: params.InternalStorage,
+		uploadMaxSize:   params.UploadMaxSize,
+		rander:          params.Rander,
+		sipSource:       params.SIPSource,
 	}
 }
 

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -34,20 +34,20 @@ func testSvc(t *testing.T, internalBucket *blob.Bucket, uploadMaxSize int64) (
 	psvc := persistence_fake.NewMockService(gomock.NewController(t))
 	temporalClient := new(temporalsdk_mocks.Client)
 	taskQueue := "test"
-	ingestsvc := ingest.NewService(
-		logr.Discard(),
-		&sql.DB{},
-		temporalClient,
-		event.NewServiceNop[*goaingest.IngestEvent](),
-		psvc,
-		&auth.NoopTokenVerifier{},
-		auth.NewTicketProvider(t.Context(), nil, nil),
-		taskQueue,
-		internalBucket,
-		uploadMaxSize,
-		rand.New(rand.NewSource(1)), // #nosec: G404
-		&sipsource.BucketSource{},
-	)
+	ingestsvc := ingest.NewService(ingest.ServiceParams{
+		Logger:             logr.Discard(),
+		DB:                 &sql.DB{},
+		TemporalClient:     temporalClient,
+		EventService:       event.NewServiceNop[*goaingest.IngestEvent](),
+		PersistenceService: psvc,
+		TokenVerifier:      &auth.NoopTokenVerifier{},
+		TicketProvider:     auth.NewTicketProvider(t.Context(), nil, nil),
+		TaskQueue:          taskQueue,
+		InternalStorage:    internalBucket,
+		UploadMaxSize:      uploadMaxSize,
+		Rander:             rand.New(rand.NewSource(1)), // #nosec: G404
+		SIPSource:          &sipsource.BucketSource{},
+	})
 
 	return ingestsvc, psvc, temporalClient
 }

--- a/internal/ingest/upload.go
+++ b/internal/ingest/upload.go
@@ -141,6 +141,7 @@ func (w *goaWrapper) initSIP(
 	}
 
 	PublishEvent(ctx, w.evsvc, sipToCreatedEvent(s))
+	w.auditLogger.Log(ctx, sipIngestAuditEvent(s))
 
 	return nil
 }


### PR DESCRIPTION
- Pass a parameter struct to the ingest service constructor to avoid passing a long list of positional arguments
- Add an audit logging package
- Log system startup and shutdown and SIP ingest events to the audit log
- Switch to a Debian (slim) Docker image for the enduro workers to simplify debugging of the running containers