### PR TITLE
Bump Bootstrap to v5.3.8 and silence deprecations

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -45,7 +45,7 @@
         "@vitejs/plugin-vue": "^5.2.4",
         "@vitest/coverage-v8": "^3.2.3",
         "@vue/tsconfig": "^0.7.0",
-        "bootstrap": "^5.3.6",
+        "bootstrap": "^5.3.8",
         "eslint": "^9.28.0",
         "eslint-import-resolver-typescript": "^4.4.3",
         "eslint-plugin-import": "^2.31.0",
@@ -3699,9 +3699,9 @@
       "license": "ISC"
     },
     "node_modules/bootstrap": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
-      "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
       "dev": true,
       "funding": [
         {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -54,7 +54,7 @@
     "@vitejs/plugin-vue": "^5.2.4",
     "@vitest/coverage-v8": "^3.2.3",
     "@vue/tsconfig": "^0.7.0",
-    "bootstrap": "^5.3.6",
+    "bootstrap": "^5.3.8",
     "eslint": "^9.28.0",
     "eslint-import-resolver-typescript": "^4.4.3",
     "eslint-plugin-import": "^2.31.0",

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -54,13 +54,19 @@ export default defineConfig({
   css: {
     preprocessorOptions: {
       scss: {
-        // Bootstrap v5.3.3 doesn't support the SASS modern API
-        // (https://github.com/twbs/bootstrap/issues/40962), so we need to use
-        // legacy mode.
+        // Bootstrap v5.3 doesn't support the SASS modern API
+        // (https://github.com/twbs/bootstrap/issues/40962),
+        // so we need to use legacy mode. This has been removed
+        // in Vite v7, which may require to upgrade Bootstrap v6
+        // (https://github.com/twbs/bootstrap/pull/41512).
         api: "legacy",
         additionalData: `@import "src/styles/bootstrap-base.scss";`,
-        // TODO: remove this line once bootstrap v5.3.4 is released.
-        silenceDeprecations: ["mixed-decls"],
+        silenceDeprecations: [
+          "color-functions",
+          "global-builtin",
+          "import",
+          "legacy-js-api",
+        ],
       },
     },
   },


### PR DESCRIPTION
Use the latest Boostrap version and fix the silenced deprecations. Note issue between Vite 7 and Bootstrap 5.