### PR TITLE
Add CSP meta to dashboard

### DIFF
--- a/dashboard/.env.development
+++ b/dashboard/.env.development
@@ -1,6 +1,6 @@
 VITE_OIDC_ENABLED=true
 VITE_OIDC_BASE_URL=http://localhost:8080
-VITE_OIDC_AUTHORITY=http://keycloak:7470/realms/artefactual
+VITE_OIDC_AUTHORITY=http://keycloak:7470/realms/artefactual/
 VITE_OIDC_CLIENT_ID=enduro
 VITE_OIDC_SCOPES="openid email profile enduro"
 VITE_OIDC_EXTRA_QUERY_PARAMS=

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -30,6 +30,24 @@ server {
     listen 80;
     root /usr/share/nginx/html;
     absolute_redirect off;
+
+    # Clickjacking protection, not supported via CSP meta.
+    add_header Content-Security-Policy "frame-ancestors 'none'" always;
+
+    # Full CSP via header, if not using the meta tag.
+    # Replace or remove the OIDC provider and institution logo URLs as needed.
+    # add_header Content-Security-Policy "default-src 'self'; script-src-attr 'none'; img-src 'self' data: http://institution.com/logo.png; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; connect-src 'self' http://oidcprovider.com/realms/example/; frame-ancestors 'none'" always;
+
+    # When serving over HTTPS:
+    # (Append to CSP) ... ; upgrade-insecure-requests
+
+    # Reporting:
+    # (Append to CSP) ... ; report-uri https://example.com/csp
+
+    # Reporting (not broadly supported yet):
+    # add_header Reporting-Endpoints 'csp="https://example.com/csp"' always;
+    # (Append to CSP) ... ; report-to csp
+
     location /api/ingest/monitor {
         proxy_pass http://backend/ingest/monitor;
         proxy_http_version 1.1;

--- a/dashboard/hack/inject-vite-envs.sh
+++ b/dashboard/hack/inject-vite-envs.sh
@@ -11,12 +11,18 @@ cp -r $ENDURO_DASHBOARD_DIST/* $ENDURO_DASHBOARD_ROOT/
 VITE_ENVS=$(printenv | awk -F= '$1 ~ /^VITE/ {print $1}' | sed 's/^/\$/g' | paste -sd,);
 echo "Vite envs: ${VITE_ENVS}"
 
-# Inject environment variables into distribution files
+# Inject environment variables into distribution files and remove
+# placeholders that were not replaced (env. vars. not set).
 for file in $ENDURO_DASHBOARD_ROOT/assets/*.js;
 do
-    echo "Inject VITE environment variables into $(basename $file)"
+    echo "Inject VITE environment variables into assets/$(basename $file)"
     envsubst $VITE_ENVS < $file > $TMP_DIR/$(basename $file)
+    sed -E -i 's/\$VITE_[A-Z0-9_]+//g' $TMP_DIR/$(basename $file)
     cp $TMP_DIR/$(basename $file) $file
 done
+echo "Inject VITE environment variables into index.html"
+envsubst $VITE_ENVS < $ENDURO_DASHBOARD_ROOT/index.html > $TMP_DIR/index.html
+sed -E -i 's/\$VITE_[A-Z0-9_]+//g' $TMP_DIR/index.html
+cp $TMP_DIR/index.html $ENDURO_DASHBOARD_ROOT/index.html
 
 rm -rf $TMP_DIR

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -62,6 +62,7 @@
         "unplugin-icons": "^22.1.0",
         "unplugin-vue-router": "^0.12.0",
         "vite": "^6.3.5",
+        "vite-plugin-csp-guard": "^2.2.0",
         "vite-plugin-vue-devtools": "^7.7.6",
         "vitest": "^3.2.3",
         "vue-tsc": "^2.2.10"
@@ -3932,6 +3933,60 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -4051,6 +4106,43 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/csp-toolkit": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/csp-toolkit/-/csp-toolkit-1.4.0.tgz",
+      "integrity": "sha512-ezMVB6+2RnsnN5ncHsLX8njyPMv7I0M6ZLDP4pgmRVS4JjCgiWyeY2vs0zVfFTbdCo0CQI47PFICiQOZ5tDiww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -4294,6 +4386,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
@@ -4301,6 +4437,21 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dunder-proto": {
@@ -4347,6 +4498,20 @@
       "version": "9.2.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.1",
@@ -5547,6 +5712,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/human-signals": {
       "version": "8.0.0",
       "dev": true,
@@ -5560,6 +5758,19 @@
       "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.33.0.tgz",
       "integrity": "sha512-vYJX7BSzn7EQ4SaP2lPYVy+icHDppB6k7myNeI3wrSRfwMS5+BHyGgzpHR0ptqJ2AQ6UuIKrclSg5ve6Ci4IAQ==",
       "license": "Unlicense"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -7334,14 +7545,56 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.2.1",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.5.0"
+        "entities": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-browserify": {
@@ -7923,6 +8176,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sass": {
       "version": "1.89.2",
@@ -8770,6 +9030,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.15.0.tgz",
+      "integrity": "sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
@@ -9142,6 +9412,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vite-plugin-csp-guard": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-csp-guard/-/vite-plugin-csp-guard-2.2.0.tgz",
+      "integrity": "sha512-OuGFHRFbvIjuDagNz93sT7BGExOsyKQ0qhAMVFlEzBdWL2Uc7ekFHUMPCDcxRRPLzs1xrbuMnPciDj03lvBGlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio": "^1.0.0",
+        "csp-toolkit": "1.4.0"
+      },
+      "peerDependencies": {
+        "vite": ">=5.0.0"
+      }
+    },
     "node_modules/vite-plugin-inspect": {
       "version": "0.8.9",
       "dev": true,
@@ -9431,6 +9715,19 @@
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -71,6 +71,7 @@
     "unplugin-icons": "^22.1.0",
     "unplugin-vue-router": "^0.12.0",
     "vite": "^6.3.5",
+    "vite-plugin-csp-guard": "^2.2.0",
     "vite-plugin-vue-devtools": "^7.7.6",
     "vitest": "^3.2.3",
     "vue-tsc": "^2.2.10"

--- a/dashboard/src/vite-env.d.ts
+++ b/dashboard/src/vite-env.d.ts
@@ -22,6 +22,9 @@ interface ImportMetaEnv {
   readonly VITE_OIDC_ABAC_CLAIM_VALUE_PREFIX: string;
   readonly VITE_OIDC_ABAC_USE_ROLES: string;
   readonly VITE_OIDC_ABAC_ROLES_MAPPING: string;
+  readonly VITE_INSTITUTION_LOGO: string;
+  readonly VITE_INSTITUTION_NAME: string;
+  readonly VITE_INSTITUTION_URL: string;
 }
 
 interface ImportMeta {

--- a/docs/src/admin-manual/iac.md
+++ b/docs/src/admin-manual/iac.md
@@ -101,6 +101,13 @@ VITE_OIDC_ABAC_USE_ROLES
 VITE_OIDC_ABAC_ROLES_MAPPING
 ```
 
+!!! important
+
+    The `VITE_OIDC_AUTHORITY` environment variable is included in the Content
+    Security Policy's `connect-src` directive. If this URL contains a path,
+    ensure it ends with a slash (`/`) to allow connections to the necessary
+    OIDC endpoints for authentication.
+
 They must match the ones configured in the API. `VITE_OIDC_AUTHORITY` has to be
 the same OIDC provider URL and `VITE_OIDC_CLIENT_ID` needs to be the same or a
 trusted client. This client (or the one used in the API configuration, if they

--- a/hack/kube/components/dev/enduro-dashboard-secret.yaml
+++ b/hack/kube/components/dev/enduro-dashboard-secret.yaml
@@ -6,7 +6,7 @@ type: Opaque
 stringData:
   oidc-enabled: "true"
   oidc-base-url: http://localhost:8080
-  oidc-provider-url: http://keycloak:7470/realms/artefactual
+  oidc-provider-url: http://keycloak:7470/realms/artefactual/
   oidc-client-id: enduro
   oidc-scopes: "openid email profile enduro"
   oidc-extra-query-params: ""


### PR DESCRIPTION
Implemet CSP meta in the dashboard using `vite-plugin-csp-guard`. Allow
to disable it at build/serve time using an ENDURO_DISABLE_CSP_META env.
var. Make sure the environment files are read during VITE build/serve.
Add CSP header and comments in Dockerfile NGINX config.

Also:

- Consider `index.html` and remove not replaced placeholders in the `inject-vite-envs.sh` script.
- Add institution vars to ImportMetaEnv.

Refs #1352.