### PR TITLE
Upgrade Keycloak from 24.0.4 to 26.3

### DIFF
--- a/hack/kube/components/dev/keycloak.yaml
+++ b/hack/kube/components/dev/keycloak.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: sdps
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:24.0.4
+          image: quay.io/keycloak/keycloak:26.3
           command:
             [
               "/opt/keycloak/bin/kc.sh",
@@ -25,12 +25,12 @@ spec:
               "--http-port=7470",
             ]
           env:
-            - name: KEYCLOAK_ADMIN
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: keycloak-secret
                   key: username
-            - name: KEYCLOAK_ADMIN_PASSWORD
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: keycloak-secret


### PR DESCRIPTION
Bump the version of Keycloak installed by the Kube helm chart from 24.0.4 to the latest version of 26.3 (currently 26.3.3).