### PR TITLE
Add `sub` claim to Keycloak enduro client

### DIFF
--- a/hack/kube/components/dev/keycloak.yaml
+++ b/hack/kube/components/dev/keycloak.yaml
@@ -199,6 +199,18 @@ data:
           "protocol": "openid-connect",
           "protocolMappers": [
             {
+              "id": "3c17ae04-4f8f-4507-9032-163eb562b3b3",
+              "name": "sub",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-sub-mapper",
+              "consentRequired": false,
+              "config": {
+                "included.client.audience": "enduro",
+                "introspection.token.claim": "true",
+                "access.token.claim": "true"
+              }
+            },
+            {
               "id": "227b056a-cc39-4209-99b0-bfa929ca892f",
               "name": "access-token-aud",
               "protocol": "openid-connect",


### PR DESCRIPTION
Version 25 of Keycloak removed the OIDC `sub` claim from the default access token claims, which breaks several checks of the `sub` claim in Enduro. This commit explicitly adds the `sub` claim back to the Keycloak enduro client.