### PR TITLE
Auto-expand workflow task lists

### DIFF
--- a/dashboard/src/pages/ingest/sips/[id]/index.vue
+++ b/dashboard/src/pages/ingest/sips/[id]/index.vue
@@ -106,6 +106,7 @@ onMounted(() => {
         <WorkflowCollapse
           :workflow="workflow"
           :index="index"
+          :of="sipStore.currentWorkflows.workflows.length"
           v-for="(workflow, index) in sipStore.currentWorkflows?.workflows"
           v-bind:key="workflow.uuid"
         />

--- a/dashboard/src/pages/storage/aips/[id]/index.vue
+++ b/dashboard/src/pages/storage/aips/[id]/index.vue
@@ -84,6 +84,7 @@ onMounted(() => {
         <WorkflowCollapse
           :workflow="workflow"
           :index="index"
+          :of="aipStore.currentWorkflows.workflows.length"
           v-for="(workflow, index) in aipStore.currentWorkflows?.workflows"
           v-bind:key="workflow.uuid"
         />


### PR DESCRIPTION
Refs #1311.

- Make a workflow task list expanded by default if the workflow is currently "in progress", "pending" a user decision or is the only workflow on the page
- Update HTML `id` attributes for workflow accordion elements