### PR TITLE
Add spinner to workflow "in progress" badge

### DIFF
--- a/dashboard/src/components/StatusBadge.vue
+++ b/dashboard/src/components/StatusBadge.vue
@@ -15,10 +15,9 @@ export type StatusEnum = packageEnum | workflowEnum | taskEnum;
 <script setup lang="ts">
 import { computed } from "vue";
 
-import type { api } from "@/client";
+import { api } from "@/client";
 
 type badgeType = "package" | "workflow";
-
 type badgeStyle = string[];
 
 const props = defineProps<{
@@ -80,6 +79,12 @@ const colorClass = computed(() => {
   <span>
     <span :class="['badge', colorClass]">
       {{ props.status.toUpperCase() }}
+      <div
+        v-if="props.status == api.EnduroIngestSipWorkflowStatusEnum.InProgress"
+        class="spinner-border spinner-border-sm text-black"
+        role="progress"
+        aria-hidden="true"
+      ></div>
     </span>
     <span v-if="props.note" class="badge text-dark fw-normal"
       >({{ props.note }})</span


### PR DESCRIPTION
Refs #1289.

Add an animated spinner to the workflow "in progress" badge as a visual cue that the workflow is still running.