### PR TITLE
Fix golangci-lint caching in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ name: Lint
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest
+    env:
+      GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -15,22 +17,23 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Get date
+        id: get_date
         shell: bash
         run: |
-          echo "DATE=$(date -u '+%Y-%m')" >> $GITHUB_ENV
+          echo "date=$(date -u '+%Y-%m')" >> $GITHUB_OUTPUT
+      - name: Ensure golangci-lint cache dir
+        run: mkdir -p "$GOLANGCI_LINT_CACHE"
       - name: Restore golangci-lint cache
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         timeout-minutes: 10
         continue-on-error: true
         with:
-          path: ${{ runner.temp }}/golangci-lint-cache
-          key: ${{ runner.os }}-golangci-lint-cache-${{ env.DATE }}
-          restore-keys: |
-            ${{ runner.os }}-golangci-lint-cache-
+          path: ${{ env.GOLANGCI_LINT_CACHE }}
+          key: ${{ runner.os }}-golangci-lint-cache-${{ steps.get_date.outputs.date }}
+          restore-keys: ${{ runner.os }}-golangci-lint-cache-
       - name: Run golangci-lint
         run: make lint LINT_FLAGS=--fix=0
-        env:
-          GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-lint-cache
+
   shfmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,23 +20,9 @@ jobs:
         run: make mod-tidy-check
       - name: Test
         run: make test-ci
-      - name: Determine skip-codecov
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        id: skip-codecov
-        with:
-          script: |
-            // Sets `ref` to the SHA of the current pull request's head commit,
-            // or, if not present, to the SHA of the commit that triggered the
-            // event.
-            const ref = '${{ github.event.pull_request.head.sha || github.event.after }}';
-            const { repo, owner } = context.repo;
-            const { data: commit } = await github.rest.repos.getCommit({ owner, repo, ref });
-            const commitMessage = commit.commit.message;
-            const skip = commitMessage.includes("[skip codecov]") || commitMessage.includes("[skip-codecov]");
-            core.setOutput("skip", skip);
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
-        if: ${{ steps.skip-codecov.outputs.skip != 'true' }}
+        if: ${{ !contains(github.event.head_commit.message, '[skip codecov]') && !contains(github.event.head_commit.message, '[skip-codecov]') }}
         with:
           files: covreport
         env:


### PR DESCRIPTION
*False alarm! For some reason I thought the cache wasn't being used in the golangci-lint job, but it is!*

---

I noticed in another project that golangci-lint was not properly using the cache due to a configuration issue. I'm not sure why `runner.tmp` wasn't working. With these changes, we should see the job making use of the cache, e.g.:

```
Cache hit for: Linux-golangci-lint-cache-2025-09
Received 1852958 of 1852958 (100.0%), 16.2 MBs/sec
Cache Size: ~2 MB (1852958 B)
/usr/bin/tar -xf /home/runner/work/_temp/61b7a35c-54e3-4c5e-8d58-179e83fa191c/cache.tzst -P -C /home/runner/work/enduro/enduro --use-compress-program unzstd
Cache restored successfully
Cache restored from key: Linux-golangci-lint-cache-2025-09
```

We can find the avg run time for the lint job in this [report](https://github.com/artefactual-sdps/enduro/actions/metrics/performance?tab=jobs&filters=workflow_file_name%3Alint.yml+job_name%3Agolangci-lint).  Comparing two runs before and after this change:

- Before: https://github.com/artefactual-sdps/enduro/actions/runs/17932587286 (duration: 3m6s)
- After: https://github.com/artefactual-sdps/enduro/actions/runs/17966962011 (duration: 2m0s)