### PR TITLE
Reconnect websockets when they close unexpectedly

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -64,6 +64,7 @@
         "vite": "^6.3.6",
         "vite-plugin-vue-devtools": "^7.7.6",
         "vitest": "^3.2.3",
+        "vitest-websocket-mock": "^0.5.0",
         "vue-tsc": "^2.2.10"
       }
     },
@@ -7662,6 +7663,16 @@
         "pathe": "^2.0.1"
       }
     },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/moment": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -10250,6 +10261,20 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest-websocket-mock": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/vitest-websocket-mock/-/vitest-websocket-mock-0.5.0.tgz",
+      "integrity": "sha512-vzBWeuF/kD/OCOFzB7WAclb7PxfI105qPkZtdOkPMwZdilBskQjJL4l319JtPtmeovDU7ZVhO3hTfGPjM4txQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "^3.0.0",
+        "mock-socket": "^9.2.1"
+      },
+      "peerDependencies": {
+        "vitest": ">=3"
       }
     },
     "node_modules/vitest/node_modules/pathe": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -73,6 +73,7 @@
     "vite": "^6.3.6",
     "vite-plugin-vue-devtools": "^7.7.6",
     "vitest": "^3.2.3",
+    "vitest-websocket-mock": "^0.5.0",
     "vue-tsc": "^2.2.10"
   }
 }

--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -2,13 +2,17 @@
 import { watch } from "vue";
 import { DialogWrapper } from "vue3-promise-dialog";
 
-import { client } from "@/client";
 import Header from "@/components/Header.vue";
 import Sidebar from "@/components/Sidebar.vue";
 import { useAuthStore } from "@/stores/auth";
+import { useIngestMonitorStore } from "@/stores/ingestMonitor";
+import { useStorageMonitorStore } from "@/stores/storageMonitor";
 
 const authStore = useAuthStore();
 authStore.loadConfig();
+
+const ingestMonitor = useIngestMonitorStore();
+const storageMonitor = useStorageMonitorStore();
 
 // Connect to the monitor APIs when the user is loaded
 // successfully or if authentication is disabled.
@@ -16,12 +20,8 @@ watch(
   () => authStore.isUserValid,
   (valid) => {
     if (valid) {
-      client.ingest.ingestMonitorRequest().then(() => {
-        client.connectIngestMonitor();
-      });
-      client.storage.storageMonitorRequest().then(() => {
-        client.connectStorageMonitor();
-      });
+      ingestMonitor.connect();
+      storageMonitor.connect();
     }
   },
   { immediate: true },

--- a/dashboard/src/__tests__/monitor.test.ts
+++ b/dashboard/src/__tests__/monitor.test.ts
@@ -1,0 +1,301 @@
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WS from "vitest-websocket-mock";
+
+import { client } from "@/client";
+import { IngestMonitorConnection, StorageMonitorConnection } from "@/monitor";
+
+vi.mock("@/client", async () => {
+  const api = await vi.importActual("@/openapi-generator");
+  return {
+    client: {
+      ingest: {
+        ingestMonitorRequest: vi.fn(() => Promise.resolve()),
+      },
+      storage: {
+        storageMonitorRequest: vi.fn(() => Promise.resolve()),
+      },
+    },
+    api: { ...api },
+  };
+});
+
+vi.mock("@/monitor-ingest", () => ({
+  handleIngestEvent: vi.fn(),
+}));
+
+vi.mock("@/monitor-storage", () => ({
+  handleStorageEvent: vi.fn(),
+}));
+
+// Mock timers.
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("MonitorConnection", () => {
+  describe("getWebSocketURL", () => {
+    it("converts http to ws", () => {
+      const connection = new IngestMonitorConnection("http://example.com");
+      expect(connection.getWebSocketURL("http://example.com/path")).toBe(
+        "ws://example.com/path",
+      );
+    });
+
+    it("converts https to wss", () => {
+      const connection = new IngestMonitorConnection("https://example.com");
+      expect(connection.getWebSocketURL("https://example.com/path")).toBe(
+        "wss://example.com/path",
+      );
+    });
+  });
+
+  describe("isConnected", () => {
+    it("returns false when socket is null", () => {
+      const connection = new IngestMonitorConnection("http://example.com");
+      expect(connection.isConnected).toBe(false);
+    });
+
+    it("returns true when socket is in OPEN state", async () => {
+      const server = new WS("ws://localhost:1234/ingest/monitor");
+      const conn = new IngestMonitorConnection("http://localhost:1234");
+
+      conn.dial();
+      await vi.runAllTimersAsync();
+
+      expect(client.ingest.ingestMonitorRequest).toHaveBeenCalledTimes(1);
+      expect(conn.isConnected).toBe(true);
+
+      conn.close();
+      server.close();
+    });
+  });
+
+  describe("retryBackoff", () => {
+    it("retries with exponential backoff until success", async () => {
+      const connection = new IngestMonitorConnection("http://example.com", {
+        initialDelay: 100,
+        maxDelay: 500,
+        backoff: 2,
+        maxAttempts: 3,
+        jitterFn: () => 0,
+      });
+
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Failed once"))
+        .mockRejectedValueOnce(new Error("Failed twice"))
+        .mockResolvedValueOnce(undefined);
+
+      connection.retryBackoff(fn);
+      await vi.runAllTimersAsync();
+      expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    it("throws after max attempts", async () => {
+      const connection = new IngestMonitorConnection("http://example.com", {
+        initialDelay: 100,
+        maxDelay: 500,
+        backoff: 2,
+        maxAttempts: 2,
+        jitterFn: () => 0,
+      });
+      const fn = vi.fn().mockRejectedValue(new Error("Always fails"));
+
+      expect(() => connection.retryBackoff(fn)).rejects.toThrow(
+        "Max attempts reached",
+      );
+      await vi.runAllTimersAsync();
+
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe("IngestMonitorConnection", () => {
+  it("connects to WebSocket and receives event", async () => {
+    const server = new WS("ws://localhost:1234/ingest/monitor");
+    const conn = new IngestMonitorConnection("http://localhost:1234");
+
+    conn.dial();
+    await vi.runAllTimersAsync();
+
+    expect(client.ingest.ingestMonitorRequest).toHaveBeenCalledTimes(1);
+    expect(conn.socket).toBeDefined();
+    expect(conn.socket!.readyState).toBe(WebSocket.OPEN);
+
+    server.send(
+      JSON.stringify({
+        ingest_value: {
+          Type: "ingest_ping_event",
+          Value: "Ping",
+        },
+      }),
+    );
+    await vi.runAllTimersAsync();
+
+    conn.close();
+    server.close();
+
+    expect(conn.socket).toBeNull();
+  });
+
+  it("reconnects after the WebSocket is closed", async () => {
+    let server = new WS("ws://localhost:1234/ingest/monitor");
+    const conn = new IngestMonitorConnection("http://localhost:1234", {
+      initialDelay: 100,
+      maxDelay: 500,
+      backoff: 2,
+      maxAttempts: 5,
+      jitterFn: () => 0,
+    });
+    conn.dial();
+    await vi.runAllTimersAsync();
+
+    expect(client.ingest.ingestMonitorRequest).toHaveBeenCalledTimes(1);
+    expect(conn.socket).toBeDefined();
+    expect(conn.socket!.readyState).toBe(WebSocket.OPEN);
+
+    // Close the server to trigger reconnect.
+    server.close();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(conn.socket).toBeDefined();
+    expect(conn.socket!.readyState).toBe(WebSocket.CONNECTING);
+
+    server = new WS("ws://localhost:1234/ingest/monitor");
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(conn.socket).toBeDefined();
+    expect(conn.socket!.readyState).toBe(WebSocket.OPEN);
+
+    conn.close();
+    server.close();
+  });
+
+  it("logs an error when ingest monitor request fails", async () => {
+    client.ingest.ingestMonitorRequest = vi.fn(() =>
+      Promise.reject(new Error("401 Unauthorized")),
+    );
+    const consoleMock = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const server = new WS("ws://localhost:1234/ingest/monitor");
+    const conn = new IngestMonitorConnection("http://localhost:1234", {
+      initialDelay: 100,
+      maxDelay: 500,
+      backoff: 2,
+      maxAttempts: 1,
+      jitterFn: () => 0,
+    });
+    expect(conn.dial()).rejects.toThrow("Max attempts reached");
+    await vi.runAllTimersAsync();
+
+    expect(consoleMock).toHaveBeenCalledTimes(1);
+    expect(consoleMock).toHaveBeenCalledWith(
+      "Ingest monitor request failed:",
+      new Error("401 Unauthorized"),
+    );
+
+    server.close();
+
+    // Restore the mock for other tests.
+    client.ingest.ingestMonitorRequest = vi.fn(() => Promise.resolve());
+  });
+});
+
+describe("StorageMonitorConnection", () => {
+  it("connects to WebSocket and receives event", async () => {
+    const server = new WS("ws://localhost:1234/storage/monitor");
+    const conn = new StorageMonitorConnection("http://localhost:1234");
+    conn.dial();
+    await vi.runAllTimersAsync();
+
+    expect(client.storage.storageMonitorRequest).toHaveBeenCalledTimes(1);
+    expect(conn.socket).toBeDefined();
+    expect(conn.socket!.readyState).toBe(WebSocket.OPEN);
+
+    server.send(
+      JSON.stringify({
+        storage_value: {
+          Type: "storage_ping_event",
+          Value: "Ping",
+        },
+      }),
+    );
+    await vi.runAllTimersAsync();
+
+    conn.close();
+    server.close();
+
+    expect(conn.socket).toBeNull();
+  });
+
+  it("reconnects after the WebSocket is closed", async () => {
+    let server = new WS("ws://localhost:1234/storage/monitor");
+    const conn = new StorageMonitorConnection("http://localhost:1234", {
+      initialDelay: 100,
+      maxDelay: 500,
+      backoff: 2,
+      maxAttempts: 5,
+      jitterFn: () => 0,
+    });
+    conn.dial();
+    await vi.runAllTimersAsync();
+
+    expect(conn.socket).toBeDefined();
+    expect(conn.socket!.readyState).toBe(WebSocket.OPEN);
+
+    // Close the server to trigger reconnect.
+    server.close();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(conn.socket).toBeDefined();
+    expect(conn.socket!.readyState).toBe(WebSocket.CONNECTING);
+
+    server = new WS("ws://localhost:1234/storage/monitor");
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(conn.socket).toBeDefined();
+    expect(conn.socket!.readyState).toBe(WebSocket.OPEN);
+
+    conn.close();
+    server.close();
+  });
+
+  it("logs an error when storage monitor request fails", async () => {
+    client.storage.storageMonitorRequest = vi.fn(() =>
+      Promise.reject(new Error("401 Unauthorized")),
+    );
+    const consoleMock = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const server = new WS("ws://localhost:1234/storage/monitor");
+    const conn = new StorageMonitorConnection("http://localhost:1234", {
+      initialDelay: 100,
+      maxDelay: 500,
+      backoff: 2,
+      maxAttempts: 1,
+      jitterFn: () => 0,
+    });
+    expect(conn.dial()).rejects.toThrow("Max attempts reached");
+    await vi.runAllTimersAsync();
+
+    expect(consoleMock).toHaveBeenCalledTimes(1);
+    expect(consoleMock).toHaveBeenCalledWith(
+      "Storage monitor request failed:",
+      new Error("401 Unauthorized"),
+    );
+
+    server.close();
+
+    // Restore the mock for other tests.
+    client.storage.storageMonitorRequest = vi.fn(() => Promise.resolve());
+  });
+});

--- a/dashboard/src/client.ts
+++ b/dashboard/src/client.ts
@@ -1,5 +1,3 @@
-import { handleIngestEvent } from "./monitor-ingest";
-import { handleStorageEvent } from "./monitor-storage";
 import * as api from "./openapi-generator";
 import * as runtime from "./openapi-generator/runtime";
 
@@ -10,8 +8,6 @@ export interface Client {
   about: api.AboutApi;
   ingest: api.IngestApi;
   storage: api.StorageApi;
-  connectIngestMonitor: () => void;
-  connectStorageMonitor: () => void;
 }
 
 function getPath(): string {
@@ -24,42 +20,6 @@ function getPath(): string {
     "/api";
 
   return path.replace(/\/$/, "");
-}
-
-function getWebSocketURL(): string {
-  let url = getPath();
-
-  if (url.startsWith("https")) {
-    url = "wss" + url.slice("https".length);
-  } else if (url.startsWith("http")) {
-    url = "ws" + url.slice("http".length);
-  }
-
-  return url;
-}
-
-function connectIngestMonitor() {
-  const url = getWebSocketURL() + "/ingest/monitor";
-  const socket = new WebSocket(url);
-  socket.onmessage = (event: MessageEvent) => {
-    const body = JSON.parse(event.data);
-    const data = api.IngestEventFromJSON(body);
-    if (data.ingestValue) {
-      handleIngestEvent(data.ingestValue);
-    }
-  };
-}
-
-function connectStorageMonitor() {
-  const url = getWebSocketURL() + "/storage/monitor";
-  const socket = new WebSocket(url);
-  socket.onmessage = (event: MessageEvent) => {
-    const body = JSON.parse(event.data);
-    const data = api.StorageEventFromJSON(body);
-    if (data.storageValue) {
-      handleStorageEvent(data.storageValue);
-    }
-  };
 }
 
 function createClient(): Client {
@@ -84,8 +44,6 @@ function createClient(): Client {
     about: new api.AboutApi(config),
     ingest: new api.IngestApi(config),
     storage: new api.StorageApi(config),
-    connectIngestMonitor: connectIngestMonitor,
-    connectStorageMonitor: connectStorageMonitor,
   };
 }
 

--- a/dashboard/src/monitor.ts
+++ b/dashboard/src/monitor.ts
@@ -1,0 +1,186 @@
+import { api, client } from "@/client";
+import { handleIngestEvent } from "@/monitor-ingest";
+import { handleStorageEvent } from "@/monitor-storage";
+
+export type RetryOptions = {
+  initialDelay: number;
+  maxDelay: number;
+  backoff: number;
+  maxAttempts: number;
+  jitterFn: () => number;
+};
+
+abstract class MonitorConnection {
+  type: "ingest" | "storage";
+  url: string;
+  socket: WebSocket | null = null;
+  isConnected: boolean = false;
+  retry: RetryOptions;
+
+  constructor(
+    type: "ingest" | "storage",
+    baseUrl: string,
+    retry?: RetryOptions,
+  ) {
+    this.type = type;
+    this.url = this.getWebSocketURL(baseUrl + "/" + this.type + "/monitor");
+    this.retry = retry || {
+      initialDelay: 1000, // 1 second.
+      maxDelay: 30000, // 30 seconds.
+      backoff: 2,
+      maxAttempts: 10,
+      jitterFn: () => Math.random() * 500, // add up to 500ms of jitter.
+    };
+  }
+
+  abstract dial(): Promise<void>;
+
+  getWebSocketURL(url: string): string {
+    if (url.startsWith("https")) {
+      url = "wss" + url.slice("https".length);
+    } else if (url.startsWith("http")) {
+      url = "ws" + url.slice("http".length);
+    }
+
+    return url;
+  }
+
+  async retryBackoff(fn: () => Promise<void>) {
+    for (let attempt = 0; attempt < this.retry.maxAttempts; attempt++) {
+      try {
+        await fn();
+        return;
+      } catch {
+        if (attempt === this.retry.maxAttempts - 1) {
+          throw new Error("Max attempts reached");
+        }
+
+        // Exponential backoff with jitter.
+        const delay =
+          Math.min(
+            this.retry.initialDelay * this.retry.backoff ** attempt,
+            this.retry.maxDelay,
+          ) + this.retry.jitterFn();
+        console.log(
+          `${this.type} monitor: reconnect attempt ${attempt + 1} in ${Math.round(delay)} ms...`,
+        );
+        await new Promise((r) => {
+          setTimeout(r, delay);
+        });
+      }
+    }
+  }
+
+  close(): void {
+    if (this.socket) {
+      this.socket.onclose = null; // Disable reconnect on close.
+      this.socket.close();
+      this.socket = null;
+    }
+  }
+
+  setupEventHandlers(): void {
+    if (this.socket === null) {
+      return;
+    }
+
+    this.socket.onopen = () => {
+      this.isConnected = true;
+      console.log(`${this.type} monitor socket connected`);
+    };
+    this.socket.onerror = () => {
+      console.error(`${this.type} monitor socket error`);
+    };
+    this.socket.onclose = () => {
+      this.isConnected = false;
+      console.error(`${this.type} monitor socket closed, reconnecting...`);
+      this.dial();
+    };
+  }
+}
+
+export class IngestMonitorConnection extends MonitorConnection {
+  constructor(baseUrl: string, retry?: RetryOptions) {
+    super("ingest", baseUrl, retry);
+  }
+
+  async dial(): Promise<void> {
+    return this.retryBackoff(async () => {
+      return client.ingest
+        .ingestMonitorRequest()
+        .then(() => {
+          try {
+            this.socket = new WebSocket(this.url);
+            this.setupEventHandlers();
+          } catch (err) {
+            console.error("Failed to create Web Socket:", err);
+            this.dial(); // Retry on failure.
+          }
+        })
+        .catch((err) => {
+          console.error("Ingest monitor request failed:", err);
+          throw err;
+        });
+    });
+  }
+
+  setupEventHandlers(): void {
+    if (this.socket === null) {
+      return;
+    }
+
+    super.setupEventHandlers();
+
+    // Handle incoming messages.
+    this.socket.onmessage = (ev: MessageEvent) => {
+      const body = JSON.parse(ev.data);
+      const data = api.IngestEventFromJSON(body);
+      if (data.ingestValue) {
+        handleIngestEvent(data.ingestValue);
+      }
+    };
+  }
+}
+
+export class StorageMonitorConnection extends MonitorConnection {
+  constructor(baseUrl: string, retry?: RetryOptions) {
+    super("storage", baseUrl, retry);
+  }
+
+  async dial(): Promise<void> {
+    return this.retryBackoff(async () => {
+      return client.storage
+        .storageMonitorRequest()
+        .then(() => {
+          try {
+            this.socket = new WebSocket(this.url);
+            this.setupEventHandlers();
+          } catch (err) {
+            console.error("Failed to create Web Socket:", err);
+            this.dial(); // Retry on failure.
+          }
+        })
+        .catch((err) => {
+          console.error("Storage monitor request failed:", err);
+          throw err;
+        });
+    });
+  }
+
+  setupEventHandlers(): void {
+    if (this.socket === null) {
+      return;
+    }
+
+    super.setupEventHandlers();
+
+    // Handle incoming messages.
+    this.socket.onmessage = (ev: MessageEvent) => {
+      const body = JSON.parse(ev.data);
+      const data = api.StorageEventFromJSON(body);
+      if (data.storageValue) {
+        handleStorageEvent(data.storageValue);
+      }
+    };
+  }
+}

--- a/dashboard/src/stores/__tests__/ingestMonitor.test.ts
+++ b/dashboard/src/stores/__tests__/ingestMonitor.test.ts
@@ -1,0 +1,45 @@
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WS from "vitest-websocket-mock";
+
+import { useIngestMonitorStore } from "@/stores/ingestMonitor";
+
+vi.mock("@/client", async () => {
+  return {
+    client: {
+      ingest: {
+        ingestMonitorRequest: vi.fn(() => Promise.resolve()),
+      },
+    },
+    getPath: () => "http://localhost:1234",
+  };
+});
+
+describe("useIngestMonitorStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("connects the monitor", async () => {
+    const server = new WS("ws://localhost:1234/ingest/monitor");
+    const store = useIngestMonitorStore();
+
+    store.connect();
+    await vi.runAllTimersAsync();
+
+    expect(store.conn.isConnected).toBe(true);
+
+    store.connect(); // second call, should be no-op
+    await vi.runAllTimersAsync();
+
+    expect(store.conn.isConnected).toBe(true);
+
+    store.conn.close();
+    server.close();
+  });
+});

--- a/dashboard/src/stores/__tests__/storageMonitor.test.ts
+++ b/dashboard/src/stores/__tests__/storageMonitor.test.ts
@@ -1,0 +1,45 @@
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WS from "vitest-websocket-mock";
+
+import { useStorageMonitorStore } from "@/stores/storageMonitor";
+
+vi.mock("@/client", async () => {
+  return {
+    client: {
+      storage: {
+        storageMonitorRequest: vi.fn(() => Promise.resolve()),
+      },
+    },
+    getPath: () => "http://localhost:1234",
+  };
+});
+
+describe("useStorageMonitorStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("connects the monitor", async () => {
+    const server = new WS("ws://localhost:1234/storage/monitor");
+    const store = useStorageMonitorStore();
+
+    store.connect();
+    await vi.runAllTimersAsync();
+
+    expect(store.conn.isConnected).toBe(true);
+
+    store.connect(); // second call, should be no-op
+    await vi.runAllTimersAsync();
+
+    expect(store.conn.isConnected).toBe(true);
+
+    store.conn.close();
+    server.close();
+  });
+});

--- a/dashboard/src/stores/ingestMonitor.ts
+++ b/dashboard/src/stores/ingestMonitor.ts
@@ -1,0 +1,22 @@
+import { acceptHMRUpdate, defineStore } from "pinia";
+
+import { getPath } from "@/client";
+import { IngestMonitorConnection } from "@/monitor";
+
+export const useIngestMonitorStore = defineStore("ingestMonitor", {
+  state: () => ({
+    conn: new IngestMonitorConnection(getPath()),
+  }),
+  actions: {
+    async connect() {
+      if (this.conn.isConnected) return;
+      return this.conn.dial();
+    },
+  },
+});
+
+if (import.meta.hot) {
+  import.meta.hot.accept(
+    acceptHMRUpdate(useIngestMonitorStore, import.meta.hot),
+  );
+}

--- a/dashboard/src/stores/storageMonitor.ts
+++ b/dashboard/src/stores/storageMonitor.ts
@@ -1,0 +1,22 @@
+import { acceptHMRUpdate, defineStore } from "pinia";
+
+import { getPath } from "@/client";
+import { StorageMonitorConnection } from "@/monitor";
+
+export const useStorageMonitorStore = defineStore("storageMonitor", {
+  state: () => ({
+    conn: new StorageMonitorConnection(getPath()),
+  }),
+  actions: {
+    async connect() {
+      if (this.conn.isConnected) return Promise.resolve();
+      return this.conn.dial();
+    },
+  },
+});
+
+if (import.meta.hot) {
+  import.meta.hot.accept(
+    acceptHMRUpdate(useStorageMonitorStore, import.meta.hot),
+  );
+}


### PR DESCRIPTION
Fixes #1057.

Attempt to reconnect the ingest and storage monitor websockets when the connection is unexpected closed at the server end (e.g. on server restart). My tests so far indicate that this change fixes the problem I've been having with the Dashboard hanging intermittently and throwing Vite "write EPIPE" errors.