### PR TITLE
Refactor processing workflow tests

### DIFF
--- a/internal/workflow/processing_expectations_test.go
+++ b/internal/workflow/processing_expectations_test.go
@@ -1,0 +1,479 @@
+package workflow
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/artefactual-sdps/temporal-activities/archiveextract"
+	"github.com/artefactual-sdps/temporal-activities/archivezip"
+	"github.com/artefactual-sdps/temporal-activities/bagcreate"
+	"github.com/artefactual-sdps/temporal-activities/bagvalidate"
+	"github.com/artefactual-sdps/temporal-activities/bucketupload"
+	"github.com/artefactual-sdps/temporal-activities/removepaths"
+	"github.com/artefactual-sdps/temporal-activities/xmlvalidate"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"go.artefactual.dev/tools/ref"
+
+	"github.com/artefactual-sdps/enduro/internal/a3m"
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
+	"github.com/artefactual-sdps/enduro/internal/enums"
+	"github.com/artefactual-sdps/enduro/internal/workflow/activities"
+)
+
+const (
+	tempPath         = "/tmp/enduro123456"
+	extractPath      = "/tmp/enduro123456/extract"
+	transferPath     = "/home/a3m/.local/share/a3m/share/enduro2985726865"
+	prepSharedPath   = "/home/enduro/preprocessing/"
+	prepDownloadPath = "/home/enduro/preprocessing/enduro123456"
+	prepExtractPath  = "/home/enduro/preprocessing/enduro123456/extract"
+	failedSIPKey     = "Failed_SIP_name-e2ace0da-8697-453d-9ea1-4c9b62309e54.zip"
+	failedPIPKey     = "Failed_PIP_name-e2ace0da-8697-453d-9ea1-4c9b62309e54.zip"
+	sipID            = 1
+	workflowID       = 1
+	copySIPTaskID    = 100
+	valBagTaskID     = 101
+	valPREMISTaskID  = 102
+	uploadTaskID     = 103
+	reviewAIPTaskID  = 104
+	moveAIPTaskID    = 105
+	sipName          = "name.zip"
+	key              = "transfer.zip"
+	watcherName      = "watcher"
+)
+
+var (
+	ctx             = mock.AnythingOfType("*context.valueCtx")
+	sessionCtx      = mock.AnythingOfType("*context.timerCtx")
+	internalCtx     = mock.AnythingOfType("*internal.valueCtx")
+	sipUUID         = uuid.MustParse("e2ace0da-8697-453d-9ea1-4c9b62309e54")
+	locationID      = uuid.MustParse("f2cc963f-c14d-4eaa-b950-bd207189a1f1")
+	amssLocationID  = uuid.MustParse("e0ed8b2a-8ae2-4546-b5d8-f0090919df04")
+	transferID      = uuid.MustParse("65233405-771e-4f7e-b2d9-b08439570ba2")
+	aipUUID         = uuid.MustParse("9e8161cc-2815-4d6f-8a75-f003c41b257b")
+	workflowUUID    = uuid.MustParse("8fdfaea1-06ed-4cf6-8bdf-d15d80420f35")
+	startTime       = time.Date(2024, 7, 9, 16, 55, 13, 50, time.UTC)
+	retentionPeriod = ref.New(time.Second)
+)
+
+// expectationParams holds configurable parameters for setting up activity expectations.
+type expectationParams struct {
+	// SIP type used for classification.
+	sipType enums.SIPType
+
+	// SIP status for status updates.
+	sipStatus enums.SIPStatus
+
+	// Workflow type for workflow creation.
+	workflowType enums.WorkflowType
+
+	// Workflow status for workflow status updates.
+	workflowStatus enums.WorkflowStatus
+
+	// Task identifier for task operations.
+	taskID int
+
+	// Task name for task operations.
+	taskName string
+
+	// Task note for task operations.
+	taskNote string
+
+	// Task status for task operations.
+	taskStatus enums.TaskStatus
+
+	// Failure type for failed SIP updates.
+	failedAs enums.SIPFailedAs
+
+	// Failure key for failed updates and bucket uploads.
+	failedKey string
+
+	// Cleanup paths for removal operations.
+	removePaths []string
+
+	// Download path for download operations.
+	downloadPath string
+
+	// Download destination path for download operations.
+	downloadDestPath string
+
+	// Extract path for multiple file operations.
+	extractPath string
+
+	// Failed path for failed uploads.
+	failedPath string
+
+	// PREMIS XML file path for validation.
+	premisXMLPath string
+}
+
+// defaultParams returns a new expectationParams instance with sensible defaults.
+// All fields that have meaningful defaults are set. Fields that must be provided
+// on each expectation (like taskID, taskName, etc.) are left as zero values.
+func defaultParams() expectationParams {
+	return expectationParams{
+		sipType:        enums.SIPTypeUnknown,
+		workflowType:   enums.WorkflowTypeCreateAip,
+		workflowStatus: enums.WorkflowStatusPending,
+		removePaths:    []string{tempPath, transferPath},
+		extractPath:    extractPath,
+		downloadPath:   tempPath + "/" + key,
+		failedPath:     tempPath + "/" + key,
+		premisXMLPath:  filepath.Join(transferPath, "metadata", "premis.xml"),
+	}
+}
+
+// updateTaskParams updates task related fields in expectationParams.
+func (p *expectationParams) updateTaskParams(id int, status enums.TaskStatus, name, note string) {
+	p.taskID = id
+	p.taskStatus = status
+	p.taskName = name
+	p.taskNote = note
+}
+
+// expectationFunc represents a function that sets up activity expectations for testing.
+// Functions configure mock activities using s.env.OnActivity() calls with the provided
+// test suite and parameters.
+type expectationFunc func(s *ProcessingWorkflowTestSuite, params expectationParams)
+
+// expectations is a map of activity names to their expectation functions.
+// Each key represents a logical activity name that corresponds to a Temporal activity.
+var expectations = map[string]expectationFunc{
+	"createSIP": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			createSIPLocalActivity,
+			ctx,
+			s.workflow.ingestsvc,
+			&createSIPLocalActivityParams{
+				UUID:   sipUUID,
+				Name:   sipName,
+				Status: enums.SIPStatusQueued,
+			},
+		).Return(sipID, nil)
+	},
+	"setStatusInProgress": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			setStatusInProgressLocalActivity,
+			ctx,
+			s.workflow.ingestsvc,
+			sipUUID,
+			startTime,
+		).Return(&setStatusInProgressLocalActivityResult{}, nil)
+	},
+	"setStatus": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			setStatusLocalActivity,
+			ctx,
+			s.workflow.ingestsvc,
+			sipUUID,
+			params.sipStatus,
+		).Return(&setStatusLocalActivityResult{}, nil)
+	},
+	"createWorkflow": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			createWorkflowLocalActivity,
+			ctx,
+			s.workflow.ingestsvc,
+			&createWorkflowLocalActivityParams{
+				RNG:        s.workflow.rng,
+				TemporalID: "default-test-workflow-id",
+				Type:       params.workflowType,
+				Status:     enums.WorkflowStatusInProgress,
+				StartedAt:  startTime,
+				SIPUUID:    sipUUID,
+			},
+		).Return(&createWorkflowLocalActivityResult{ID: workflowID, UUID: workflowUUID}, nil)
+	},
+	"setWorkflowStatus": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			setWorkflowStatusLocalActivity,
+			ctx,
+			s.workflow.ingestsvc,
+			workflowID,
+			params.workflowStatus,
+		).Return(nil, nil)
+	},
+	"completeWorkflow": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			completeWorkflowLocalActivity,
+			ctx,
+			s.workflow.ingestsvc,
+			mock.AnythingOfType("*workflow.completeWorkflowLocalActivityParams"),
+		).Return(nil, nil)
+	},
+	"createTask": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			createTaskLocalActivity,
+			ctx,
+			&createTaskLocalActivityParams{
+				Ingestsvc: s.workflow.ingestsvc,
+				RNG:       s.workflow.rng,
+				Task: &datatypes.Task{
+					Name:         params.taskName,
+					Status:       params.taskStatus,
+					WorkflowUUID: workflowUUID,
+					Note:         params.taskNote,
+				},
+			},
+		).Return(params.taskID, nil)
+	},
+	"completeTask": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		var taskNote *string
+		if params.taskNote != "" {
+			taskNote = &params.taskNote
+		}
+		s.env.OnActivity(
+			completeTaskLocalActivity,
+			ctx,
+			s.workflow.ingestsvc,
+			&completeTaskLocalActivityParams{
+				ID:          params.taskID,
+				Status:      params.taskStatus,
+				CompletedAt: startTime,
+				Note:        taskNote,
+			},
+		).Return(&completeTaskLocalActivityResult{}, nil)
+	},
+	"download": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			activities.DownloadActivityName,
+			sessionCtx,
+			&activities.DownloadActivityParams{
+				Key:             key,
+				WatcherName:     watcherName,
+				DestinationPath: params.downloadDestPath,
+			},
+		).Return(&activities.DownloadActivityResult{Path: params.downloadPath}, nil)
+	},
+	"getSIPExtension": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			activities.GetSIPExtensionActivityName,
+			sessionCtx,
+			&activities.GetSIPExtensionActivityParams{Path: params.downloadPath},
+		).Return(&activities.GetSIPExtensionActivityResult{Extension: ".zip"}, nil)
+	},
+	"archiveExtract": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			archiveextract.Name,
+			sessionCtx,
+			&archiveextract.Params{SourcePath: params.downloadPath},
+		).Return(&archiveextract.Result{ExtractPath: params.extractPath}, nil)
+	},
+	"classifySIP": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			activities.ClassifySIPActivityName,
+			sessionCtx,
+			activities.ClassifySIPActivityParams{Path: params.extractPath},
+		).Return(&activities.ClassifySIPActivityResult{Type: params.sipType}, nil)
+	},
+	"updateSIPProcessing": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			updateSIPLocalActivity,
+			ctx,
+			s.workflow.ingestsvc,
+			&updateSIPLocalActivityParams{
+				UUID:    sipUUID,
+				Name:    sipName,
+				AIPUUID: aipUUID.String(),
+				Status:  enums.SIPStatusProcessing,
+			},
+		).Return(nil, nil)
+	},
+	"updateSIPIngested": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			updateSIPLocalActivity,
+			ctx,
+			s.workflow.ingestsvc,
+			mock.MatchedBy(func(updateParams *updateSIPLocalActivityParams) bool {
+				return updateParams.UUID == sipUUID &&
+					updateParams.Name == sipName &&
+					updateParams.AIPUUID == aipUUID.String() &&
+					updateParams.Status == enums.SIPStatusIngested &&
+					updateParams.FailedAs == "" &&
+					updateParams.FailedKey == "" &&
+					!updateParams.CompletedAt.IsZero()
+			}),
+		).Return(nil, nil)
+	},
+	"updateSIPFailed": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			updateSIPLocalActivity,
+			ctx,
+			s.workflow.ingestsvc,
+			mock.MatchedBy(func(updateParams *updateSIPLocalActivityParams) bool {
+				return updateParams.UUID == sipUUID &&
+					updateParams.Name == sipName &&
+					updateParams.AIPUUID == "" &&
+					updateParams.Status == params.sipStatus &&
+					updateParams.FailedAs == params.failedAs &&
+					updateParams.FailedKey == params.failedKey &&
+					!updateParams.CompletedAt.IsZero()
+			}),
+		).Return(nil, nil)
+	},
+	"removePaths": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			removepaths.Name,
+			sessionCtx,
+			&removepaths.Params{Paths: params.removePaths},
+		).Return(&removepaths.Result{}, nil)
+	},
+	"deleteOriginal": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			activities.DeleteOriginalActivityName,
+			sessionCtx,
+			watcherName,
+			key,
+		).Return(nil, nil)
+	},
+	"validateBag": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			bagvalidate.Name,
+			sessionCtx,
+			&bagvalidate.Params{Path: params.extractPath},
+		).Return(&bagvalidate.Result{Valid: true}, nil)
+	},
+	"validatePREMIS": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			xmlvalidate.Name,
+			sessionCtx,
+			&xmlvalidate.Params{
+				XMLPath: params.premisXMLPath,
+				XSDPath: "/home/enduro/premis.xsd",
+			},
+		).Return(&xmlvalidate.Result{Failures: []string{}}, nil)
+	},
+	"createBag": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			bagcreate.Name,
+			sessionCtx,
+			&bagcreate.Params{SourcePath: params.extractPath},
+		).Return(&bagcreate.Result{BagPath: params.extractPath}, nil)
+	},
+	"zipArchive": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			archivezip.Name,
+			sessionCtx,
+			&archivezip.Params{SourceDir: params.extractPath},
+		).Return(&archivezip.Result{Path: params.extractPath + "/" + key}, nil)
+	},
+	"uploadToFailed": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			bucketupload.Name,
+			sessionCtx,
+			&bucketupload.Params{
+				Path:       params.failedPath,
+				Key:        params.failedKey,
+				BufferSize: 100_000_000,
+			},
+		).Return(&bucketupload.Result{}, nil)
+	},
+	"bundle": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			activities.BundleActivityName,
+			sessionCtx,
+			&activities.BundleActivityParams{
+				SourcePath:  params.extractPath,
+				TransferDir: s.transferDir,
+				IsDir:       true,
+			},
+		).Return(&activities.BundleActivityResult{FullPath: transferPath}, nil)
+	},
+	"createAIP": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			a3m.CreateAIPActivityName,
+			sessionCtx,
+			&a3m.CreateAIPActivityParams{
+				Name:         sipName,
+				Path:         transferPath,
+				WorkflowUUID: workflowUUID,
+			},
+		).Return(&a3m.CreateAIPActivityResult{UUID: aipUUID.String()}, nil)
+	},
+	"uploadAIP": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			activities.UploadActivityName,
+			sessionCtx,
+			&activities.UploadActivityParams{
+				Name:  sipName,
+				AIPID: aipUUID.String(),
+			},
+		).Return(nil, nil)
+	},
+	"moveAIP": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			activities.MoveToPermanentStorageActivityName,
+			sessionCtx,
+			&activities.MoveToPermanentStorageActivityParams{
+				AIPID:      aipUUID.String(),
+				LocationID: locationID,
+			},
+		).Return(nil, nil)
+	},
+	"pollMoveAIP": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			activities.PollMoveToPermanentStorageActivityName,
+			sessionCtx,
+			&activities.PollMoveToPermanentStorageActivityParams{AIPID: aipUUID.String()},
+		).Return(nil, nil)
+	},
+}
+
+func downloadExpectations(s *ProcessingWorkflowTestSuite, params expectationParams) {
+	expectations["createSIP"](s, params)
+	expectations["setStatusInProgress"](s, params)
+	expectations["createWorkflow"](s, params)
+	params.updateTaskParams(copySIPTaskID, enums.TaskStatusInProgress, "Copy SIP to workspace", "")
+	expectations["createTask"](s, params)
+	expectations["download"](s, params)
+	params.updateTaskParams(copySIPTaskID, enums.TaskStatusDone, "", "SIP successfully copied")
+	expectations["completeTask"](s, params)
+	expectations["getSIPExtension"](s, params)
+}
+
+func reviewA3mExpectations(s *ProcessingWorkflowTestSuite, params expectationParams) {
+	expectations["bundle"](s, params)
+	expectations["createAIP"](s, params)
+	expectations["updateSIPProcessing"](s, params)
+	params.updateTaskParams(uploadTaskID, enums.TaskStatusInProgress, "Move AIP", "Moving to review bucket")
+	expectations["createTask"](s, params)
+	expectations["uploadAIP"](s, params)
+	params.updateTaskParams(uploadTaskID, enums.TaskStatusDone, "", "Moved to review bucket")
+	expectations["completeTask"](s, params)
+	params.sipStatus = enums.SIPStatusPending
+	expectations["setStatus"](s, params)
+	params.workflowStatus = enums.WorkflowStatusPending
+	expectations["setWorkflowStatus"](s, params)
+	params.updateTaskParams(reviewAIPTaskID, enums.TaskStatusPending, "Review AIP", "Awaiting user decision")
+	expectations["createTask"](s, params)
+	params.sipStatus = enums.SIPStatusProcessing
+	expectations["setStatus"](s, params)
+	params.workflowStatus = enums.WorkflowStatusInProgress
+	expectations["setWorkflowStatus"](s, params)
+}
+
+func autoApproveA3mExpectations(s *ProcessingWorkflowTestSuite, params expectationParams) {
+	expectations["bundle"](s, params)
+	expectations["createAIP"](s, params)
+	expectations["updateSIPProcessing"](s, params)
+	expectations["uploadAIP"](s, params)
+	params.updateTaskParams(moveAIPTaskID, enums.TaskStatusInProgress, "Move AIP", "Moving to permanent storage")
+	expectations["createTask"](s, params)
+	expectations["moveAIP"](s, params)
+	expectations["pollMoveAIP"](s, params)
+	params.updateTaskParams(
+		moveAIPTaskID,
+		enums.TaskStatusDone,
+		"",
+		"Moved to location f2cc963f-c14d-4eaa-b950-bd207189a1f1",
+	)
+	expectations["completeTask"](s, params)
+}
+
+func cleanupExpectations(s *ProcessingWorkflowTestSuite, params expectationParams) {
+	expectations["removePaths"](s, params)
+	expectations["deleteOriginal"](s, params)
+	expectations["updateSIPIngested"](s, params)
+	expectations["completeWorkflow"](s, params)
+}

--- a/internal/workflow/processing_setup_test.go
+++ b/internal/workflow/processing_setup_test.go
@@ -1,0 +1,266 @@
+package workflow
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/artefactual-sdps/temporal-activities/archiveextract"
+	"github.com/artefactual-sdps/temporal-activities/archivezip"
+	"github.com/artefactual-sdps/temporal-activities/bagcreate"
+	"github.com/artefactual-sdps/temporal-activities/bagvalidate"
+	"github.com/artefactual-sdps/temporal-activities/bucketcopy"
+	"github.com/artefactual-sdps/temporal-activities/bucketdelete"
+	"github.com/artefactual-sdps/temporal-activities/bucketdownload"
+	"github.com/artefactual-sdps/temporal-activities/bucketupload"
+	"github.com/artefactual-sdps/temporal-activities/removepaths"
+	"github.com/artefactual-sdps/temporal-activities/xmlvalidate"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/suite"
+	"go.artefactual.dev/amclient/amclienttest"
+	"go.opentelemetry.io/otel/trace/noop"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	temporalsdk_worker "go.temporal.io/sdk/worker"
+	temporalsdk_workflow "go.temporal.io/sdk/workflow"
+	"go.uber.org/mock/gomock"
+	"gocloud.dev/blob/memblob"
+
+	"github.com/artefactual-sdps/enduro/internal/a3m"
+	a3mfake "github.com/artefactual-sdps/enduro/internal/a3m/fake"
+	"github.com/artefactual-sdps/enduro/internal/am"
+	"github.com/artefactual-sdps/enduro/internal/config"
+	"github.com/artefactual-sdps/enduro/internal/ingest"
+	ingest_fake "github.com/artefactual-sdps/enduro/internal/ingest/fake"
+	"github.com/artefactual-sdps/enduro/internal/poststorage"
+	"github.com/artefactual-sdps/enduro/internal/preprocessing"
+	sftp_fake "github.com/artefactual-sdps/enduro/internal/sftp/fake"
+	"github.com/artefactual-sdps/enduro/internal/temporal"
+	watcherfake "github.com/artefactual-sdps/enduro/internal/watcher/fake"
+	"github.com/artefactual-sdps/enduro/internal/workflow/activities"
+)
+
+type ProcessingWorkflowTestSuite struct {
+	suite.Suite
+	temporalsdk_testsuite.WorkflowTestSuite
+
+	env *temporalsdk_testsuite.TestWorkflowEnvironment
+
+	// Each test creates its own temporary transfer directory.
+	transferDir string
+
+	// Each test registers the workflow with a different name to avoid
+	// duplicates.
+	workflow *ProcessingWorkflow
+}
+
+func preprocessingChildWorkflow(
+	ctx temporalsdk_workflow.Context,
+	params *preprocessing.WorkflowParams,
+) (*preprocessing.WorkflowResult, error) {
+	return nil, nil
+}
+
+func poststorageChildWorkflow(
+	ctx temporalsdk_workflow.Context,
+	params *poststorage.WorkflowParams,
+) (*any, error) {
+	return nil, nil
+}
+
+func (s *ProcessingWorkflowTestSuite) CreateTransferDir() string {
+	s.transferDir = s.T().TempDir()
+
+	return s.transferDir
+}
+
+func (s *ProcessingWorkflowTestSuite) SetupWorkflowTest(cfg config.Configuration) {
+	s.env = s.NewTestWorkflowEnvironment()
+	s.env.SetWorkerOptions(temporalsdk_worker.Options{EnableSessionWorker: true})
+	s.env.SetStartTime(startTime)
+
+	ctrl := gomock.NewController(s.T())
+	ingestsvc := ingest_fake.NewMockService(ctrl)
+	wsvc := watcherfake.NewMockService(ctrl)
+	rng := rand.New(rand.NewSource(1)) // #nosec: G404
+
+	s.env.RegisterActivityWithOptions(
+		activities.NewDownloadActivity(noop.Tracer{}, wsvc).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.DownloadActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		bucketdownload.New(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.DownloadFromSIPSourceActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		bucketdownload.New(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.DownloadFromInternalBucketActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewGetSIPExtensionActivity().Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.GetSIPExtensionActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		archiveextract.New(cfg.ExtractActivity).Execute,
+		temporalsdk_activity.RegisterOptions{Name: archiveextract.Name},
+	)
+	s.env.RegisterActivityWithOptions(
+		xmlvalidate.New(xmlvalidate.NewXMLLintValidator()).Execute,
+		temporalsdk_activity.RegisterOptions{Name: xmlvalidate.Name},
+	)
+	s.env.RegisterActivityWithOptions(
+		bagvalidate.New(bagvalidate.NewNoopValidator()).Execute,
+		temporalsdk_activity.RegisterOptions{Name: bagvalidate.Name},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewClassifySIPActivity().Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.ClassifySIPActivityName},
+	)
+
+	// Set up AM taskqueue.
+	if cfg.Preservation.TaskQueue == temporal.AmWorkerTaskQueue {
+		s.setupAMWorkflowTest(&cfg.AM, ctrl, ingestsvc)
+	} else {
+		s.setupA3mWorkflowTest(ctrl, ingestsvc)
+	}
+
+	s.env.RegisterActivityWithOptions(
+		removepaths.New().Execute,
+		temporalsdk_activity.RegisterOptions{Name: removepaths.Name},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewDeleteOriginalActivity(wsvc).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		archivezip.New().Execute,
+		temporalsdk_activity.RegisterOptions{Name: archivezip.Name},
+	)
+	s.env.RegisterActivityWithOptions(
+		bucketcopy.New(memblob.OpenBucket(nil)).Execute,
+		temporalsdk_activity.RegisterOptions{Name: bucketcopy.Name},
+	)
+	s.env.RegisterActivityWithOptions(
+		bucketdelete.New(memblob.OpenBucket(nil)).Execute,
+		temporalsdk_activity.RegisterOptions{Name: bucketdelete.Name},
+	)
+	s.env.RegisterActivityWithOptions(
+		bucketupload.New(memblob.OpenBucket(nil)).Execute,
+		temporalsdk_activity.RegisterOptions{Name: bucketupload.Name},
+	)
+
+	s.env.RegisterWorkflowWithOptions(
+		preprocessingChildWorkflow,
+		temporalsdk_workflow.RegisterOptions{Name: "preprocessing"},
+	)
+	s.env.RegisterWorkflowWithOptions(
+		poststorageChildWorkflow,
+		temporalsdk_workflow.RegisterOptions{Name: "poststorage_1"},
+	)
+	s.env.RegisterWorkflowWithOptions(
+		poststorageChildWorkflow,
+		temporalsdk_workflow.RegisterOptions{Name: "poststorage_2"},
+	)
+
+	s.workflow = NewProcessingWorkflow(cfg, rng, ingestsvc, wsvc)
+}
+
+func (s *ProcessingWorkflowTestSuite) setupAMWorkflowTest(
+	cfg *am.Config,
+	ctrl *gomock.Controller,
+	ingestsvc ingest.Service,
+) {
+	clock := clockwork.NewFakeClock()
+	sftpc := sftp_fake.NewMockClient(ctrl)
+
+	s.env.RegisterActivityWithOptions(
+		bagcreate.New(bagcreate.Config{}).Execute,
+		temporalsdk_activity.RegisterOptions{Name: bagcreate.Name},
+	)
+	s.env.RegisterActivityWithOptions(
+		am.NewUploadTransferActivity(sftpc, 10*time.Second).Execute,
+		temporalsdk_activity.RegisterOptions{Name: am.UploadTransferActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		am.NewStartTransferActivity(&am.Config{}, amclienttest.NewMockPackageService(ctrl)).Execute,
+		temporalsdk_activity.RegisterOptions{Name: am.StartTransferActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		am.NewPollTransferActivity(
+			cfg,
+			clock,
+			amclienttest.NewMockTransferService(ctrl),
+			amclienttest.NewMockJobsService(ctrl),
+			ingestsvc,
+		).Execute,
+		temporalsdk_activity.RegisterOptions{Name: am.PollTransferActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		am.NewPollIngestActivity(
+			cfg,
+			clock,
+			amclienttest.NewMockIngestService(ctrl),
+			amclienttest.NewMockJobsService(ctrl),
+			ingestsvc,
+		).Execute,
+		temporalsdk_activity.RegisterOptions{Name: am.PollIngestActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewCreateStorageAIPActivity(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.CreateStorageAIPActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		am.NewDeleteTransferActivity(sftpc).Execute,
+		temporalsdk_activity.RegisterOptions{
+			Name: am.DeleteTransferActivityName,
+		},
+	)
+}
+
+func (s *ProcessingWorkflowTestSuite) setupA3mWorkflowTest(
+	ctrl *gomock.Controller,
+	ingestsvc ingest.Service,
+) {
+	tsvc := a3mfake.NewMockTransferServiceClient(ctrl)
+
+	s.env.RegisterActivityWithOptions(
+		activities.NewBundleActivity().Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.BundleActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		a3m.NewCreateAIPActivity(noop.Tracer{}, tsvc, &a3m.Config{}, ingestsvc).Execute,
+		temporalsdk_activity.RegisterOptions{Name: a3m.CreateAIPActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewUploadActivity(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.UploadActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewMoveToPermanentStorageActivity(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.MoveToPermanentStorageActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewPollMoveToPermanentStorageActivity(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.PollMoveToPermanentStorageActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewRejectSIPActivity(nil).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.RejectSIPActivityName},
+	)
+}
+
+func (s *ProcessingWorkflowTestSuite) AfterTest(suiteName, testName string) {
+	s.env.AssertExpectations(s.T())
+}
+
+func (s *ProcessingWorkflowTestSuite) ExecuteAndValidateWorkflow(
+	req *ingest.ProcessingWorkflowRequest,
+	shouldError bool,
+) {
+	s.env.ExecuteWorkflow(s.workflow.Execute, req)
+	s.True(s.env.IsWorkflowCompleted())
+	if shouldError {
+		s.Error(s.env.GetWorkflowResult(nil))
+	} else {
+		s.NoError(s.env.GetWorkflowResult(nil))
+	}
+}


### PR DESCRIPTION
Split large test file into three and introduce a reusable expectation system to reduce code duplication, improve reusability, and enable easier extension. The expectation functions provide parameterized mock setups for common workflow activities.

- Extract expectation functions for reusable activity mocks.
- Centralize test constants and variables in expectations file.
- Separate test setup logic into dedicated setup file.
- Add ExecuteAndValidateWorkflow helper.