### PR TITLE
Sort `ListSIPSourceObjects` API results by date

### DIFF
--- a/internal/sipsource/fake/mock_sipsource.go
+++ b/internal/sipsource/fake/mock_sipsource.go
@@ -81,18 +81,18 @@ func (c *MockSIPSourceCloseCall) DoAndReturn(f func() error) *MockSIPSourceClose
 }
 
 // ListObjects mocks base method.
-func (m *MockSIPSource) ListObjects(ctx context.Context, token []byte, limit int) (*sipsource.Page, error) {
+func (m *MockSIPSource) ListObjects(arg0 context.Context, arg1 sipsource.ListOptions) (*sipsource.Page, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListObjects", ctx, token, limit)
+	ret := m.ctrl.Call(m, "ListObjects", arg0, arg1)
 	ret0, _ := ret[0].(*sipsource.Page)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListObjects indicates an expected call of ListObjects.
-func (mr *MockSIPSourceMockRecorder) ListObjects(ctx, token, limit any) *MockSIPSourceListObjectsCall {
+func (mr *MockSIPSourceMockRecorder) ListObjects(arg0, arg1 any) *MockSIPSourceListObjectsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjects", reflect.TypeOf((*MockSIPSource)(nil).ListObjects), ctx, token, limit)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjects", reflect.TypeOf((*MockSIPSource)(nil).ListObjects), arg0, arg1)
 	return &MockSIPSourceListObjectsCall{Call: call}
 }
 
@@ -108,13 +108,13 @@ func (c *MockSIPSourceListObjectsCall) Return(arg0 *sipsource.Page, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSIPSourceListObjectsCall) Do(f func(context.Context, []byte, int) (*sipsource.Page, error)) *MockSIPSourceListObjectsCall {
+func (c *MockSIPSourceListObjectsCall) Do(f func(context.Context, sipsource.ListOptions) (*sipsource.Page, error)) *MockSIPSourceListObjectsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSIPSourceListObjectsCall) DoAndReturn(f func(context.Context, []byte, int) (*sipsource.Page, error)) *MockSIPSourceListObjectsCall {
+func (c *MockSIPSourceListObjectsCall) DoAndReturn(f func(context.Context, sipsource.ListOptions) (*sipsource.Page, error)) *MockSIPSourceListObjectsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/sipsource/sipsource.go
+++ b/internal/sipsource/sipsource.go
@@ -2,13 +2,22 @@ package sipsource
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"time"
+)
+
+const defaultLimit = 100
+
+var (
+	ErrInvalidSource = errors.New("invalid SIP source")
+	ErrInvalidToken  = errors.New("invalid token")
 )
 
 // SIPSource defines the interface for a SIP source location.
 type SIPSource interface {
 	// ListObjects returns a paged list of items in the SIP source.
-	ListObjects(ctx context.Context, token []byte, limit int) (*Page, error)
+	ListObjects(context.Context, ListOptions) (*Page, error)
 
 	// Close releases resources associated with the SIP source.
 	Close() error
@@ -18,17 +27,20 @@ type SIPSource interface {
 	RetentionPeriod() time.Duration
 }
 
-// Page is a paginated list of SIP source objects.
-type Page struct {
-	// Objects is the current page of SIP source objects.
-	Objects []*Object
+// ListOptions specifies options for listing SIP source objects.
+type ListOptions struct {
+	// Token is used to retrieve a specific page of objects. If Token is nil,
+	// the first page of objects will be returned.
+	Token []byte
 
-	// Limit is the maximum number of objects returned per page.
+	// Limit is the maximum number of objects to return. If Limit is less than
+	// or equal to zero, the page limit will be set to defaultLimit.
 	Limit int
 
-	// NextToken is used retrieve the next page of objects. If NextToken is nil
-	// there are no more objects to list.
-	NextToken []byte
+	// Sort specifies the key and direction by which to sort the objects. If
+	// Sort is nil, the objects will be returned in the default order provided
+	// by the underlying implementation.
+	Sort *Sort
 }
 
 // Object represents a single object in the SIP source.
@@ -44,4 +56,71 @@ type Object struct {
 
 	// IsDir indicates whether the object is a directory.
 	IsDir bool
+}
+
+// Page is a paginated list of SIP source objects.
+type Page struct {
+	// Objects is the current page of SIP source objects.
+	Objects []*Object
+
+	// Limit is the maximum number of objects returned per page.
+	Limit int
+
+	// NextToken is used retrieve the next page of objects. If NextToken is nil
+	// there are no more objects to list.
+	NextToken []byte
+}
+
+// Sort specifies the attribute and order by which to sort SIP source objects.
+type Sort struct {
+	// Attr is the object attribute to sort by.
+	attr string
+	// Desc indicates whether to sort in descending order.
+	desc bool
+}
+
+// SortByKey returns a Sort that sorts by the object key.
+func SortByKey() *Sort {
+	return &Sort{attr: "key"}
+}
+
+// SortByModTime returns a Sort that sorts by the object modification time.
+func SortByModTime() *Sort {
+	return &Sort{attr: "modtime"}
+}
+
+// Desc sets the sort order to descending (Z-A).
+func (s *Sort) Desc() *Sort {
+	s.desc = true
+	return s
+}
+
+// Asc sets the sort order to ascending (A-Z).
+func (s *Sort) Asc() *Sort {
+	s.desc = false
+	return s
+}
+
+// Compare two objects based on the Sort configuration. Compare returns -1 if
+// `a` sorts before `b`, 0 if `a` and `b` are equal in sort order, and 1 if `a`
+// sorts after `b`. If Sort is nil or has no attribute set, Compare returns 0.
+func (s *Sort) Compare(a, b *Object) int {
+	if s == nil || s.attr == "" {
+		return 0
+	}
+
+	var r int
+	switch s.attr {
+	case "key":
+		r = strings.Compare(a.Key, b.Key)
+	case "modtime":
+		r = a.ModTime.Compare(b.ModTime)
+	default:
+		return 0
+	}
+
+	if s.desc {
+		return -r
+	}
+	return r
 }

--- a/internal/sipsource/sipsource_test.go
+++ b/internal/sipsource/sipsource_test.go
@@ -1,0 +1,101 @@
+package sipsource_test
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/sipsource"
+)
+
+func TestSort(t *testing.T) {
+	t.Parallel()
+
+	type test = struct {
+		name string
+		objs []*sipsource.Object
+		sort *sipsource.Sort
+		want []*sipsource.Object
+	}
+	for _, tt := range []test{
+		{
+			name: "No sort returns the order unchanged",
+			objs: []*sipsource.Object{
+				{Key: "b"},
+				{Key: "a"},
+				{Key: "c"},
+			},
+			want: []*sipsource.Object{
+				{Key: "b"},
+				{Key: "a"},
+				{Key: "c"},
+			},
+		},
+		{
+			name: "Sorts by key ascending",
+			objs: []*sipsource.Object{
+				{Key: "b"},
+				{Key: "a"},
+				{Key: "c"},
+			},
+			sort: sipsource.SortByKey().Asc(),
+			want: []*sipsource.Object{
+				{Key: "a"},
+				{Key: "b"},
+				{Key: "c"},
+			},
+		},
+		{
+			name: "Sorts by key descending",
+			objs: []*sipsource.Object{
+				{Key: "b"},
+				{Key: "a"},
+				{Key: "c"},
+			},
+			sort: sipsource.SortByKey().Desc(),
+			want: []*sipsource.Object{
+				{Key: "c"},
+				{Key: "b"},
+				{Key: "a"},
+			},
+		},
+		{
+			name: "Sorts by ModTime ascending",
+			objs: []*sipsource.Object{
+				{Key: "a", ModTime: time.Date(2025, 10, 15, 12, 30, 0, 0, time.UTC)},
+				{Key: "b", ModTime: time.Date(2025, 10, 15, 12, 29, 0, 0, time.UTC)},
+				{Key: "c", ModTime: time.Date(2025, 10, 15, 12, 29, 0, 0, time.UTC)},
+				{Key: "d", ModTime: time.Date(2025, 10, 15, 12, 31, 0, 0, time.UTC)},
+			},
+			sort: sipsource.SortByModTime().Asc(),
+			want: []*sipsource.Object{
+				{Key: "b", ModTime: time.Date(2025, 10, 15, 12, 29, 0, 0, time.UTC)},
+				{Key: "c", ModTime: time.Date(2025, 10, 15, 12, 29, 0, 0, time.UTC)},
+				{Key: "a", ModTime: time.Date(2025, 10, 15, 12, 30, 0, 0, time.UTC)},
+				{Key: "d", ModTime: time.Date(2025, 10, 15, 12, 31, 0, 0, time.UTC)},
+			},
+		},
+		{
+			name: "Sorts by ModTime descending",
+			objs: []*sipsource.Object{
+				{ModTime: time.Date(2025, 10, 15, 12, 30, 0, 0, time.UTC)},
+				{ModTime: time.Date(2025, 10, 15, 12, 29, 0, 0, time.UTC)},
+				{ModTime: time.Date(2025, 10, 15, 12, 31, 0, 0, time.UTC)},
+			},
+			sort: sipsource.SortByModTime().Desc(),
+			want: []*sipsource.Object{
+				{ModTime: time.Date(2025, 10, 15, 12, 31, 0, 0, time.UTC)},
+				{ModTime: time.Date(2025, 10, 15, 12, 30, 0, 0, time.UTC)},
+				{ModTime: time.Date(2025, 10, 15, 12, 29, 0, 0, time.UTC)},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			slices.SortFunc(tt.objs, tt.sort.Compare)
+			assert.DeepEqual(t, tt.objs, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
Refs #1373

- Sort the objects returned from the `ListSIPSourceObjects" API endpoint by last modified date, in descending order (most recent first).
- Add a `sipsource.ListOptions` struct and use it the `sipsource.List()` calls.
- Add sort options to the `sipsource.List()` method.
- Return an "invalid cursor" error when a bad token is provided