### PR TITLE
Add configurable approval for AMSS AIP deletions

### DIFF
--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -529,7 +529,7 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: storage.CopyToPermanentLocationActivityName},
 		)
 		w.RegisterActivityWithOptions(
-			storage_activities.NewDeleteFromAMSSLocationActivity().Execute,
+			storage_activities.NewDeleteFromAMSSLocationActivity(cfg.Storage.AIPDeletion.ApproveAMSS).Execute,
 			temporalsdk_activity.RegisterOptions{Name: storage.DeleteFromAMSSLocationActivityName},
 		)
 

--- a/enduro.toml
+++ b/enduro.toml
@@ -138,32 +138,6 @@ workflowType = "create aip"
 # It must be a string format compatible with https://pkg.go.dev/time#ParseDuration.
 retentionPeriod = "0"
 
-[storage]
-enduroAddress = "enduro.enduro-sdps:9002"
-
-# defaultPermanentLocationId is the UUID of the storage location used for
-# permanent AIP storage in the "auto-approve" processing workflow. The value of
-# "f2cc963f-c14d-4eaa-b950-bd207189a1f1" represents the first permanent location
-# defined in the mysql-create-locations-job.yaml Kubernetes manifest.
-defaultPermanentLocationId = "f2cc963f-c14d-4eaa-b950-bd207189a1f1"
-
-[storage.database]
-driver = "mysql"
-dsn = "enduro:enduro123@tcp(mysql.enduro-sdps:3306)/enduro_storage"
-migrate = true
-
-[storage.internal]
-endpoint = "http://minio.enduro-sdps:9000"
-pathStyle = true
-key = "minio"
-secret = "minio123"
-region = "us-west-1"
-bucket = "aips"
-
-[storage.event]
-redisAddress = "redis://redis.enduro-sdps:6379"
-redisChannel = "enduro-storage-events"
-
 # Change the taskqueue setting to your prefered preservation system, by default
 # it is a3m. Use 'am' to configure Archivematica instead.
 [preservation]
@@ -322,3 +296,44 @@ workflowName = "preprocessing"
 # namespace = "default"
 # taskQueue = "poststorage"
 # workflowName = "poststorage"
+
+#########################################################################
+#                                                                       #
+#                     STORAGE SERVICE CONFIGURATION                     #
+#                                                                       #
+# The configuration settings below are specific to the storage service. #
+#                                                                       #
+#########################################################################
+
+[storage]
+enduroAddress = "enduro.enduro-sdps:9002"
+
+# defaultPermanentLocationId is the UUID of the storage location used for
+# permanent AIP storage in the "auto-approve" processing workflow. The value of
+# "f2cc963f-c14d-4eaa-b950-bd207189a1f1" represents the first permanent location
+# defined in the mysql-create-locations-job.yaml Kubernetes manifest.
+defaultPermanentLocationId = "f2cc963f-c14d-4eaa-b950-bd207189a1f1"
+
+[storage.database]
+driver = "mysql"
+dsn = "enduro:enduro123@tcp(mysql.enduro-sdps:3306)/enduro_storage"
+migrate = true
+
+[storage.internal]
+endpoint = "http://minio.enduro-sdps:9000"
+pathStyle = true
+key = "minio"
+secret = "minio123"
+region = "us-west-1"
+bucket = "aips"
+
+[storage.event]
+redisAddress = "redis://redis.enduro-sdps:6379"
+redisChannel = "enduro-storage-events"
+
+[storage.aipDeletion]
+# approveAMSS determines whether AIP deletions are automatically approved in the
+# Archivematica's Storage Service for AMSS locations. When set to false (default),
+# AIP deletions in AMSS locations require manual approval in AMSS. When set to true,
+# they are automatically approved by Enduro, this requires AMSS v0.25.0 or later.
+approveAMSS = false

--- a/internal/storage/activities/delete_amss_test.go
+++ b/internal/storage/activities/delete_amss_test.go
@@ -1,0 +1,339 @@
+package activities_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/storage"
+	"github.com/artefactual-sdps/enduro/internal/storage/activities"
+	"github.com/artefactual-sdps/enduro/internal/storage/types"
+)
+
+func setupServer(t *testing.T, h http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(func() { srv.Close() })
+	return srv
+}
+
+func TestDeleteFromAMSSLocationActivity(t *testing.T) {
+	t.Parallel()
+
+	aipUUID := "2db707f3-3cd2-44b7-9012-9b68eb10d207"
+	pipelineUUID := "a1b2c3d4-e5f6-4321-9876-abcdef123456"
+
+	// Common happy path handlers.
+	handleAIPInfo := func(w http.ResponseWriter, r *http.Request, s string) {
+		// Validate request.
+		assert.Equal(t, r.Header.Get("Authorization"), "ApiKey test:test")
+		assert.Equal(t, r.URL.Path, "/api/v2/file/"+aipUUID+"/")
+
+		// Fake response.
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"origin_pipeline": "/api/v2/pipeline/" + pipelineUUID + "/",
+			"status":          s,
+		}
+		err := json.NewEncoder(w).Encode(resp)
+		assert.NilError(t, err)
+	}
+	handleRequest := func(w http.ResponseWriter, r *http.Request) {
+		// Validate request.
+		assert.Equal(t, r.Header.Get("Authorization"), "ApiKey test:test")
+		assert.Equal(t, r.URL.Path, "/api/v2/file/"+aipUUID+"/delete_aip/")
+		type deletionReq struct {
+			EventReason string `json:"event_reason"`
+			Pipeline    string `json:"pipeline"`
+			UserID      int    `json:"user_id"`
+			UserEmail   string `json:"user_email"`
+		}
+		body, err := io.ReadAll(r.Body)
+		assert.NilError(t, err)
+		var got deletionReq
+		err = json.Unmarshal(body, &got)
+		assert.NilError(t, err)
+		expected := deletionReq{
+			EventReason: "Deletion from Enduro",
+			Pipeline:    pipelineUUID,
+			UserID:      123,
+			UserEmail:   "enduro@example.com",
+		}
+		assert.DeepEqual(t, got, expected)
+
+		// Fake response.
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(map[string]any{"id": int64(42)})
+		assert.NilError(t, err)
+	}
+	handleReview := func(w http.ResponseWriter, r *http.Request) {
+		// Validate request.
+		assert.Equal(t, r.Header.Get("Authorization"), "ApiKey test:test")
+		assert.Equal(t, r.URL.Path, "/api/v2/file/"+aipUUID+"/review_aip_deletion/")
+		type approvalReq struct {
+			EventID  int64  `json:"event_id"`
+			Decision string `json:"decision"`
+			Reason   string `json:"reason"`
+		}
+		body, err := io.ReadAll(r.Body)
+		assert.NilError(t, err)
+		var got approvalReq
+		err = json.Unmarshal(body, &got)
+		assert.NilError(t, err)
+		expected := approvalReq{
+			EventID:  42,
+			Decision: "approve",
+			Reason:   "Approval from Enduro",
+		}
+		assert.DeepEqual(t, got, expected)
+
+		// Fake response.
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(map[string]any{"message": "Deleted"})
+		assert.NilError(t, err)
+	}
+
+	for _, tt := range []struct {
+		name    string
+		approve bool
+		handler http.HandlerFunc
+		want    activities.DeleteFromAMSSLocationActivityResult
+		wantErr string
+	}{
+		{
+			name:    "Deletes AIP with approval",
+			approve: true,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v2/file/" + aipUUID + "/":
+					handleAIPInfo(w, r, "UPLOADED")
+				case "/api/v2/file/" + aipUUID + "/delete_aip/":
+					handleRequest(w, r)
+				case "/api/v2/file/" + aipUUID + "/review_aip_deletion/":
+					handleReview(w, r)
+				default:
+					t.Fatalf("unexpected request to %s", r.URL.Path)
+				}
+			},
+			want: activities.DeleteFromAMSSLocationActivityResult{Deleted: true},
+		},
+		{
+			name:    "Fails getting pipeline UUID (HTTP error)",
+			approve: true,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/v2/file/"+aipUUID+"/" {
+					http.Error(w, "", http.StatusInternalServerError)
+					return
+				}
+				t.Fatalf("unexpected request to %s", r.URL.Path)
+			},
+			wantErr: "get pipeline UUID: response code: 500",
+		},
+		{
+			name:    "Fails getting pipeline UUID (decode error)",
+			approve: true,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/v2/file/"+aipUUID+"/" {
+					w.Header().Set("Content-Type", "application/json")
+					_, err := w.Write([]byte("{"))
+					assert.NilError(t, err)
+					return
+				}
+				t.Fatalf("unexpected request to %s", r.URL.Path)
+			},
+			wantErr: "get pipeline UUID: failed to decode response body",
+		},
+		{
+			name:    "Fails requesting deletion (HTTP error)",
+			approve: true,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v2/file/" + aipUUID + "/":
+					handleAIPInfo(w, r, "UPLOADED")
+				case "/api/v2/file/" + aipUUID + "/delete_aip/":
+					http.Error(w, "", http.StatusInternalServerError)
+				default:
+					t.Fatalf("unexpected request to %s", r.URL.Path)
+				}
+			},
+			wantErr: "request deletion: response code: 500",
+		},
+		{
+			name:    "Fails requesting deletion (decode error)",
+			approve: true,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v2/file/" + aipUUID + "/":
+					handleAIPInfo(w, r, "UPLOADED")
+				case "/api/v2/file/" + aipUUID + "/delete_aip/":
+					w.Header().Set("Content-Type", "application/json")
+					_, err := w.Write([]byte("{"))
+					assert.NilError(t, err)
+				default:
+					t.Fatalf("unexpected request to %s", r.URL.Path)
+				}
+			},
+			wantErr: "request deletion: failed to decode response body",
+		},
+		{
+			name:    "Fails approving deletion (HTTP error)",
+			approve: true,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v2/file/" + aipUUID + "/":
+					handleAIPInfo(w, r, "UPLOADED")
+				case "/api/v2/file/" + aipUUID + "/delete_aip/":
+					handleRequest(w, r)
+				case "/api/v2/file/" + aipUUID + "/review_aip_deletion/":
+					http.Error(w, "", http.StatusInternalServerError)
+				default:
+					t.Fatalf("unexpected request to %s", r.URL.Path)
+				}
+			},
+			wantErr: "approve deletion: response code: 500",
+		},
+		{
+			name:    "Fails approving deletion (decode error)",
+			approve: true,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v2/file/" + aipUUID + "/":
+					handleAIPInfo(w, r, "UPLOADED")
+				case "/api/v2/file/" + aipUUID + "/delete_aip/":
+					handleRequest(w, r)
+				case "/api/v2/file/" + aipUUID + "/review_aip_deletion/":
+					w.Header().Set("Content-Type", "application/json")
+					_, err := w.Write([]byte("{"))
+					assert.NilError(t, err)
+				default:
+					t.Fatalf("unexpected request to %s", r.URL.Path)
+				}
+			},
+			wantErr: "approve deletion: failed to decode response body",
+		},
+		{
+			name:    "Fails approving deletion (response error_message)",
+			approve: true,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v2/file/" + aipUUID + "/":
+					handleAIPInfo(w, r, "UPLOADED")
+				case "/api/v2/file/" + aipUUID + "/delete_aip/":
+					handleRequest(w, r)
+				case "/api/v2/file/" + aipUUID + "/review_aip_deletion/":
+					w.Header().Set("Content-Type", "application/json")
+					err := json.NewEncoder(w).Encode(map[string]any{"error_message": "error message"})
+					assert.NilError(t, err)
+				default:
+					t.Fatalf("unexpected request to %s", r.URL.Path)
+				}
+			},
+			wantErr: "approve deletion: error message",
+		},
+		{
+			name: "Deletes AIP after polling for status",
+			handler: func() http.HandlerFunc {
+				var requested, polled bool
+				return func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/v2/file/" + aipUUID + "/":
+						if !requested {
+							handleAIPInfo(w, r, "UPLOADED")
+							return
+						}
+						if !polled {
+							handleAIPInfo(w, r, "DEL_REQ")
+							polled = true
+							return
+						}
+						handleAIPInfo(w, r, "DELETED")
+					case "/api/v2/file/" + aipUUID + "/delete_aip/":
+						handleRequest(w, r)
+						requested = true
+					default:
+						t.Fatalf("unexpected request to %s", r.URL.Path)
+					}
+				}
+			}(),
+			want: activities.DeleteFromAMSSLocationActivityResult{Deleted: true},
+		},
+		{
+			name: "Doesn't delete AIP after polling for status",
+			handler: func() http.HandlerFunc {
+				var requested, polled bool
+				return func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/v2/file/" + aipUUID + "/":
+						if !requested {
+							handleAIPInfo(w, r, "UPLOADED")
+							return
+						}
+						if !polled {
+							handleAIPInfo(w, r, "DEL_REQ")
+							polled = true
+							return
+						}
+						handleAIPInfo(w, r, "UPLOADED")
+					case "/api/v2/file/" + aipUUID + "/delete_aip/":
+						handleRequest(w, r)
+						requested = true
+					default:
+						t.Fatalf("unexpected request to %s", r.URL.Path)
+					}
+				}
+			}(),
+			want: activities.DeleteFromAMSSLocationActivityResult{Deleted: false},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := setupServer(t, tt.handler)
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			env.SetTestTimeout(5 * time.Second)
+
+			// Set up a ticker channel for polling tests and tick twice.
+			ch := make(chan time.Time, 2)
+			ch <- time.Now()
+			ch <- time.Now()
+
+			env.RegisterActivityWithOptions(
+				activities.NewDeleteFromAMSSLocationActivityWithTicker(tt.approve, ch).Execute,
+				temporalsdk_activity.RegisterOptions{
+					Name: storage.DeleteFromAMSSLocationActivityName,
+				},
+			)
+
+			fut, err := env.ExecuteActivity(
+				storage.DeleteFromAMSSLocationActivityName,
+				activities.DeleteFromAMSSLocationActivityParams{
+					Config: types.AMSSConfig{
+						URL:      srv.URL,
+						Username: "test",
+						APIKey:   "test",
+					},
+					AIPUUID: uuid.MustParse(aipUUID),
+				},
+			)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+
+			var res activities.DeleteFromAMSSLocationActivityResult
+			err = fut.Get(&res)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, res, tt.want)
+		})
+	}
+}

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Internal                   LocationConfig
 	Database                   Database
 	Event                      event.Config
+	AIPDeletion                AIPDeletionConfig
 }
 
 type Database struct {
@@ -43,4 +44,12 @@ type LocationConfig struct {
 	Secret    string
 	Token     string
 	Bucket    string
+}
+
+type AIPDeletionConfig struct {
+	// ApproveAMSS determines whether AIP deletions are automatically approved in the
+	// Archivematica's Storage Service for AMSS locations. When set to false (default),
+	// AIP deletions in AMSS locations require manual approval in AMSS. When set to true,
+	// they are automatically approved by Enduro, this requires AMSS v0.25.0 or later.
+	ApproveAMSS bool
 }

--- a/internal/storage/workflows/delete_test.go
+++ b/internal/storage/workflows/delete_test.go
@@ -59,7 +59,7 @@ func NewStorageDeleteWorkflowTestSuite(
 	}
 
 	s.env.RegisterActivityWithOptions(
-		activities.NewDeleteFromAMSSLocationActivity().Execute,
+		activities.NewDeleteFromAMSSLocationActivity(false).Execute,
 		temporalsdk_activity.RegisterOptions{Name: storage.DeleteFromAMSSLocationActivityName},
 	)
 


### PR DESCRIPTION
Introduce a new `aipDeletion.approveAMSS` boolean option to the
storage service configuration that enables automatic approval of
AIP deletion requests in Archivematica Storage Service (AMSS)
locations. This requires AMSS v0.25.0 or later.

Refs https://github.com/artefactual-sdps/enduro/issues/1401.