### PR TITLE
Fix Tilt CI

### DIFF
--- a/.github/workflows/tilt-ci.yml
+++ b/.github/workflows/tilt-ci.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           setup-tools: |
             tilt
-          tilt: v0.33.11
+          tilt: v0.35.2
       - name: Check tilt ci
         run: timeout 600 tilt ci

--- a/.github/workflows/tilt-ci.yml
+++ b/.github/workflows/tilt-ci.yml
@@ -26,4 +26,4 @@ jobs:
             tilt
           tilt: v0.35.2
       - name: Check tilt ci
-        run: timeout 600 tilt ci
+        run: tilt ci

--- a/.github/workflows/tilt-ci.yml
+++ b/.github/workflows/tilt-ci.yml
@@ -18,6 +18,7 @@ jobs:
             --registry-create sdps-ci-registry
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+            --k3s-arg "--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@server:*"
       - name: Install Tilt
         uses: yokawasa/action-setup-kube-tools@3e3886c11bfa25fe33f8eb90f59542dd151da442 # v0.13.1
         with:

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,5 +1,6 @@
 version_settings(constraint=">=0.22.2")
 secret_settings(disable_scrub=True)
+ci_settings(timeout="10m", readiness_timeout="10m")
 load("ext://uibutton", "cmd_button", "text_input")
 load('ext://dotenv', 'dotenv')
 


### PR DESCRIPTION
Main fix was increasing the [readiness timeout](https://docs.tilt.dev/api.html#api.ci_settings). But I also saw the following error while testing:

```
[event: pod enduro-sdps/enduro-a3m-0] The node was low on resource: ephemeral-storage.
```

So I lowered the eviction threshold in the Tilt CI cluster to 1%, from the defaults nodefs.available<10% and imagefs.available<15%:

https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#hard-eviction-thresholds

Also upgraded Tilt to its latest version.