### PR TITLE
Enable extra eslint rules

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -18,5 +18,3 @@ jobs:
         working-directory: ./dashboard
       - run: npm run lint
         working-directory: ./dashboard
-      - run: npm run format-check
-        working-directory: ./dashboard

--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -3,6 +3,7 @@ import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 import pluginImport from "eslint-plugin-import";
+import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -29,6 +30,8 @@ export default [
   pluginImport.flatConfigs.recommended,
   ...tseslint.configs.recommended,
   ...pluginVue.configs["flat/essential"],
+  ...pluginVue.configs["flat/strongly-recommended"],
+  ...pluginVue.configs["flat/recommended"],
   {
     files: ["**/*.{ts,vue}"],
     languageOptions: { parserOptions: { parser: tseslint.parser } },
@@ -40,6 +43,28 @@ export default [
         },
       ],
       "vue/multi-word-component-names": "off", // doesn't work with auto-router paths.
+      "vue/no-v-html": "off", // must be fixed soon.
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          selector: "function",
+          format: ["camelCase"],
+        },
+        {
+          selector: "variableLike",
+          format: ["camelCase"],
+          leadingUnderscore: "allow",
+        },
+        {
+          selector: "typeLike",
+          format: ["PascalCase"],
+        },
+      ],
+      "vue/component-name-in-template-casing": [
+        "error",
+        "PascalCase",
+        { registeredComponentsOnly: false },
+      ],
       "import/order": [
         "error",
         {
@@ -50,4 +75,5 @@ export default [
       ],
     },
   },
+  eslintPluginPrettierRecommended,
 ];

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -47,8 +47,10 @@
         "@vue/tsconfig": "^0.7.0",
         "bootstrap": "^5.3.8",
         "eslint": "^9.28.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.3",
         "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-prettier": "^5.5.4",
         "eslint-plugin-vue": "^10.2.0",
         "globals": "^16.2.0",
         "happy-dom": "^20.0.2",
@@ -1810,6 +1812,19 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@polka/url": {
@@ -5476,6 +5491,22 @@
         }
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-import-context": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
@@ -5628,6 +5659,37 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
+      "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-vue": {
@@ -5837,6 +5899,13 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -8481,6 +8550,19 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
@@ -9415,6 +9497,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
       }
     },
     "node_modules/test-exclude": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -11,7 +11,6 @@
     "preview": "vite preview",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "format-check": "prettier --check .",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
     "deps": "ncu --format=group --interactive"
@@ -56,8 +55,10 @@
     "@vue/tsconfig": "^0.7.0",
     "bootstrap": "^5.3.8",
     "eslint": "^9.28.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.3",
     "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-vue": "^10.2.0",
     "globals": "^16.2.0",
     "happy-dom": "^20.0.2",

--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -31,8 +31,8 @@ watch(
 <template>
   <div class="d-flex flex-column min-vh-100">
     <div
-      class="visually-hidden-focusable p-3 border-bottom"
       v-if="authStore.isUserValid"
+      class="visually-hidden-focusable p-3 border-bottom"
     >
       <a class="btn btn-sm btn-outline-primary" href="#main"
         >Skip to main content</a
@@ -41,8 +41,8 @@ watch(
     <Header v-if="authStore.isUserValid" />
     <div class="flex-grow-1 d-flex">
       <Sidebar v-if="authStore.isUserValid" />
-      <main class="flex-grow-1 d-flex px-2 pt-3" id="main">
-        <router-view></router-view>
+      <main id="main" class="flex-grow-1 d-flex px-2 pt-3">
+        <RouterView />
       </main>
     </div>
     <DialogWrapper v-if="authStore.isUserValid" />

--- a/dashboard/src/components/AboutDialog.vue
+++ b/dashboard/src/components/AboutDialog.vue
@@ -26,7 +26,7 @@ useEventListener(el, "hidden.bs.modal", () => closeDialog(null));
 </script>
 
 <template>
-  <div class="modal" tabindex="-1" ref="el">
+  <div ref="el" class="modal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
@@ -38,7 +38,7 @@ useEventListener(el, "hidden.bs.modal", () => closeDialog(null));
             class="btn-close"
             data-bs-dismiss="modal"
             aria-label="Close"
-          ></button>
+          />
         </div>
         <div class="modal-body">
           <div class="mb-3">
@@ -62,7 +62,7 @@ useEventListener(el, "hidden.bs.modal", () => closeDialog(null));
                 {{ aboutStore.preservationSystem }}
               </div>
             </div>
-            <div class="row" v-if="aboutStore.preprocessing.enabled">
+            <div v-if="aboutStore.preprocessing.enabled" class="row">
               <div
                 class="col-12 col-sm-6 text-primary fw-bold text-sm-end text-truncate"
               >
@@ -73,8 +73,8 @@ useEventListener(el, "hidden.bs.modal", () => closeDialog(null));
               </div>
             </div>
             <div
-              class="row"
               v-if="aboutStore.poststorage && aboutStore.poststorage.length > 0"
+              class="row"
             >
               <div
                 class="col-12 col-sm-6 text-primary fw-bold text-sm-end text-truncate"

--- a/dashboard/src/components/AipDeletionRequestDialog.vue
+++ b/dashboard/src/components/AipDeletionRequestDialog.vue
@@ -35,7 +35,7 @@ const request = () => {
 </script>
 
 <template>
-  <div class="modal" tabindex="-1" ref="el">
+  <div ref="el" class="modal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
@@ -57,14 +57,14 @@ const request = () => {
             <div>
               <label for="reason" class="form-label">Reason:</label>
               <textarea
-                class="form-control"
                 id="reason"
-                rows="3"
                 v-model="reason"
+                class="form-control"
+                rows="3"
                 required
                 minlength="10"
                 maxlength="500"
-              ></textarea>
+              />
               <div class="form-text text-end">
                 Reason must be between 10 and 500 characters.
               </div>

--- a/dashboard/src/components/AipDeletionReviewAlert.vue
+++ b/dashboard/src/components/AipDeletionReviewAlert.vue
@@ -31,9 +31,9 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="alert alert-info" role="alert" v-if="aipStore.isPending">
+  <div v-if="aipStore.isPending" class="alert alert-info" role="alert">
     <h4 class="alert-heading">Task: Review AIP deletion request</h4>
-    <p class="line-break" v-html="addEmailLinks(note)"></p>
+    <p class="line-break" v-html="addEmailLinks(note)" />
     <div class="d-flex flex-wrap gap-2">
       <template v-if="canCancel">
         <hr />

--- a/dashboard/src/components/AipLocationCard.vue
+++ b/dashboard/src/components/AipLocationCard.vue
@@ -78,18 +78,18 @@ const requestDeletion = async () => {
               "
               type="button"
               class="btn btn-primary btn-sm"
-              @click="choose"
               :disabled="!aipStore.isMovable"
+              @click="choose"
             >
               <template v-if="aipStore.isMoving">
                 <span
                   class="spinner-grow spinner-grow-sm me-2"
                   role="status"
                   aria-hidden="true"
-                ></span>
+                />
                 Moving...
               </template>
-              <template v-else>Move</template>
+              <template v-else> Move </template>
             </button>
             <button
               v-if="

--- a/dashboard/src/components/Breadcrumb.vue
+++ b/dashboard/src/components/Breadcrumb.vue
@@ -17,10 +17,12 @@ const layoutStore = useLayoutStore();
           i == layoutStore.breadcrumb.length - 1 ? 'page' : undefined
         "
       >
-        <router-link :to="item.route" v-if="item.route" class="text-primary">{{
-          item.text
-        }}</router-link>
-        <template v-else>{{ item.text }}</template>
+        <RouterLink v-if="item.route" :to="item.route" class="text-primary">
+          {{ item.text }}
+        </RouterLink>
+        <template v-else>
+          {{ item.text }}
+        </template>
       </li>
     </ol>
   </nav>

--- a/dashboard/src/components/Header.vue
+++ b/dashboard/src/components/Header.vue
@@ -55,14 +55,14 @@ const institution: { logo: string; name: string; url: string } = {
         />
       </button>
 
-      <router-link
+      <RouterLink
         class="navbar-brand h1 mb-0 me-auto p-3 px-2 text-primary text-decoration-none d-flex align-items-center fw-bold"
         :class="layoutStore.sidebarCollapsed ? '' : 'ms-2'"
         :to="{ name: '/' }"
       >
         <img src="/logo.png" alt="" height="30" class="me-2" />
         Enduro
-      </router-link>
+      </RouterLink>
 
       <div class="flex-grow-1 d-none d-md-block">
         <Breadcrumb />

--- a/dashboard/src/components/InstitutionLogo.vue
+++ b/dashboard/src/components/InstitutionLogo.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { defineProps } from "vue";
-
 const props = defineProps<{
   logo: string;
   name: string;
@@ -18,11 +16,7 @@ const imgTag = `<img
 
 <template>
   <div v-if="props.logo && props.url" class="d-none d-sm-block mx-3">
-    <a :href="props.url" target="_blank" rel="external" v-html="imgTag"></a>
+    <a :href="props.url" target="_blank" rel="external" v-html="imgTag" />
   </div>
-  <div
-    v-else-if="props.logo"
-    v-html="imgTag"
-    class="d-none d-sm-block mx-3"
-  ></div>
+  <div v-else-if="props.logo" class="d-none d-sm-block mx-3" v-html="imgTag" />
 </template>

--- a/dashboard/src/components/LocationDialog.vue
+++ b/dashboard/src/components/LocationDialog.vue
@@ -7,7 +7,7 @@ import useEventListener from "@/composables/useEventListener";
 import { useLocationStore } from "@/stores/location";
 
 const props = defineProps({
-  currentLocationId: { type: String, required: false },
+  currentLocationId: { type: String, required: false, default: undefined },
 });
 
 const locationStore = useLocationStore();
@@ -36,7 +36,7 @@ const onChoose = (locationId: string) => {
 </script>
 
 <template>
-  <div class="modal" tabindex="-1" ref="el">
+  <div ref="el" class="modal" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
@@ -49,7 +49,7 @@ const onChoose = (locationId: string) => {
                 <tr>
                   <th>Location name</th>
                   <th>Status</th>
-                  <th></th>
+                  <th />
                 </tr>
               </thead>
               <tbody>
@@ -77,7 +77,7 @@ const onChoose = (locationId: string) => {
               </tbody>
             </table>
           </div>
-          <small class="text-muted" v-if="props.currentLocationId">
+          <small v-if="props.currentLocationId" class="text-muted">
             The current location is {{ props.currentLocationId }}.
           </small>
         </div>

--- a/dashboard/src/components/PageLoadingAlert.vue
+++ b/dashboard/src/components/PageLoadingAlert.vue
@@ -6,10 +6,14 @@ import type { runtime } from "@/client";
 interface Props {
   title?: string;
   error?: unknown;
-  execute?: (delay?: number, ...args: unknown[]) => Promise<unknown>;
+  execute?: ((delay?: number, ...args: unknown[]) => Promise<unknown>) | null;
 }
 
-const { title = "Page loading error", error, execute } = defineProps<Props>();
+const {
+  title = "Page loading error",
+  error = undefined,
+  execute = null,
+} = defineProps<Props>();
 
 const retry = () => {
   if (execute) execute();
@@ -29,18 +33,20 @@ const is404 = computed(() => {
 
 <template>
   <!-- Not found. -->
-  <div class="alert alert-warning" role="alert" v-if="error && is404">
+  <div v-if="error && is404" class="alert alert-warning" role="alert">
     <h4 class="alert-heading">Page not found!</h4>
     <p>We can't find the page you're looking for.</p>
     <hr />
-    <router-link class="btn btn-warning" :to="{ name: '/' }"
-      >Take me home</router-link
-    >
+    <RouterLink class="btn btn-warning" :to="{ name: '/' }">
+      Take me home
+    </RouterLink>
   </div>
 
   <!-- Other errors. -->
-  <div class="alert alert-danger" role="alert" v-if="error && !is404">
-    <h4 class="alert-heading">{{ title }}</h4>
+  <div v-if="error && !is404" class="alert alert-danger" role="alert">
+    <h4 class="alert-heading">
+      {{ title }}
+    </h4>
     <slot>
       <p>It was not possible to load this page.</p>
     </slot>

--- a/dashboard/src/components/Pager.vue
+++ b/dashboard/src/components/Pager.vue
@@ -77,9 +77,9 @@ const goToPage = (page: number) => {
           id="prev-page"
           class="page-link"
           href="#"
-          @click.prevent="goToPage(currentPage - 1)"
           aria-label="Go to previous page"
           title="Previous page"
+          @click.prevent="goToPage(currentPage - 1)"
         >
           <IconPrev />
         </a>
@@ -112,8 +112,8 @@ const goToPage = (page: number) => {
           :id="`page-${page}`"
           class="page-link"
           href="#"
-          @click.prevent="goToPage(page)"
           :aria-label="`Go to page ${page}`"
+          @click.prevent="goToPage(page)"
           >{{ page }}</a
         >
       </li>
@@ -144,9 +144,9 @@ const goToPage = (page: number) => {
           id="next-page"
           class="page-link"
           href="#"
-          @click.prevent="goToPage(currentPage + 1)"
           aria-label="Go to next page"
           title="Next page"
+          @click.prevent="goToPage(currentPage + 1)"
         >
           <IconNext />
         </a>

--- a/dashboard/src/components/ResultCounter.vue
+++ b/dashboard/src/components/ResultCounter.vue
@@ -22,7 +22,7 @@ const last = computed(() => {
 </script>
 
 <template>
-  <template v-if="props.total === 0">No results found</template>
+  <template v-if="props.total === 0"> No results found </template>
   <template v-else-if="props.total === 1">
     Found {{ props.total }} result
   </template>

--- a/dashboard/src/components/SIPUploadLocal.vue
+++ b/dashboard/src/components/SIPUploadLocal.vue
@@ -17,8 +17,8 @@ const authStore = useAuthStore();
 const aboutStore = useAboutStore();
 const router = useRouter();
 
-const GiB = 1024 ** 3; // 1 GiB in bytes
-const uploadMaxDefault = 4 * GiB;
+const gib = 1024 ** 3; // 1 GiB in bytes
+const uploadMaxDefault = 4 * gib;
 
 aboutStore.$subscribe((_, state) => {
   uppy.setOptions({

--- a/dashboard/src/components/SIPUploadSource.vue
+++ b/dashboard/src/components/SIPUploadSource.vue
@@ -87,9 +87,9 @@ const clickSip = (key: string) => {
     <button
       type="button"
       class="btn-close"
-      @click="errorMessage = null"
       aria-label="Close"
-    ></button>
+      @click="errorMessage = null"
+    />
   </div>
 
   <h2 class="mb-3">1. Select SIPs to Ingest</h2>
@@ -118,8 +118,8 @@ const clickSip = (key: string) => {
             <td colspan="4">No SIPs found</td>
           </tr>
           <tr
-            v-else
             v-for="item in items"
+            v-else
             :key="item.key"
             :class="selectedSips.includes(item.key) ? 'table-primary' : ''"
             role="button"
@@ -127,11 +127,11 @@ const clickSip = (key: string) => {
           >
             <td>
               <input
+                :id="'cb-' + item.key"
+                v-model="selectedSips"
                 class="form-check-input"
                 type="checkbox"
-                v-model="selectedSips"
                 :value="item.key"
-                :id="'cb-' + item.key"
               />
             </td>
             <td>
@@ -153,7 +153,7 @@ const clickSip = (key: string) => {
               <div
                 class="spinner-border spinner-border-sm text-muted"
                 role="status"
-              ></div>
+              />
             </td>
           </tr>
         </tbody>
@@ -167,8 +167,8 @@ const clickSip = (key: string) => {
   <h2 class="mb-3">2. Launch Ingest</h2>
   <button
     class="btn btn-primary"
-    @click="startIngest"
     :disabled="selectedSips.length === 0"
+    @click="startIngest"
   >
     Start Ingest
   </button>

--- a/dashboard/src/components/Sidebar.vue
+++ b/dashboard/src/components/Sidebar.vue
@@ -83,22 +83,22 @@ const closeOffcanvas = () => {
 
 <template>
   <div
+    id="menu-offcanvas"
+    ref="offcanvas"
     class="sidebar offcanvas-md offcanvas-start d-flex bg-light"
     :class="layoutStore.sidebarCollapsed ? 'collapsed' : ''"
     tabindex="-1"
-    id="menu-offcanvas"
     aria-labelledby="offcanvasLabel"
-    ref="offcanvas"
   >
     <div class="offcanvas-header">
-      <h5 class="offcanvas-title" id="offcanvasLabel">Navigation</h5>
+      <h5 id="offcanvasLabel" class="offcanvas-title">Navigation</h5>
       <button
         type="button"
         class="btn-close"
         data-bs-dismiss="offcanvas"
         data-bs-target="#menu-offcanvas"
         aria-label="Close"
-      ></button>
+      />
     </div>
     <div class="offcanvas-body d-flex flex-grow-1 p-0">
       <nav
@@ -106,10 +106,7 @@ const closeOffcanvas = () => {
         class="flex-grow-1 d-flex flex-column"
       >
         <ul class="list-unstyled flex-grow-1 mb-0">
-          <li
-            v-for="(item, i) in menuItems.filter((it) => it.show)"
-            v-bind:key="i"
-          >
+          <li v-for="(item, i) in menuItems.filter((it) => it.show)" :key="i">
             <div
               v-if="!item.route"
               class="py-2 text-muted small"
@@ -117,7 +114,7 @@ const closeOffcanvas = () => {
             >
               {{ item.text }}
             </div>
-            <router-link
+            <RouterLink
               v-else
               class="d-block py-3 text-decoration-none sidebar-link"
               active-class="active"
@@ -135,7 +132,7 @@ const closeOffcanvas = () => {
                         : ''
                     "
                   >
-                    <span v-html="item.icon" aria-hidden="true" />
+                    <span aria-hidden="true" v-html="item.icon" />
                   </div>
                   <div
                     class="col-9 d-flex align-items-center"
@@ -148,15 +145,15 @@ const closeOffcanvas = () => {
                     {{ item.text }}
                   </div>
                 </div>
-              </div></router-link
-            >
+              </div>
+            </RouterLink>
           </li>
         </ul>
         <button
           v-if="authStore.isEnabled"
+          id="user-menu-button"
           ref="collapse"
           type="button"
-          id="user-menu-button"
           class="btn btn-link d-block p-0 py-3 text-decoration-none text-dark sidebar-link rounded-0 collapsed border-top"
           data-bs-toggle="collapse"
           data-bs-target="#user-menu"
@@ -174,9 +171,9 @@ const closeOffcanvas = () => {
                 "
               >
                 <span
-                  v-html="IconUser"
                   class="text-primary"
                   aria-hidden="true"
+                  v-html="IconUser"
                 />
               </div>
               <div
@@ -195,11 +192,11 @@ const closeOffcanvas = () => {
             </div>
           </div>
         </button>
-        <div class="collapse" id="user-menu">
+        <div id="user-menu" class="collapse">
           <a
             class="d-block py-3 text-decoration-none text-dark sidebar-link"
-            @click="authStore.signoutRedirect()"
             href="#"
+            @click="authStore.signoutRedirect()"
           >
             <div class="container-fluid">
               <div class="row">
@@ -211,7 +208,7 @@ const closeOffcanvas = () => {
                       : ''
                   "
                 >
-                  <span v-html="IconLogout" aria-hidden="true" />
+                  <span aria-hidden="true" v-html="IconLogout" />
                 </div>
                 <div
                   class="col-9 d-flex align-items-center"

--- a/dashboard/src/components/SipListSelectFilters.vue
+++ b/dashboard/src/components/SipListSelectFilters.vue
@@ -13,8 +13,8 @@ const sipStore = useSipStore();
       <select
         id="filter-status"
         v-model="sipStore.filters.status"
-        @change="sipStore.fetchSips(1)"
         class="form-select"
+        @change="sipStore.fetchSips(1)"
       >
         <option value="">any</option>
         <option

--- a/dashboard/src/components/SipRelatedPackages.vue
+++ b/dashboard/src/components/SipRelatedPackages.vue
@@ -10,11 +10,11 @@ const sipStore = useSipStore();
 
 <template>
   <div
-    class="card mb-3"
     v-if="
       sipStore.current?.aipUuid ||
       (sipStore.current?.failedAs && sipStore.current?.failedKey)
     "
+    class="card mb-3"
   >
     <div class="card-body">
       <h4 class="card-title">Related Packages</h4>
@@ -23,15 +23,16 @@ const sipStore = useSipStore();
           <strong>AIP</strong>
           <UUID :id="sipStore.current.aipUuid" />
         </p>
-        <router-link
+        <RouterLink
           v-if="authStore.checkAttributes(['storage:aips:read'])"
           class="btn btn-primary btn-sm"
           :to="{
             name: '/storage/aips/[id]/',
             params: { id: sipStore.current.aipUuid },
           }"
-          >View</router-link
         >
+          View
+        </RouterLink>
       </template>
       <template
         v-else-if="sipStore.current?.failedAs && sipStore.current?.failedKey"
@@ -53,8 +54,8 @@ const sipStore = useSipStore();
           {{ sipStore.current.failedKey }}
         </p>
         <Transition
-          mode="out-in"
           v-if="authStore.checkAttributes(['ingest:sips:download'])"
+          mode="out-in"
         >
           <div
             v-if="sipStore.downloadError"

--- a/dashboard/src/components/SipReviewAlert.vue
+++ b/dashboard/src/components/SipReviewAlert.vue
@@ -28,7 +28,7 @@ const confirm = async () => {
 </script>
 
 <template>
-  <div class="alert alert-info" role="alert" v-if="sipStore.isPending">
+  <div v-if="sipStore.isPending" class="alert alert-info" role="alert">
     <h4 class="alert-heading">Task: Review AIP</h4>
     <p>
       Please review the output and decide if you would like to keep the AIP or

--- a/dashboard/src/components/StatusBadge.vue
+++ b/dashboard/src/components/StatusBadge.vue
@@ -1,15 +1,15 @@
 <script lang="ts">
-type packageEnum =
+type PackageEnum =
   | api.EnduroIngestSipStatusEnum
   | api.EnduroStorageAipStatusEnum;
-type workflowEnum =
+type WorkflowEnum =
   | api.EnduroIngestSipWorkflowStatusEnum
   | api.EnduroStorageAipWorkflowStatusEnum;
-type taskEnum =
+type TaskEnum =
   | api.EnduroIngestSipTaskStatusEnum
   | api.EnduroStorageAipTaskStatusEnum;
 
-export type StatusEnum = packageEnum | workflowEnum | taskEnum;
+export type StatusEnum = PackageEnum | WorkflowEnum | TaskEnum;
 </script>
 
 <script setup lang="ts">
@@ -17,17 +17,17 @@ import { computed } from "vue";
 
 import { api } from "@/client";
 
-type badgeType = "package" | "workflow";
-type badgeStyle = string[];
+type BadgeType = "package" | "workflow";
+type BadgeStyle = string[];
 
 const props = defineProps<{
   status: StatusEnum;
-  type: badgeType;
+  type: BadgeType;
   note?: string;
 }>();
 
 const packageStyle: {
-  [key in packageEnum]: badgeStyle;
+  [key in PackageEnum]: BadgeStyle;
 } = {
   ingested: [
     "text-dark",
@@ -49,7 +49,7 @@ const packageStyle: {
 };
 
 const workflowStyle: {
-  [key in workflowEnum | taskEnum]: badgeStyle;
+  [key in WorkflowEnum | TaskEnum]: BadgeStyle;
 } = {
   done: ["text-bg-success"],
   failed: ["text-bg-danger"],
@@ -62,12 +62,12 @@ const workflowStyle: {
 };
 
 const colorClass = computed(() => {
-  function getBadgeStyle(type: badgeType): badgeStyle {
+  function getBadgeStyle(type: BadgeType): BadgeStyle {
     switch (type) {
       case "package":
-        return packageStyle[props.status as packageEnum];
+        return packageStyle[props.status as PackageEnum];
       case "workflow":
-        return workflowStyle[props.status as workflowEnum];
+        return workflowStyle[props.status as WorkflowEnum];
     }
   }
 
@@ -84,7 +84,7 @@ const colorClass = computed(() => {
         class="spinner-border spinner-border-sm text-black"
         role="progress"
         aria-hidden="true"
-      ></div>
+      />
     </span>
     <span v-if="props.note" class="badge text-dark fw-normal"
       >({{ props.note }})</span

--- a/dashboard/src/components/StatusLegend.vue
+++ b/dashboard/src/components/StatusLegend.vue
@@ -10,7 +10,7 @@ export type LegendItem = {
 };
 
 const { show = false } = defineProps<{
-  show: boolean;
+  show?: boolean;
   items: LegendItem[];
 }>();
 
@@ -27,9 +27,9 @@ const visible = computed(() => show);
 
 <template>
   <Transition>
-    <div class="alert alert-secondary alert-dismissible" v-if="visible">
+    <div v-if="visible" class="alert alert-secondary alert-dismissible">
       <div class="container-fluid">
-        <div class="row" v-for="(item, index) in items" :key="item.status">
+        <div v-for="(item, index) in items" :key="item.status" class="row">
           <div class="col-12 col-md-2 py-2 text-end">
             <StatusBadge
               :status="item.status"
@@ -37,7 +37,7 @@ const visible = computed(() => show);
               :aria-describedby="`badge-${index}-desc`"
             />
           </div>
-          <div class="col-12 col-md-10 py-2" :id="`badge-${index}-desc`">
+          <div :id="`badge-${index}-desc`" class="col-12 col-md-10 py-2">
             {{ item.description }}
           </div>
         </div>
@@ -46,9 +46,9 @@ const visible = computed(() => show);
       <button
         type="button"
         class="btn-close"
-        @click="dismiss"
         aria-label="Close"
-      ></button>
+        @click="dismiss"
+      />
     </div>
   </Transition>
 </template>

--- a/dashboard/src/components/Tabs.vue
+++ b/dashboard/src/components/Tabs.vue
@@ -27,17 +27,17 @@ function isActive(tab: Tab): boolean {
 <template>
   <nav aria-label="Tabs" class="mb-3">
     <ul class="nav nav-tabs d-flex flex-nowrap">
-      <li class="nav-item d-flex" v-for="tab in tabs" :key="tab.text">
-        <router-link
+      <li v-for="tab in tabs" :key="tab.text" class="nav-item d-flex">
+        <RouterLink
           v-if="tab.show"
           :to="tab.route"
           class="nav-link text-primary text-nowrap d-flex align-items-center"
           :class="{ active: isActive(tab) }"
         >
-          <span v-html="tab.icon" class="me-2 text-dark" aria-hidden="true" />{{
+          <span class="me-2 text-dark" aria-hidden="true" v-html="tab.icon" />{{
             tab.text
           }}
-        </router-link>
+        </RouterLink>
       </li>
     </ul>
   </nav>

--- a/dashboard/src/components/Task.vue
+++ b/dashboard/src/components/Task.vue
@@ -3,7 +3,7 @@ import { computed, ref } from "vue";
 
 import StatusBadge from "@/components/StatusBadge.vue";
 import { addEmailLinks } from "@/composables/addEmailLinks";
-import { FormatDateTime } from "@/composables/format";
+import { formatDateTime } from "@/composables/format";
 import type {
   EnduroIngestSipTask,
   EnduroStorageAipTask,
@@ -63,13 +63,13 @@ const toggle = () => {
             {{ task.name }}
           </div>
           <div :id="'pt-' + index + '-time'" class="me-3">
-            <span v-if="!isComplete(task) && FormatDateTime(task.startedAt)">
+            <span v-if="!isComplete(task) && formatDateTime(task.startedAt)">
               Started:
-              {{ FormatDateTime(task.startedAt) }}
+              {{ formatDateTime(task.startedAt) }}
             </span>
-            <span v-if="isComplete(task) && FormatDateTime(task.completedAt)">
+            <span v-if="isComplete(task) && formatDateTime(task.completedAt)">
               Completed:
-              {{ FormatDateTime(task.completedAt) }}
+              {{ formatDateTime(task.completedAt) }}
             </span>
           </div>
         </div>
@@ -77,7 +77,7 @@ const toggle = () => {
           <span
             :id="'pt-' + index + '-note'"
             v-html="addEmailLinks(noteData.note)"
-          ></span>
+          />
           <span v-if="noteData.more">
             <span v-show="!isOpen">... </span>
             <Transition name="fade">
@@ -86,14 +86,14 @@ const toggle = () => {
                 :id="'pt-' + index + '-note-more'"
                 class="line-break"
                 v-html="addEmailLinks(noteData.more)"
-              ></p>
+              />
             </Transition>
             <a
               :id="'pt-' + index + '-note-toggle'"
               :aria-controls="'pt-' + index + '-note-more'"
               aria-label="Toggle display of additional notes"
-              @click.prevent="toggle"
               href="#"
+              @click.prevent="toggle"
             >
               {{ isOpen ? "Show less" : "Show more" }}
             </a>

--- a/dashboard/src/components/TimeDropdown.vue
+++ b/dashboard/src/components/TimeDropdown.vue
@@ -13,12 +13,12 @@ const emit = defineEmits<{
   change: [name: string, start: string, end: string];
 }>();
 
-type option = {
+type Option = {
   value: string;
   label: string;
 };
 
-const options: option[] = [
+const options: Option[] = [
   { value: "", label: "Select a time range" },
   { value: "3h", label: "The last 3 hours" },
   { value: "6h", label: "The last 6 hours" },
@@ -144,7 +144,7 @@ const earliestTimeFromOption = (value: string) => {
 </script>
 
 <template>
-  <div class="dropdown" ref="el">
+  <div ref="el" class="dropdown">
     <button
       :id="'tdd-' + props.name + '-toggle'"
       class="btn btn-primary dropdown-toggle"
@@ -155,12 +155,12 @@ const earliestTimeFromOption = (value: string) => {
       {{ btnLabel }}
     </button>
     <button
+      v-show="startTime !== null || endTime !== null"
       :id="'tdd-' + props.name + '-reset'"
-      @click="reset()"
       class="btn btn-secondary"
       type="reset"
       aria-label="Reset time filter"
-      v-show="startTime !== null || endTime !== null"
+      @click="reset()"
     >
       <IconClose />
     </button>
@@ -168,10 +168,10 @@ const earliestTimeFromOption = (value: string) => {
       <h5>Preset range</h5>
       <select
         :id="'tdd-' + props.name + '-preset'"
+        v-model="selectedPreset"
         name="preset-times"
         class="form-select"
         aria-label="Select a time range"
-        v-model="selectedPreset"
       >
         <option
           v-for="item in options"
@@ -188,11 +188,11 @@ const earliestTimeFromOption = (value: string) => {
       <div>
         <label :for="'tdd-' + props.name + '-start-input'">From</label>
         <VueDatePicker
-          time-picker-inline
           :id="'tdd-' + props.name + '-start'"
+          v-model="startTime"
+          time-picker-inline
           :name="'tdd-' + props.name + '-start-input'"
           :format="dateFormat"
-          v-model="startTime"
           placeholder="Start time"
           @update:model-value="handleStartChange"
         />
@@ -200,11 +200,11 @@ const earliestTimeFromOption = (value: string) => {
       <div>
         <label :for="'tdd-' + props.name + '-end-input'">To</label>
         <VueDatePicker
-          time-picker-inline
           :id="'tdd-' + props.name + '-end'"
+          v-model="endTime"
+          time-picker-inline
           :name="'tdd-' + props.name + '-end-input'"
           :format="dateFormat"
-          v-model="endTime"
           placeholder="End time"
           @update:model-value="handleEndChange"
         />

--- a/dashboard/src/components/UUID.vue
+++ b/dashboard/src/components/UUID.vue
@@ -33,10 +33,10 @@ watch(copied, (val) => {
     <template v-if="isSupported">
       <button
         ref="el"
-        @click="copy()"
         class="btn btn-sm btn-link link-secondary p-0"
         data-bs-toggle="tooltip"
         data-bs-title="Copy to clipboard"
+        @click="copy()"
       >
         <!-- Copied visual hint. -->
         <span v-if="copied">

--- a/dashboard/src/components/WorkflowCollapse.vue
+++ b/dashboard/src/components/WorkflowCollapse.vue
@@ -80,10 +80,10 @@ const showTasks = computed(() => {
 
 <template>
   <div class="accordion-item border-0 mb-2">
-    <h4 class="accordion-header" :id="'wf' + index + '-heading'">
+    <h4 :id="'wf' + index + '-heading'" class="accordion-header">
       <button
-        ref="wfBtn"
         v-if="workflow.tasks"
+        ref="wfBtn"
         :class="[
           'accordion-button',
           {
@@ -134,11 +134,11 @@ const showTasks = computed(() => {
       data-bs-parent="#workflows"
     >
       <SipReviewAlert
-        v-model:expandCounter="expandCounter"
         v-if="
           showSipReviewAlert() &&
           authStore.checkAttributes(['ingest:sips:review'])
         "
+        v-model:expand-counter="expandCounter"
       />
       <AipDeletionReviewAlert
         v-if="

--- a/dashboard/src/components/WorkflowHelp.vue
+++ b/dashboard/src/components/WorkflowHelp.vue
@@ -29,7 +29,7 @@ const statuses = [
 ];
 
 const { show = false } = defineProps<{
-  show: boolean;
+  show?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -60,22 +60,22 @@ const emit = defineEmits<{
                 id="workflow-help-close"
                 type="button"
                 class="btn-close align-middle"
-                @click="() => emit('update:show', false)"
                 aria-label="Close"
-              ></button>
+                @click="() => emit('update:show', false)"
+              />
             </div>
           </div>
           <span class="h5">Task status legend</span>
           <div id="task-status-legend" class="container-fluid border p-2 mb-3">
             <div
-              class="row"
               v-for="(item, index) in statuses"
               :key="item.status"
+              class="row"
             >
               <div class="col col-md-2 py-2 text-end">
                 <StatusBadge :status="item.status" type="workflow" />
               </div>
-              <div class="col col-md-10 py-2" :id="`badge-${index}-desc`">
+              <div :id="`badge-${index}-desc`" class="col col-md-10 py-2">
                 {{ item.description }}
               </div>
             </div>

--- a/dashboard/src/components/__tests__/PageLoadingAlert.test.ts
+++ b/dashboard/src/components/__tests__/PageLoadingAlert.test.ts
@@ -24,7 +24,7 @@ describe("PageLoadingAlert.vue", () => {
       <div class="alert alert-warning" role="alert">
         <h4 class="alert-heading">Page not found!</h4>
         <p>We can't find the page you're looking for.</p>
-        <hr><a class="btn btn-warning">Take me home</a>
+        <hr><a class="btn btn-warning"> Take me home </a>
       </div>
       <!-- Other errors. -->
       <!--v-if-->"

--- a/dashboard/src/composables/__tests__/format.test.ts
+++ b/dashboard/src/composables/__tests__/format.test.ts
@@ -1,39 +1,39 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  FormatDateTime,
-  FormatDateTimeString,
-  FormatDuration,
+  formatDateTime,
+  formatDateTimeString,
+  formatDuration,
   humanFileSize,
 } from "../format";
 
 describe("formatDateTime", () => {
   it("formats a date object with time", () => {
-    expect(FormatDateTime(new Date("2023-01-15T12:30:45"))).toBe(
+    expect(formatDateTime(new Date("2023-01-15T12:30:45"))).toBe(
       "2023-01-15 12:30:45",
     );
   });
 
   it("formats a date string with time", () => {
-    expect(FormatDateTime(new Date("2023-01-15T12:30:45"))).toBe(
+    expect(formatDateTime(new Date("2023-01-15T12:30:45"))).toBe(
       "2023-01-15 12:30:45",
     );
   });
 
   it("returns an empty string for undefined input", () => {
-    expect(FormatDateTime(undefined)).toBe("");
+    expect(formatDateTime(undefined)).toBe("");
   });
 });
 
 describe("formatDateTimeString", () => {
   it("formats a valid date string", () => {
-    expect(FormatDateTimeString("2023-01-15T12:30:45")).toBe(
+    expect(formatDateTimeString("2023-01-15T12:30:45")).toBe(
       "2023-01-15 12:30:45",
     );
   });
 
   it("returns 'Invalid date' for an invalid date string", () => {
-    expect(FormatDateTimeString("invalid-date")).toBe("Invalid date");
+    expect(formatDateTimeString("invalid-date")).toBe("Invalid date");
   });
 });
 
@@ -41,13 +41,13 @@ describe("formatDuration", () => {
   it("formats duration between two dates", () => {
     const from = new Date("2023-01-15T12:00:00Z");
     const to = new Date("2023-01-15T14:03:00Z");
-    expect(FormatDuration(from, to)).toBe("2 hours");
+    expect(formatDuration(from, to)).toBe("2 hours");
   });
 
   it("handles durations less than a minute", () => {
     const from = new Date("2023-01-15T12:00:00Z");
     const to = new Date("2023-01-15T12:00:30Z");
-    expect(FormatDuration(from, to)).toBe("a few seconds");
+    expect(formatDuration(from, to)).toBe("a few seconds");
   });
 });
 

--- a/dashboard/src/composables/format.ts
+++ b/dashboard/src/composables/format.ts
@@ -1,18 +1,18 @@
 import moment from "moment";
 
-export function FormatDateTime(value: Date | undefined) {
+export function formatDateTime(value: Date | undefined) {
   if (!value || Number.isNaN(value.getTime())) {
     return "";
   }
   return moment(value).format("YYYY-MM-DD HH:mm:ss");
 }
 
-export function FormatDateTimeString(value: string) {
+export function formatDateTimeString(value: string) {
   const date = new Date(value);
   return moment(date).format("YYYY-MM-DD HH:mm:ss");
 }
 
-export function FormatDuration(from: Date, to: Date) {
+export function formatDuration(from: Date, to: Date) {
   const diff = moment(to).diff(from);
   return moment.duration(diff).humanize();
 }

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -8,9 +8,9 @@ import { PromiseDialog } from "vue3-promise-dialog";
 import App from "./App.vue";
 import { api } from "./client";
 import {
-  FormatDateTime,
-  FormatDateTimeString,
-  FormatDuration,
+  formatDateTime,
+  formatDateTimeString,
+  formatDuration,
 } from "./composables/format";
 import router from "./router";
 
@@ -36,13 +36,13 @@ declare module "@vue/runtime-core" {
 
 app.config.globalProperties.$filters = {
   formatDateTimeString(value: string) {
-    return FormatDateTimeString(value);
+    return formatDateTimeString(value);
   },
   formatDateTime(value: Date | undefined) {
-    return FormatDateTime(value);
+    return formatDateTime(value);
   },
   formatDuration(from: Date, to: Date) {
-    return FormatDuration(from, to);
+    return formatDuration(from, to);
   },
   getWorkflowLabel(
     value:

--- a/dashboard/src/pages/[...path].vue
+++ b/dashboard/src/pages/[...path].vue
@@ -10,9 +10,9 @@ useLayoutStore().updateBreadcrumb([{ text: "Not found" }]);
       <h4 class="alert-heading">Page not found!</h4>
       <p>We can't find the page you're looking for.</p>
       <hr />
-      <router-link class="btn btn-warning" :to="{ name: '/' }"
-        >Take me home</router-link
-      >
+      <RouterLink class="btn btn-warning" :to="{ name: '/' }">
+        Take me home
+      </RouterLink>
     </div>
   </div>
 </template>

--- a/dashboard/src/pages/index.vue
+++ b/dashboard/src/pages/index.vue
@@ -44,7 +44,7 @@ onMounted(async () => {
       <div v-else-if="error" class="alert alert-warning" role="alert">
         {{ error }}
       </div>
-      <div v-else-if="content" v-html="content"></div>
+      <div v-else-if="content" v-html="content" />
     </template>
 
     <!-- Default content -->

--- a/dashboard/src/pages/ingest.vue
+++ b/dashboard/src/pages/ingest.vue
@@ -1,3 +1,3 @@
 <template>
-  <router-view></router-view>
+  <RouterView />
 </template>

--- a/dashboard/src/pages/ingest/sips.vue
+++ b/dashboard/src/pages/ingest/sips.vue
@@ -1,3 +1,3 @@
 <template>
-  <router-view></router-view>
+  <RouterView />
 </template>

--- a/dashboard/src/pages/ingest/sips/[id].vue
+++ b/dashboard/src/pages/ingest/sips/[id].vue
@@ -46,12 +46,12 @@ const tabs = [
 
     <SipPendingAlert v-if="sipStore.current" />
 
-    <h1 class="d-flex mb-3" v-if="sipStore.current">
+    <h1 v-if="sipStore.current" class="d-flex mb-3">
       <IconSIPs class="me-3 text-dark" />{{ sipStore.current.name }}
     </h1>
 
     <Tabs :tabs="tabs" param="id" />
 
-    <router-view></router-view>
+    <RouterView />
   </div>
 </template>

--- a/dashboard/src/pages/ingest/sips/[id]/index.vue
+++ b/dashboard/src/pages/ingest/sips/[id]/index.vue
@@ -83,8 +83,8 @@ onMounted(() => {
         <h2 class="mb-0">
           Ingest workflow details
           <a
-            ref="el"
             id="workflowHelpToggle"
+            ref="el"
             href="#workflowHelp"
             role="button"
             aria-expanded="false"
@@ -102,13 +102,13 @@ onMounted(() => {
       />
       <hr />
 
-      <div class="accordion mb-2" id="workflows">
+      <div id="workflows" class="accordion mb-2">
         <WorkflowCollapse
+          v-for="(workflow, index) in sipStore.currentWorkflows?.workflows"
+          :key="workflow.uuid"
           :workflow="workflow"
           :index="index"
           :of="sipStore.currentWorkflows.workflows.length"
-          v-for="(workflow, index) in sipStore.currentWorkflows?.workflows"
-          v-bind:key="workflow.uuid"
         />
       </div>
     </div>

--- a/dashboard/src/pages/ingest/sips/index.vue
+++ b/dashboard/src/pages/ingest/sips/index.vue
@@ -330,8 +330,8 @@ onMounted(() => {
         <form id="sipSearch" @submit.prevent="searchByName">
           <div class="input-group">
             <input
-              type="text"
               v-model.trim="sipStore.filters.name"
+              type="text"
               class="form-control"
               name="name"
               placeholder="Search by name"
@@ -339,12 +339,12 @@ onMounted(() => {
             />
             <button
               class="btn btn-secondary"
+              type="reset"
+              aria-label="Reset search"
               @click="
                 sipStore.filters.name = '';
                 searchByName();
               "
-              type="reset"
-              aria-label="Reset search"
             >
               <IconClose />
             </button>
@@ -363,7 +363,7 @@ onMounted(() => {
           authStore.checkAttributes(['ingest:users:list']) && userStore.hasUsers
         "
       >
-        <div class="dropdown" ref="uploaderEl">
+        <div ref="uploaderEl" class="dropdown">
           <button
             id="dd-uploader-button"
             class="btn btn-primary dropdown-toggle"
@@ -375,16 +375,16 @@ onMounted(() => {
             {{ uploaderDDLabel }}
           </button>
           <button
+            v-show="sipStore.filters.uploaderId !== ''"
             id="dd-uploader-reset"
+            class="btn btn-secondary"
+            type="reset"
+            aria-label="Reset 'Ingested by' filter"
             @click="
               sipStore.filters.uploaderId = '';
               uploaderDDLabel = 'Ingested by';
               updateUploaderFilter();
             "
-            class="btn btn-secondary"
-            type="reset"
-            aria-label="Reset 'Ingested by' filter"
-            v-show="sipStore.filters.uploaderId !== ''"
           >
             <IconClose />
           </button>
@@ -396,12 +396,12 @@ onMounted(() => {
             >
               <a
                 class="dropdown-item"
+                href="#"
                 @click.prevent="
                   sipStore.filters.uploaderId = user.uuid;
                   uploaderDDLabel = userStore.getHandle(user);
                   updateUploaderFilter();
                 "
-                href="#"
                 >{{ userStore.getHandle(user) }}</a
               >
             </li>
@@ -446,9 +446,9 @@ onMounted(() => {
                   ref="el"
                   class="btn btn-sm btn-link text-decoration-none ms-auto p-0"
                   type="button"
-                  @click="toggleLegend"
                   data-bs-toggle="tooltip"
                   data-bs-title="Toggle legend"
+                  @click="toggleLegend"
                 >
                   <IconInfo style="font-size: 1.2em" aria-hidden="true" />
                   <span class="visually-hidden">Toggle SIP status legend</span>
@@ -460,16 +460,19 @@ onMounted(() => {
         <tbody>
           <tr v-for="sip in sipStore.sips" :key="sip.uuid">
             <td>
-              <router-link
+              <RouterLink
                 v-if="authStore.checkAttributes(['ingest:sips:read'])"
                 :to="{ name: '/ingest/sips/[id]/', params: { id: sip.uuid } }"
-                >{{ sip.name }}</router-link
               >
+                {{ sip.name }}
+              </RouterLink>
               <span v-else>{{ sip.name }}</span>
             </td>
             <td>{{ uploader(sip) }}</td>
             <td>{{ $filters.formatDateTime(sip.startedAt) }}</td>
-            <td><StatusBadge :status="sip.status" type="package" /></td>
+            <td>
+              <StatusBadge :status="sip.status" type="package" />
+            </td>
           </tr>
         </tbody>
       </table>

--- a/dashboard/src/pages/ingest/upload.vue
+++ b/dashboard/src/pages/ingest/upload.vue
@@ -1,3 +1,3 @@
 <template>
-  <router-view></router-view>
+  <RouterView />
 </template>

--- a/dashboard/src/pages/storage.vue
+++ b/dashboard/src/pages/storage.vue
@@ -1,3 +1,3 @@
 <template>
-  <router-view></router-view>
+  <RouterView />
 </template>

--- a/dashboard/src/pages/storage/aips.vue
+++ b/dashboard/src/pages/storage/aips.vue
@@ -1,3 +1,3 @@
 <template>
-  <router-view></router-view>
+  <RouterView />
 </template>

--- a/dashboard/src/pages/storage/aips/[id].vue
+++ b/dashboard/src/pages/storage/aips/[id].vue
@@ -48,7 +48,7 @@ const tabs = [
 
       <Tabs :tabs="tabs" param="id" />
 
-      <router-view></router-view>
+      <RouterView />
     </template>
   </div>
 </template>

--- a/dashboard/src/pages/storage/aips/[id]/index.vue
+++ b/dashboard/src/pages/storage/aips/[id]/index.vue
@@ -60,8 +60,8 @@ onMounted(() => {
         <h2 class="mb-0">
           Workflows
           <a
-            ref="el"
             id="workflowHelpToggle"
+            ref="el"
             href="#workflowHelp"
             role="button"
             aria-expanded="false"
@@ -80,13 +80,13 @@ onMounted(() => {
 
       <hr />
 
-      <div class="accordion mb-2" id="workflows">
+      <div id="workflows" class="accordion mb-2">
         <WorkflowCollapse
+          v-for="(workflow, index) in aipStore.currentWorkflows?.workflows"
+          :key="workflow.uuid"
           :workflow="workflow"
           :index="index"
           :of="aipStore.currentWorkflows.workflows.length"
-          v-for="(workflow, index) in aipStore.currentWorkflows?.workflows"
-          v-bind:key="workflow.uuid"
         />
       </div>
     </div>

--- a/dashboard/src/pages/storage/aips/index.vue
+++ b/dashboard/src/pages/storage/aips/index.vue
@@ -272,8 +272,8 @@ const statuses = [
         <form id="sipSearch" @submit.prevent="searchByName">
           <div class="input-group">
             <input
-              type="text"
               v-model.trim="aipStore.filters.name"
+              type="text"
               class="form-control"
               name="name"
               placeholder="Search by name"
@@ -281,12 +281,12 @@ const statuses = [
             />
             <button
               class="btn btn-secondary"
+              type="reset"
+              aria-label="Reset search"
               @click="
                 aipStore.filters.name = '';
                 searchByName();
               "
-              type="reset"
-              aria-label="Reset search"
             >
               <IconClose />
             </button>
@@ -339,9 +339,9 @@ const statuses = [
                   ref="el"
                   class="btn btn-sm btn-link text-decoration-none ms-auto p-0"
                   type="button"
-                  @click="toggleLegend"
                   data-bs-toggle="tooltip"
                   data-bs-title="Toggle legend"
+                  @click="toggleLegend"
                 >
                   <IconInfo style="font-size: 1.2em" aria-hidden="true" />
                   <span class="visually-hidden">Toggle AIP status legend</span>
@@ -353,17 +353,20 @@ const statuses = [
         <tbody>
           <tr v-for="aip in aipStore.aips" :key="aip.uuid">
             <td>
-              <router-link
+              <RouterLink
                 v-if="authStore.checkAttributes(['storage:aips:read'])"
                 :to="{ name: '/storage/aips/[id]/', params: { id: aip.uuid } }"
-                >{{ aip.name }}</router-link
               >
+                {{ aip.name }}
+              </RouterLink>
               <span v-else>{{ aip.name }}</span>
             </td>
             <td><UUID :id="aip.uuid" /></td>
             <td>{{ $filters.formatDateTime(aip.createdAt) }}</td>
             <td><UUID :id="aip.locationUuid" /></td>
-            <td><StatusBadge :status="aip.status" type="package" /></td>
+            <td>
+              <StatusBadge :status="aip.status" type="package" />
+            </td>
           </tr>
         </tbody>
       </table>

--- a/dashboard/src/pages/storage/locations.vue
+++ b/dashboard/src/pages/storage/locations.vue
@@ -1,3 +1,3 @@
 <template>
-  <router-view></router-view>
+  <RouterView />
 </template>

--- a/dashboard/src/pages/storage/locations/[id].vue
+++ b/dashboard/src/pages/storage/locations/[id].vue
@@ -46,12 +46,12 @@ const tabs = [
   <div class="container-xxl">
     <PageLoadingAlert v-if="error" :execute="execute" :error="error" />
 
-    <h1 class="d-flex mb-3" v-if="locationStore.current">
+    <h1 v-if="locationStore.current" class="d-flex mb-3">
       <IconLocations class="me-3 text-dark" />{{ locationStore.current.name }}
     </h1>
 
     <Tabs :tabs="tabs" param="id" />
 
-    <router-view></router-view>
+    <RouterView />
   </div>
 </template>

--- a/dashboard/src/pages/storage/locations/[id]/aips.vue
+++ b/dashboard/src/pages/storage/locations/[id]/aips.vue
@@ -26,11 +26,12 @@ const locationStore = useLocationStore();
         <tbody>
           <tr v-for="aip in locationStore.currentAips" :key="aip.uuid">
             <td>
-              <router-link
+              <RouterLink
                 v-if="authStore.checkAttributes(['storage:aips:read'])"
                 :to="{ name: '/storage/aips/[id]/', params: { id: aip.uuid } }"
-                >{{ aip.name }}</router-link
               >
+                {{ aip.name }}
+              </RouterLink>
               <span v-else>{{ aip.name }}</span>
             </td>
             <td><UUID :id="aip.uuid" /></td>

--- a/dashboard/src/pages/storage/locations/index.vue
+++ b/dashboard/src/pages/storage/locations/index.vue
@@ -41,14 +41,15 @@ const { execute, error } = useAsyncState(() => {
         <tbody>
           <tr v-for="item in locationStore.locations" :key="item.uuid">
             <td>
-              <router-link
+              <RouterLink
                 v-if="authStore.checkAttributes(['storage:locations:read'])"
                 :to="{
                   name: '/storage/locations/[id]/',
                   params: { id: item.uuid },
                 }"
-                >{{ item.name }}</router-link
               >
+                {{ item.name }}
+              </RouterLink>
               <span v-else>{{ item.name }}</span>
             </td>
             <td><UUID :id="item.uuid" /></td>

--- a/dashboard/src/pages/user.vue
+++ b/dashboard/src/pages/user.vue
@@ -1,3 +1,3 @@
 <template>
-  <router-view></router-view>
+  <RouterView />
 </template>

--- a/dashboard/src/pages/user/signin-callback.vue
+++ b/dashboard/src/pages/user/signin-callback.vue
@@ -7,4 +7,4 @@ useAuthStore()
   .then(() => router.push({ name: "/" }));
 </script>
 
-<template><div></div></template>
+<template><div /></template>

--- a/dashboard/src/pages/user/signout-callback.vue
+++ b/dashboard/src/pages/user/signout-callback.vue
@@ -7,4 +7,4 @@ useAuthStore()
   .then(() => router.push({ name: "/" }));
 </script>
 
-<template><div></div></template>
+<template><div /></template>

--- a/dashboard/typed-misc.d.ts
+++ b/dashboard/typed-misc.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 declare module "vue3-promise-dialog" {
   export const openDialog;
   export const closeDialog;


### PR DESCRIPTION
This commit enables a couple of extra config groups from eslint-plugin-vue
bringing many new [useful rules]. I've also adjusted naming-convention to
be stricter, e.g. funcs only in camelCase.

eslint-plugin-prettier reports formatting violations (eslint no longer
rewrites code in ways that prettier will reformat again), so `npm run lint`
will fail if files aren't formatted. You still need to run `npm run format`
(prettier) to format the code; `npm run format-check` has been removed.

[useful rules]: https://eslint.vuejs.org/rules/

Related: https://github.com/artefactual-sdps/enduro/pull/1385#discussion_r2437292686.