### PR TITLE
Enable revive:package-directory-mismatch linter

### DIFF
--- a/.bine.json
+++ b/.bine.json
@@ -33,7 +33,7 @@
     {
       "name": "golangci-lint",
       "url": "https://github.com/golangci/golangci-lint",
-      "version": "2.4.0",
+      "version": "2.6.2",
       "asset_pattern": "{name}-{version}-{goos}-{goarch}.tar.gz"
     },
     {

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - importas
     - intrange
     - misspell
+    - revive
     - tparallel
     - unparam
   settings:
@@ -24,6 +25,10 @@ linters:
           alias: temporalapi_$1
       no-unaliased: true
       no-extra-aliases: false
+    revive:
+      enable-all-rules: false
+      rules:
+        - name: package-directory-mismatch
   exclusions:
     generated: lax
     presets:

--- a/internal/persistence/ent/client/batch.go
+++ b/internal/persistence/ent/client/batch.go
@@ -1,4 +1,4 @@
-package entclient
+package client
 
 import (
 	"context"

--- a/internal/persistence/ent/client/batch_test.go
+++ b/internal/persistence/ent/client/batch_test.go
@@ -1,4 +1,4 @@
-package entclient_test
+package client_test
 
 import (
 	"database/sql"

--- a/internal/persistence/ent/client/client.go
+++ b/internal/persistence/ent/client/client.go
@@ -1,4 +1,4 @@
-package entclient
+package client
 
 import (
 	"github.com/go-logr/logr"

--- a/internal/persistence/ent/client/client_test.go
+++ b/internal/persistence/ent/client/client_test.go
@@ -1,4 +1,4 @@
-package entclient_test
+package client_test
 
 import (
 	"fmt"

--- a/internal/persistence/ent/client/convert.go
+++ b/internal/persistence/ent/client/convert.go
@@ -1,4 +1,4 @@
-package entclient
+package client
 
 import (
 	"database/sql"

--- a/internal/persistence/ent/client/errors.go
+++ b/internal/persistence/ent/client/errors.go
@@ -1,4 +1,4 @@
-package entclient
+package client
 
 import (
 	"fmt"

--- a/internal/persistence/ent/client/sip.go
+++ b/internal/persistence/ent/client/sip.go
@@ -1,4 +1,4 @@
-package entclient
+package client
 
 import (
 	"context"

--- a/internal/persistence/ent/client/sip_test.go
+++ b/internal/persistence/ent/client/sip_test.go
@@ -1,4 +1,4 @@
-package entclient_test
+package client_test
 
 import (
 	"database/sql"

--- a/internal/persistence/ent/client/task.go
+++ b/internal/persistence/ent/client/task.go
@@ -1,4 +1,4 @@
-package entclient
+package client
 
 import (
 	"context"

--- a/internal/persistence/ent/client/task_test.go
+++ b/internal/persistence/ent/client/task_test.go
@@ -1,4 +1,4 @@
-package entclient_test
+package client_test
 
 import (
 	"database/sql"

--- a/internal/persistence/ent/client/tx.go
+++ b/internal/persistence/ent/client/tx.go
@@ -1,4 +1,4 @@
-package entclient
+package client
 
 import (
 	"fmt"

--- a/internal/persistence/ent/client/user.go
+++ b/internal/persistence/ent/client/user.go
@@ -1,4 +1,4 @@
-package entclient
+package client
 
 import (
 	"context"

--- a/internal/persistence/ent/client/user_test.go
+++ b/internal/persistence/ent/client/user_test.go
@@ -1,4 +1,4 @@
-package entclient_test
+package client_test
 
 import (
 	"testing"

--- a/internal/persistence/ent/client/workflow.go
+++ b/internal/persistence/ent/client/workflow.go
@@ -1,4 +1,4 @@
-package entclient
+package client
 
 import (
 	"context"

--- a/internal/persistence/ent/client/workflow_test.go
+++ b/internal/persistence/ent/client/workflow_test.go
@@ -1,4 +1,4 @@
-package entclient_test
+package client_test
 
 import (
 	"database/sql"


### PR DESCRIPTION
While revisiting https://github.com/artefactual-sdps/enduro/pull/1048, I noticed that the internal package `github.com/artefactual-sdps/enduro/internal/persistence/ent/client` declares its name as `entclient` instead of `client`. Go allows this kind of mismatch, but it can be misleading. I've enabled the [`package-directory-mismatch`](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#package-directory-mismatch) rule in revive to warn us if this happens again.