### PR TITLE
Wait for Batch signal after SIP validation

### DIFF
--- a/dashboard/src/components/StatusBadge.vue
+++ b/dashboard/src/components/StatusBadge.vue
@@ -46,6 +46,12 @@ const packageStyle: {
   processing: ["text-dark", "bg-info-subtle", "border border-2 border-info"],
   pending: ["text-dark", "bg-warning-subtle", "border border-2 border-warning"],
   unspecified: ["text-dark", "bg-dark-subtle", "border border-2 border-dark"],
+  validated: [
+    "text-dark",
+    "bg-success-subtle",
+    "border border-2 border-success",
+  ],
+  canceled: ["text-dark", "bg-dark-subtle", "border border-2 border-dark"],
 };
 
 const workflowStyle: {

--- a/dashboard/src/openapi-generator/apis/IngestApi.ts
+++ b/dashboard/src/openapi-generator/apis/IngestApi.ts
@@ -293,7 +293,7 @@ export interface IngestApiInterface {
      * @param {string} [aipUuid] Identifier of AIP
      * @param {Date} [earliestCreatedTime] 
      * @param {Date} [latestCreatedTime] 
-     * @param {'error' | 'failed' | 'queued' | 'processing' | 'pending' | 'ingested'} [status] 
+     * @param {'error' | 'failed' | 'queued' | 'processing' | 'pending' | 'ingested' | 'validated' | 'canceled'} [status] 
      * @param {string} [uploaderUuid] UUID of the SIP uploader
      * @param {string} [batchUuid] UUID of the related Batch
      * @param {number} [limit] Limit number of results to return
@@ -1163,6 +1163,8 @@ export const IngestListSipsStatusEnum = {
     Queued: 'queued',
     Processing: 'processing',
     Pending: 'pending',
-    Ingested: 'ingested'
+    Ingested: 'ingested',
+    Validated: 'validated',
+    Canceled: 'canceled'
 } as const;
 export type IngestListSipsStatusEnum = typeof IngestListSipsStatusEnum[keyof typeof IngestListSipsStatusEnum];

--- a/dashboard/src/openapi-generator/models/EnduroIngestSip.ts
+++ b/dashboard/src/openapi-generator/models/EnduroIngestSip.ts
@@ -143,7 +143,9 @@ export const EnduroIngestSipStatusEnum = {
     Queued: 'queued',
     Processing: 'processing',
     Pending: 'pending',
-    Ingested: 'ingested'
+    Ingested: 'ingested',
+    Validated: 'validated',
+    Canceled: 'canceled'
 } as const;
 export type EnduroIngestSipStatusEnum = typeof EnduroIngestSipStatusEnum[keyof typeof EnduroIngestSipStatusEnum];
 

--- a/dashboard/src/openapi-generator/models/EnduroIngestSipWorkflow.ts
+++ b/dashboard/src/openapi-generator/models/EnduroIngestSipWorkflow.ts
@@ -87,7 +87,8 @@ export const EnduroIngestSipWorkflowStatusEnum = {
     Error: 'error',
     Queued: 'queued',
     Pending: 'pending',
-    Failed: 'failed'
+    Failed: 'failed',
+    Canceled: 'canceled'
 } as const;
 export type EnduroIngestSipWorkflowStatusEnum = typeof EnduroIngestSipWorkflowStatusEnum[keyof typeof EnduroIngestSipWorkflowStatusEnum];
 

--- a/dashboard/src/openapi-generator/models/IngestEventValue.ts
+++ b/dashboard/src/openapi-generator/models/IngestEventValue.ts
@@ -122,7 +122,9 @@ export const IngestEventValueStatusEnum = {
     Queued: 'queued',
     Processing: 'processing',
     Pending: 'pending',
-    Ingested: 'ingested'
+    Ingested: 'ingested',
+    Validated: 'validated',
+    Canceled: 'canceled'
 } as const;
 export type IngestEventValueStatusEnum = typeof IngestEventValueStatusEnum[keyof typeof IngestEventValueStatusEnum];
 

--- a/dashboard/src/openapi-generator/models/SIPStatusUpdatedEvent.ts
+++ b/dashboard/src/openapi-generator/models/SIPStatusUpdatedEvent.ts
@@ -43,7 +43,9 @@ export const SIPStatusUpdatedEventStatusEnum = {
     Queued: 'queued',
     Processing: 'processing',
     Pending: 'pending',
-    Ingested: 'ingested'
+    Ingested: 'ingested',
+    Validated: 'validated',
+    Canceled: 'canceled'
 } as const;
 export type SIPStatusUpdatedEventStatusEnum = typeof SIPStatusUpdatedEventStatusEnum[keyof typeof SIPStatusUpdatedEventStatusEnum];
 

--- a/docs/src/dev-manual/api/openapi3.json
+++ b/docs/src/dev-manual/api/openapi3.json
@@ -1006,7 +1006,9 @@
               "queued",
               "processing",
               "pending",
-              "ingested"
+              "ingested",
+              "validated",
+              "canceled"
             ],
             "example": "failed",
             "type": "string"
@@ -1148,7 +1150,8 @@
               "error",
               "queued",
               "pending",
-              "failed"
+              "failed",
+              "canceled"
             ],
             "example": "in progress",
             "type": "string"
@@ -2432,7 +2435,9 @@
               "queued",
               "processing",
               "pending",
-              "ingested"
+              "ingested",
+              "validated",
+              "canceled"
             ],
             "example": "failed",
             "type": "string"
@@ -3667,7 +3672,9 @@
                 "queued",
                 "processing",
                 "pending",
-                "ingested"
+                "ingested",
+                "validated",
+                "canceled"
               ],
               "example": "failed",
               "type": "string"

--- a/internal/api/gen/http/ingest/client/cli.go
+++ b/internal/api/gen/http/ingest/client/cli.go
@@ -91,8 +91,8 @@ func BuildListSipsPayload(ingestListSipsName string, ingestListSipsAipUUID strin
 	{
 		if ingestListSipsStatus != "" {
 			status = &ingestListSipsStatus
-			if !(*status == "error" || *status == "failed" || *status == "queued" || *status == "processing" || *status == "pending" || *status == "ingested") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("status", *status, []any{"error", "failed", "queued", "processing", "pending", "ingested"}))
+			if !(*status == "error" || *status == "failed" || *status == "queued" || *status == "processing" || *status == "pending" || *status == "ingested" || *status == "validated" || *status == "canceled") {
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("status", *status, []any{"error", "failed", "queued", "processing", "pending", "ingested", "validated", "canceled"}))
 			}
 			if err != nil {
 				return nil, err

--- a/internal/api/gen/http/ingest/client/types.go
+++ b/internal/api/gen/http/ingest/client/types.go
@@ -2741,8 +2741,8 @@ func ValidateSIPResponseBody(body *SIPResponseBody) (err error) {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
 	}
 	if body.Status != nil {
-		if !(*body.Status == "error" || *body.Status == "failed" || *body.Status == "queued" || *body.Status == "processing" || *body.Status == "pending" || *body.Status == "ingested") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.status", *body.Status, []any{"error", "failed", "queued", "processing", "pending", "ingested"}))
+		if !(*body.Status == "error" || *body.Status == "failed" || *body.Status == "queued" || *body.Status == "processing" || *body.Status == "pending" || *body.Status == "ingested" || *body.Status == "validated" || *body.Status == "canceled") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.status", *body.Status, []any{"error", "failed", "queued", "processing", "pending", "ingested", "validated", "canceled"}))
 		}
 	}
 	if body.AipUUID != nil {
@@ -2825,8 +2825,8 @@ func ValidateSIPWorkflowResponseBody(body *SIPWorkflowResponseBody) (err error) 
 		}
 	}
 	if body.Status != nil {
-		if !(*body.Status == "unspecified" || *body.Status == "in progress" || *body.Status == "done" || *body.Status == "error" || *body.Status == "queued" || *body.Status == "pending" || *body.Status == "failed") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.status", *body.Status, []any{"unspecified", "in progress", "done", "error", "queued", "pending", "failed"}))
+		if !(*body.Status == "unspecified" || *body.Status == "in progress" || *body.Status == "done" || *body.Status == "error" || *body.Status == "queued" || *body.Status == "pending" || *body.Status == "failed" || *body.Status == "canceled") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.status", *body.Status, []any{"unspecified", "in progress", "done", "error", "queued", "pending", "failed", "canceled"}))
 		}
 	}
 	if body.StartedAt != nil {

--- a/internal/api/gen/http/ingest/server/encode_decode.go
+++ b/internal/api/gen/http/ingest/server/encode_decode.go
@@ -238,8 +238,8 @@ func DecodeListSipsRequest(mux goahttp.Muxer, decoder func(*http.Request) goahtt
 			status = &statusRaw
 		}
 		if status != nil {
-			if !(*status == "error" || *status == "failed" || *status == "queued" || *status == "processing" || *status == "pending" || *status == "ingested") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("status", *status, []any{"error", "failed", "queued", "processing", "pending", "ingested"}))
+			if !(*status == "error" || *status == "failed" || *status == "queued" || *status == "processing" || *status == "pending" || *status == "ingested" || *status == "validated" || *status == "canceled") {
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("status", *status, []any{"error", "failed", "queued", "processing", "pending", "ingested", "validated", "canceled"}))
 			}
 		}
 		uploaderUUIDRaw := qp.Get("uploader_uuid")

--- a/internal/api/gen/http/openapi.json
+++ b/internal/api/gen/http/openapi.json
@@ -751,7 +751,9 @@
             "queued",
             "processing",
             "pending",
-            "ingested"
+            "ingested",
+            "validated",
+            "canceled"
           ],
           "example": "failed",
           "type": "string"
@@ -3059,7 +3061,9 @@
             "queued",
             "processing",
             "pending",
-            "ingested"
+            "ingested",
+            "validated",
+            "canceled"
           ],
           "example": "failed",
           "type": "string"
@@ -3301,7 +3305,8 @@
             "error",
             "queued",
             "pending",
-            "failed"
+            "failed",
+            "canceled"
           ],
           "example": "in progress",
           "type": "string"
@@ -5317,7 +5322,9 @@
               "queued",
               "processing",
               "pending",
-              "ingested"
+              "ingested",
+              "validated",
+              "canceled"
             ],
             "in": "query",
             "name": "status",

--- a/internal/api/gen/http/openapi.yaml
+++ b/internal/api/gen/http/openapi.yaml
@@ -385,6 +385,8 @@ paths:
                     - processing
                     - pending
                     - ingested
+                    - validated
+                    - canceled
                 - name: uploader_uuid
                   in: query
                   description: UUID of the SIP uploader
@@ -2466,6 +2468,8 @@ definitions:
                     - processing
                     - pending
                     - ingested
+                    - validated
+                    - canceled
             uploader_email:
                 type: string
                 description: Email of the user who uploaded the SIP
@@ -4309,6 +4313,8 @@ definitions:
                     - processing
                     - pending
                     - ingested
+                    - validated
+                    - canceled
             uploader_email:
                 type: string
                 description: Email of the user who uploaded the SIP
@@ -4497,6 +4503,7 @@ definitions:
                     - queued
                     - pending
                     - failed
+                    - canceled
             tasks:
                 $ref: '#/definitions/SIPTaskResponseBodyCollection'
             temporal_id:

--- a/internal/api/gen/http/openapi3.json
+++ b/internal/api/gen/http/openapi3.json
@@ -1006,7 +1006,9 @@
               "queued",
               "processing",
               "pending",
-              "ingested"
+              "ingested",
+              "validated",
+              "canceled"
             ],
             "example": "failed",
             "type": "string"
@@ -1148,7 +1150,8 @@
               "error",
               "queued",
               "pending",
-              "failed"
+              "failed",
+              "canceled"
             ],
             "example": "in progress",
             "type": "string"
@@ -2432,7 +2435,9 @@
               "queued",
               "processing",
               "pending",
-              "ingested"
+              "ingested",
+              "validated",
+              "canceled"
             ],
             "example": "failed",
             "type": "string"
@@ -3667,7 +3672,9 @@
                 "queued",
                 "processing",
                 "pending",
-                "ingested"
+                "ingested",
+                "validated",
+                "canceled"
               ],
               "example": "failed",
               "type": "string"

--- a/internal/api/gen/http/openapi3.yaml
+++ b/internal/api/gen/http/openapi3.yaml
@@ -538,6 +538,8 @@ paths:
                         - processing
                         - pending
                         - ingested
+                        - validated
+                        - canceled
                   example: failed
                 - name: uploader_uuid
                   in: query
@@ -3311,6 +3313,8 @@ components:
                         - processing
                         - pending
                         - ingested
+                        - validated
+                        - canceled
                 uploader_email:
                     type: string
                     description: Email of the user who uploaded the SIP
@@ -3425,6 +3429,7 @@ components:
                         - queued
                         - pending
                         - failed
+                        - canceled
                 tasks:
                     $ref: '#/components/schemas/SIPTaskCollection'
                 temporal_id:
@@ -4415,6 +4420,8 @@ components:
                         - processing
                         - pending
                         - ingested
+                        - validated
+                        - canceled
                 uuid:
                     type: string
                     description: Identifier of SIP

--- a/internal/api/gen/ingest/views/view.go
+++ b/internal/api/gen/ingest/views/view.go
@@ -749,8 +749,8 @@ func ValidateSIPView(result *SIPView) (err error) {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "result"))
 	}
 	if result.Status != nil {
-		if !(*result.Status == "error" || *result.Status == "failed" || *result.Status == "queued" || *result.Status == "processing" || *result.Status == "pending" || *result.Status == "ingested") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("result.status", *result.Status, []any{"error", "failed", "queued", "processing", "pending", "ingested"}))
+		if !(*result.Status == "error" || *result.Status == "failed" || *result.Status == "queued" || *result.Status == "processing" || *result.Status == "pending" || *result.Status == "ingested" || *result.Status == "validated" || *result.Status == "canceled") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("result.status", *result.Status, []any{"error", "failed", "queued", "processing", "pending", "ingested", "validated", "canceled"}))
 		}
 	}
 	if result.AipUUID != nil {
@@ -800,8 +800,8 @@ func ValidateSIPStatusUpdatedEventView(result *SIPStatusUpdatedEventView) (err e
 		err = goa.MergeErrors(err, goa.MissingFieldError("status", "result"))
 	}
 	if result.Status != nil {
-		if !(*result.Status == "error" || *result.Status == "failed" || *result.Status == "queued" || *result.Status == "processing" || *result.Status == "pending" || *result.Status == "ingested") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("result.status", *result.Status, []any{"error", "failed", "queued", "processing", "pending", "ingested"}))
+		if !(*result.Status == "error" || *result.Status == "failed" || *result.Status == "queued" || *result.Status == "processing" || *result.Status == "pending" || *result.Status == "ingested" || *result.Status == "validated" || *result.Status == "canceled") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("result.status", *result.Status, []any{"error", "failed", "queued", "processing", "pending", "ingested", "validated", "canceled"}))
 		}
 	}
 	return
@@ -851,8 +851,8 @@ func ValidateSIPWorkflowViewSimple(result *SIPWorkflowView) (err error) {
 		}
 	}
 	if result.Status != nil {
-		if !(*result.Status == "unspecified" || *result.Status == "in progress" || *result.Status == "done" || *result.Status == "error" || *result.Status == "queued" || *result.Status == "pending" || *result.Status == "failed") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("result.status", *result.Status, []any{"unspecified", "in progress", "done", "error", "queued", "pending", "failed"}))
+		if !(*result.Status == "unspecified" || *result.Status == "in progress" || *result.Status == "done" || *result.Status == "error" || *result.Status == "queued" || *result.Status == "pending" || *result.Status == "failed" || *result.Status == "canceled") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("result.status", *result.Status, []any{"unspecified", "in progress", "done", "error", "queued", "pending", "failed", "canceled"}))
 		}
 	}
 	if result.StartedAt != nil {
@@ -891,8 +891,8 @@ func ValidateSIPWorkflowView(result *SIPWorkflowView) (err error) {
 		}
 	}
 	if result.Status != nil {
-		if !(*result.Status == "unspecified" || *result.Status == "in progress" || *result.Status == "done" || *result.Status == "error" || *result.Status == "queued" || *result.Status == "pending" || *result.Status == "failed") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("result.status", *result.Status, []any{"unspecified", "in progress", "done", "error", "queued", "pending", "failed"}))
+		if !(*result.Status == "unspecified" || *result.Status == "in progress" || *result.Status == "done" || *result.Status == "error" || *result.Status == "queued" || *result.Status == "pending" || *result.Status == "failed" || *result.Status == "canceled") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("result.status", *result.Status, []any{"unspecified", "in progress", "done", "error", "queued", "pending", "failed", "canceled"}))
 		}
 	}
 	if result.StartedAt != nil {

--- a/internal/db/migrations/20251124204400_add_sip_statuses.up.sql
+++ b/internal/db/migrations/20251124204400_add_sip_statuses.up.sql
@@ -1,0 +1,2 @@
+-- Modify "sip" table
+ALTER TABLE `sip` MODIFY COLUMN `status` enum('error','failed','queued','processing','pending','ingested','validated','canceled') NOT NULL;

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:hXMeh9Hrl/RQVQS3Y9gsIrVgVKzJc9KLnxbgWXXbJ5c=
+h1:+w0cFlo2J6po1A+Xh2d1s3AOIbBR68sVVU6MdKrVrX0=
 1570659451_init.up.sql h1:zyiKKl39RqMxuEhop5jeeiPTxPiSSq00Tn6u06gyNmk=
 1710442322_nullable_aip_id.up.sql h1:vL4eG5YELXr3k4ymhHuRD/R7KpNt3/DNRhH26t83x3A=
 20250207193001_rename_package_table.up.sql h1:d2RjfIturPoFYMMtFocrMvvjEXEqDXDdxQRttcknX/0=
@@ -17,3 +17,4 @@ h1:hXMeh9Hrl/RQVQS3Y9gsIrVgVKzJc9KLnxbgWXXbJ5c=
 20250807063231_add_unique_index_to_user.up.sql h1:6Jj6qFG61OnlYoVVPEX5VT0La74WqoT7bRuqONZxF5c=
 20251114163946_add_batch_table.up.sql h1:cvMYRBO1l4OfFdrNWmc9H2GK0oP4S4OU78Tk/JTyWqs=
 20251121205505_add_batch_failed_status.up.sql h1:jfxlOIIF7+9jpPsCcm0GZ4KNt2+tcm8AaWmO+DWqaOU=
+20251124204400_add_sip_statuses.up.sql h1:EmniCLIzTUvVmmWfX7rQ75ZmO33v+hv3OlCP6ToRLPo=

--- a/internal/enums/sip_status.go
+++ b/internal/enums/sip_status.go
@@ -8,6 +8,8 @@ queued       // Awaiting resource allocation.
 processing   // Undergoing work.
 pending      // Awaiting user decision.
 ingested     // Successfully ingested.
+validated	 // Passed validation, waiting for other SIPs in the Batch.
+canceled     // Canceled as part of a Batch that failed.
 )
 */
 type SIPStatus string

--- a/internal/enums/sip_status_enum.go
+++ b/internal/enums/sip_status_enum.go
@@ -24,6 +24,10 @@ const (
 	SIPStatusPending SIPStatus = "pending"
 	// Successfully ingested.
 	SIPStatusIngested SIPStatus = "ingested"
+	// Passed validation, waiting for other SIPs in the Batch.
+	SIPStatusValidated SIPStatus = "validated"
+	// Canceled as part of a Batch that failed.
+	SIPStatusCanceled SIPStatus = "canceled"
 )
 
 var ErrInvalidSIPStatus = fmt.Errorf("not a valid SIPStatus, try [%s]", strings.Join(_SIPStatusNames, ", "))
@@ -35,6 +39,8 @@ var _SIPStatusNames = []string{
 	string(SIPStatusProcessing),
 	string(SIPStatusPending),
 	string(SIPStatusIngested),
+	string(SIPStatusValidated),
+	string(SIPStatusCanceled),
 }
 
 // SIPStatusNames returns a list of possible string values of SIPStatus.
@@ -63,6 +69,8 @@ var _SIPStatusValue = map[string]SIPStatus{
 	"processing": SIPStatusProcessing,
 	"pending":    SIPStatusPending,
 	"ingested":   SIPStatusIngested,
+	"validated":  SIPStatusValidated,
+	"canceled":   SIPStatusCanceled,
 }
 
 // ParseSIPStatus attempts to convert a string to a SIPStatus.

--- a/internal/enums/workflow_status.go
+++ b/internal/enums/workflow_status.go
@@ -9,6 +9,7 @@ error        // Halted due to a system error.
 queued       // Awaiting resource allocation.
 pending      // Awaiting user decision.
 failed       // Halted due to a policy violation.
+canceled     // Canceled by Batch workflow.
 )
 */
 type WorkflowStatus uint

--- a/internal/enums/workflow_status_enum.go
+++ b/internal/enums/workflow_status_enum.go
@@ -26,11 +26,13 @@ const (
 	WorkflowStatusPending
 	// Halted due to a policy violation.
 	WorkflowStatusFailed
+	// Canceled by Batch workflow.
+	WorkflowStatusCanceled
 )
 
 var ErrInvalidWorkflowStatus = fmt.Errorf("not a valid WorkflowStatus, try [%s]", strings.Join(_WorkflowStatusNames, ", "))
 
-const _WorkflowStatusName = "unspecifiedin progressdoneerrorqueuedpendingfailed"
+const _WorkflowStatusName = "unspecifiedin progressdoneerrorqueuedpendingfailedcanceled"
 
 var _WorkflowStatusNames = []string{
 	_WorkflowStatusName[0:11],
@@ -40,6 +42,7 @@ var _WorkflowStatusNames = []string{
 	_WorkflowStatusName[31:37],
 	_WorkflowStatusName[37:44],
 	_WorkflowStatusName[44:50],
+	_WorkflowStatusName[50:58],
 }
 
 // WorkflowStatusNames returns a list of possible string values of WorkflowStatus.
@@ -57,6 +60,7 @@ var _WorkflowStatusMap = map[WorkflowStatus]string{
 	WorkflowStatusQueued:      _WorkflowStatusName[31:37],
 	WorkflowStatusPending:     _WorkflowStatusName[37:44],
 	WorkflowStatusFailed:      _WorkflowStatusName[44:50],
+	WorkflowStatusCanceled:    _WorkflowStatusName[50:58],
 }
 
 // String implements the Stringer interface.
@@ -82,6 +86,7 @@ var _WorkflowStatusValue = map[string]WorkflowStatus{
 	_WorkflowStatusName[31:37]: WorkflowStatusQueued,
 	_WorkflowStatusName[37:44]: WorkflowStatusPending,
 	_WorkflowStatusName[44:50]: WorkflowStatusFailed,
+	_WorkflowStatusName[50:58]: WorkflowStatusCanceled,
 }
 
 // ParseWorkflowStatus attempts to convert a string to a WorkflowStatus.

--- a/internal/ingest/workflows.go
+++ b/internal/ingest/workflows.go
@@ -14,6 +14,9 @@ import (
 )
 
 const (
+	// BatchSignalName is the name of the signal to continue processing a SIP.
+	BatchSignalName = "batch-signal"
+
 	// BatchWorkflowName is the name of the Batch processing workflow.
 	BatchWorkflowName = "batch-workflow"
 
@@ -25,6 +28,11 @@ const (
 )
 
 type (
+	BatchSignal struct {
+		// Continue indicates whether to continue processing the SIP.
+		Continue bool
+	}
+
 	BatchWorkflowRequest struct {
 		// Batch contains the Batch details.
 		Batch datatypes.Batch
@@ -73,6 +81,9 @@ type (
 		// Extension is the file extension of the original SIP. If it's missing and the SIP
 		// is not a directory, the workflow will try to obtain the value after download.
 		Extension string
+
+		// BatchUUID is the UUID of the batch this SIP belongs to, if any.
+		BatchUUID uuid.UUID
 	}
 
 	ReviewPerformedSignal struct {

--- a/internal/persistence/ent/db/migrate/schema.go
+++ b/internal/persistence/ent/db/migrate/schema.go
@@ -71,7 +71,7 @@ var (
 		{Name: "uuid", Type: field.TypeUUID, Unique: true},
 		{Name: "name", Type: field.TypeString, Size: 2048},
 		{Name: "aip_id", Type: field.TypeUUID, Nullable: true},
-		{Name: "status", Type: field.TypeEnum, Enums: []string{"error", "failed", "queued", "processing", "pending", "ingested"}},
+		{Name: "status", Type: field.TypeEnum, Enums: []string{"error", "failed", "queued", "processing", "pending", "ingested", "validated", "canceled"}},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "started_at", Type: field.TypeTime, Nullable: true},
 		{Name: "completed_at", Type: field.TypeTime, Nullable: true},

--- a/internal/persistence/ent/db/sip/sip.go
+++ b/internal/persistence/ent/db/sip/sip.go
@@ -107,7 +107,7 @@ var (
 // StatusValidator is a validator for the "status" field enum values. It is called by the builders before save.
 func StatusValidator(s enums.SIPStatus) error {
 	switch s.String() {
-	case "error", "failed", "queued", "processing", "pending", "ingested":
+	case "error", "failed", "queued", "processing", "pending", "ingested", "validated", "canceled":
 		return nil
 	default:
 		return fmt.Errorf("sip: invalid enum value for status field: %q", s)

--- a/internal/workflow/processing_expectations_test.go
+++ b/internal/workflow/processing_expectations_test.go
@@ -35,10 +35,11 @@ const (
 	copySIPTaskID    = 100
 	valBagTaskID     = 101
 	valPREMISTaskID  = 102
-	uploadTaskID     = 103
-	reviewAIPTaskID  = 104
-	moveAIPTaskID    = 105
-	deleteSIPTaskID  = 106
+	batchWaitTaskID  = 103
+	uploadTaskID     = 104
+	reviewAIPTaskID  = 105
+	moveAIPTaskID    = 106
+	deleteSIPTaskID  = 107
 	sipName          = "name.zip"
 	key              = "transfer.zip"
 	watcherName      = "watcher"


### PR DESCRIPTION
Add a `BatchUUID` param to the processing workflow request to indicate
the SIP belongs to a Batch. Mark the SIP as validated and wait for Batch
signal in the processing workflow. Set the workflow and SIP statuses to
canceled if the signal indicates to not continue, continue processing
otherwise.

Add `Canceled` status for ingest Workflows and SIPs and `Validated`
status for SIPs.

Refs #1405.

