### PR TITLE
Bump minimum Tilt version to v0.35.0

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,4 +1,4 @@
-version_settings(constraint=">=0.22.2")
+version_settings(constraint=">=0.35.0")
 secret_settings(disable_scrub=True)
 ci_settings(timeout="10m", readiness_timeout="10m")
 load("ext://uibutton", "cmd_button", "text_input")

--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -9,7 +9,7 @@ Kubernetes cluster. It has been tested with k3d, Minikube and Kind.
 
 - [Docker] (v18.09+)
 - [kubectl]
-- [Tilt] (v0.22.2+)
+- [Tilt] (v0.35.0+)
 
 A local Kubernetes cluster:
 


### PR DESCRIPTION
Commit 9f36343 added `ci_settings(readiness_timeout)` to the Tiltfile, which was introduced in Tilt v0.35.0:
https://github.com/tilt-dev/tilt/releases/tag/v0.35.0