### PR TITLE
Add poll SIP statuses activity

### DIFF
--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -488,6 +488,7 @@ func main() {
 			os.Exit(1)
 		}
 
+		// Ingest processing workflow and activities.
 		w.RegisterWorkflowWithOptions(
 			workflow.NewProcessingWorkflow(cfg, rand.Reader, ingestsvc, wsvc).Execute,
 			temporalsdk_workflow.RegisterOptions{Name: ingest.ProcessingWorkflowName},
@@ -513,12 +514,17 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: activities.DisposeOriginalActivityName},
 		)
 
-		// Batch workflow.
+		// Ingest batch workflow and activities.
 		w.RegisterWorkflowWithOptions(
 			workflow.NewBatchWorkflow(cfg, rand.Reader, ingestsvc, temporalClient).Execute,
 			temporalsdk_workflow.RegisterOptions{Name: ingest.BatchWorkflowName},
 		)
+		w.RegisterActivityWithOptions(
+			activities.NewPollSIPStatusesActivity(ingestsvc, time.Second*60).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.PollSIPStatusesActivityName},
+		)
 
+		// Storage workflows and activities.
 		w.RegisterWorkflowWithOptions(
 			storage_workflows.NewStorageDeleteWorkflow(
 				cfg.Storage.AIPDeletion,

--- a/internal/ingest/convert.go
+++ b/internal/ingest/convert.go
@@ -80,7 +80,17 @@ func taskToGoa(task *datatypes.Task) *goaingest.SIPTask {
 func listSipsPayloadToSIPFilter(payload *goaingest.ListSipsPayload) (*persistence.SIPFilter, error) {
 	aipID, err := stringToUUIDPtr(payload.AipUUID)
 	if err != nil {
-		return nil, goaingest.MakeNotValid(errors.New("aip_id: invalid UUID"))
+		return nil, goaingest.MakeNotValid(errors.New("aip_uuid: invalid UUID"))
+	}
+
+	batchID, err := stringToUUIDPtr(payload.BatchUUID)
+	if err != nil {
+		return nil, goaingest.MakeNotValid(errors.New("batch_uuid: invalid UUID"))
+	}
+
+	uploaderID, err := stringToUUIDPtr(payload.UploaderUUID)
+	if err != nil {
+		return nil, goaingest.MakeNotValid(errors.New("uploader_uuid: invalid UUID"))
 	}
 
 	var status *enums.SIPStatus
@@ -97,21 +107,13 @@ func listSipsPayloadToSIPFilter(payload *goaingest.ListSipsPayload) (*persistenc
 		return nil, goaingest.MakeNotValid(fmt.Errorf("created at: %v", err))
 	}
 
-	var uploaderID *uuid.UUID
-	if payload.UploaderUUID != nil {
-		id, err := uuid.Parse(*payload.UploaderUUID)
-		if err != nil {
-			return nil, goaingest.MakeNotValid(errors.New("uploader_id: invalid UUID"))
-		}
-		uploaderID = &id
-	}
-
 	pf := persistence.SIPFilter{
 		AIPID:      aipID,
 		Name:       payload.Name,
 		Status:     status,
 		CreatedAt:  createdAt,
 		UploaderID: uploaderID,
+		BatchID:    batchID,
 		Sort:       entfilter.NewSort().AddCol("id", true),
 		Page: persistence.Page{
 			Limit:  ref.DerefZero(payload.Limit),

--- a/internal/ingest/goa_test.go
+++ b/internal/ingest/goa_test.go
@@ -467,6 +467,7 @@ func TestListSIPs(t *testing.T) {
 				EarliestCreatedTime: ref.New("2024-09-25T09:30:00Z"),
 				LatestCreatedTime:   ref.New("2024-09-25T09:40:00Z"),
 				Status:              ref.New(enums.SIPStatusIngested.String()),
+				BatchUUID:           ref.New("ffdb12f4-1735-4022-b746-a9bf4a32109b"),
 				UploaderUUID:        ref.New("0b075937-458c-43d9-b46c-222a072d62a9"),
 				Limit:               ref.New(10),
 				Offset:              ref.New(1),
@@ -482,6 +483,7 @@ func TestListSIPs(t *testing.T) {
 							End:   time.Date(2024, 9, 25, 9, 40, 0, 0, time.UTC),
 						},
 						Status:     ref.New(enums.SIPStatusIngested),
+						BatchID:    ref.New(uuid.MustParse("ffdb12f4-1735-4022-b746-a9bf4a32109b")),
 						UploaderID: ref.New(uuid.MustParse("0b075937-458c-43d9-b46c-222a072d62a9")),
 						Sort:       entfilter.NewSort().AddCol("id", true),
 						Page: persistence.Page{
@@ -537,11 +539,25 @@ func TestListSIPs(t *testing.T) {
 			wantErr: "not found error",
 		},
 		{
-			name: "Errors on a bad aip_id",
+			name: "Errors on a bad aip_uuid",
 			payload: &goaingest.ListSipsPayload{
 				AipUUID: ref.New("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"),
 			},
-			wantErr: "aip_id: invalid UUID",
+			wantErr: "aip_uuid: invalid UUID",
+		},
+		{
+			name: "Errors on a bad batch_uuid",
+			payload: &goaingest.ListSipsPayload{
+				BatchUUID: ref.New("invalid"),
+			},
+			wantErr: "batch_uuid: invalid UUID",
+		},
+		{
+			name: "Errors on a bad uploader_uuid",
+			payload: &goaingest.ListSipsPayload{
+				UploaderUUID: ref.New("invalid"),
+			},
+			wantErr: "uploader_uuid: invalid UUID",
 		},
 		{
 			name: "Errors on a bad status",
@@ -571,13 +587,6 @@ func TestListSIPs(t *testing.T) {
 				LatestCreatedTime:   ref.New("2023-10-01T17:43:52Z"),
 			},
 			wantErr: "created at: time range: end cannot be before start",
-		},
-		{
-			name: "Errors on a bad uploader_id",
-			payload: &goaingest.ListSipsPayload{
-				UploaderUUID: ref.New("invalid"),
-			},
-			wantErr: "uploader_id: invalid UUID",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/workflow/activities/poll_sip_statuses.go
+++ b/internal/workflow/activities/poll_sip_statuses.go
@@ -1,0 +1,125 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+	"go.artefactual.dev/tools/ref"
+	temporal_tools "go.artefactual.dev/tools/temporal"
+
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	"github.com/artefactual-sdps/enduro/internal/entfilter"
+	"github.com/artefactual-sdps/enduro/internal/enums"
+	"github.com/artefactual-sdps/enduro/internal/ingest"
+)
+
+// finalStatuses lists all SIP statuses that are considered terminal. Any SIP
+// reporting one of these statuses is treated as final by the polling logic,
+// except the caller's ExpectedStatus, which is checked separately for success.
+var finalStatuses = []enums.SIPStatus{
+	enums.SIPStatusIngested,
+	enums.SIPStatusFailed,
+	enums.SIPStatusError,
+	enums.SIPStatusCanceled,
+}
+
+const PollSIPStatusesActivityName = "poll-sip-statuses-activity"
+
+type PollSIPStatusesActivityParams struct {
+	BatchUUID        uuid.UUID
+	ExpectedSIPCount int
+	ExpectedStatus   enums.SIPStatus
+}
+
+type PollSIPStatusesActivityResult struct {
+	AllExpectedStatus bool
+}
+
+// PollSIPStatusesActivity polls the ingest service until all SIPs in a batch
+// reach a final state, failing immediately if the SIP count differs from
+// ExpectedSIPCount or any SIP reports an invalid final status.
+type PollSIPStatusesActivity struct {
+	ingestsvc    ingest.Service
+	pollInterval time.Duration
+}
+
+func NewPollSIPStatusesActivity(ingestsvc ingest.Service, pollInterval time.Duration) *PollSIPStatusesActivity {
+	return &PollSIPStatusesActivity{
+		ingestsvc:    ingestsvc,
+		pollInterval: pollInterval,
+	}
+}
+
+func (a *PollSIPStatusesActivity) Execute(
+	ctx context.Context,
+	params *PollSIPStatusesActivityParams,
+) (*PollSIPStatusesActivityResult, error) {
+	h := temporal_tools.StartAutoHeartbeat(ctx)
+	defer h.Stop()
+
+	ticker := time.NewTicker(a.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			result, err := a.checkSIPStatuses(ctx, params.BatchUUID, params.ExpectedSIPCount, params.ExpectedStatus)
+			if err != nil {
+				return nil, fmt.Errorf("check SIP statuses: %v", err)
+			}
+			if result.done {
+				return &PollSIPStatusesActivityResult{AllExpectedStatus: result.allExpected}, nil
+			}
+		}
+	}
+}
+
+type checkResult struct {
+	done        bool
+	allExpected bool
+}
+
+func (a *PollSIPStatusesActivity) checkSIPStatuses(
+	ctx context.Context,
+	batchUUID uuid.UUID,
+	expectedSIPCount int,
+	expectedStatus enums.SIPStatus,
+) (*checkResult, error) {
+	// Query all SIPs for this batch. Limit to the maximum page size for now,
+	// we may switch to a stats-based or aggregated query approach in the future.
+	result, err := a.ingestsvc.ListSips(ctx, &goaingest.ListSipsPayload{
+		BatchUUID: ref.New(batchUUID.String()),
+		Limit:     ref.New(entfilter.MaxPageSize),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list SIPs: %v", err)
+	}
+
+	// Fail if we don't have the expected number of SIPs.
+	if len(result.Items) != expectedSIPCount {
+		return nil, fmt.Errorf("expected %d SIPs but found %d", expectedSIPCount, len(result.Items))
+	}
+
+	expectedStatusCount := 0
+	for _, sip := range result.Items {
+		status, err := enums.ParseSIPStatus(sip.Status)
+		if err != nil {
+			return nil, fmt.Errorf("parse SIP status: %v", err)
+		}
+
+		// Check if this SIP has the expected status.
+		// If not and it's not in a final status, keep polling.
+		if status == expectedStatus {
+			expectedStatusCount++
+		} else if !slices.Contains(finalStatuses, status) {
+			return &checkResult{done: false}, nil
+		}
+	}
+
+	return &checkResult{done: true, allExpected: expectedStatusCount == expectedSIPCount}, nil
+}

--- a/internal/workflow/activities/poll_sip_statuses_test.go
+++ b/internal/workflow/activities/poll_sip_statuses_test.go
@@ -1,0 +1,193 @@
+package activities_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"go.artefactual.dev/tools/mockutil"
+	"go.artefactual.dev/tools/ref"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	"github.com/artefactual-sdps/enduro/internal/entfilter"
+	"github.com/artefactual-sdps/enduro/internal/enums"
+	ingestfake "github.com/artefactual-sdps/enduro/internal/ingest/fake"
+	"github.com/artefactual-sdps/enduro/internal/workflow/activities"
+)
+
+func TestPollSIPStatusesActivity(t *testing.T) {
+	t.Parallel()
+
+	batchUUID := uuid.New()
+	sip1UUID := uuid.New()
+	sip2UUID := uuid.New()
+	payload := &goaingest.ListSipsPayload{
+		BatchUUID: ref.New(batchUUID.String()),
+		Limit:     ref.New(entfilter.MaxPageSize),
+	}
+
+	type test struct {
+		name    string
+		params  *activities.PollSIPStatusesActivityParams
+		mock    func(*ingestfake.MockServiceMockRecorder)
+		want    *activities.PollSIPStatusesActivityResult
+		wantErr string
+	}
+	for _, tt := range []test{
+		{
+			name: "Returns true when all SIPs have expected status",
+			params: &activities.PollSIPStatusesActivityParams{
+				BatchUUID:        batchUUID,
+				ExpectedSIPCount: 2,
+				ExpectedStatus:   enums.SIPStatusValidated,
+			},
+			mock: func(r *ingestfake.MockServiceMockRecorder) {
+				r.ListSips(mockutil.Context(), payload).
+					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
+						{UUID: sip1UUID, Status: enums.SIPStatusValidated.String()},
+						{UUID: sip2UUID, Status: enums.SIPStatusValidated.String()},
+					}}, nil)
+			},
+			want: &activities.PollSIPStatusesActivityResult{AllExpectedStatus: true},
+		},
+		{
+			name: "Returns false when some SIPs have failed status",
+			params: &activities.PollSIPStatusesActivityParams{
+				BatchUUID:        batchUUID,
+				ExpectedSIPCount: 2,
+				ExpectedStatus:   enums.SIPStatusValidated,
+			},
+			mock: func(r *ingestfake.MockServiceMockRecorder) {
+				r.ListSips(mockutil.Context(), payload).
+					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
+						{UUID: sip1UUID, Status: enums.SIPStatusValidated.String()},
+						{UUID: sip2UUID, Status: enums.SIPStatusFailed.String()},
+					}}, nil)
+			},
+			want: &activities.PollSIPStatusesActivityResult{AllExpectedStatus: false},
+		},
+		{
+			name: "Returns false when some SIPs have error status",
+			params: &activities.PollSIPStatusesActivityParams{
+				BatchUUID:        batchUUID,
+				ExpectedSIPCount: 2,
+				ExpectedStatus:   enums.SIPStatusValidated,
+			},
+			mock: func(r *ingestfake.MockServiceMockRecorder) {
+				r.ListSips(mockutil.Context(), payload).
+					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
+						{UUID: sip1UUID, Status: enums.SIPStatusValidated.String()},
+						{UUID: sip2UUID, Status: enums.SIPStatusError.String()},
+					}}, nil)
+			},
+			want: &activities.PollSIPStatusesActivityResult{AllExpectedStatus: false},
+		},
+		{
+			name: "Returns false when some SIPs have canceled status",
+			params: &activities.PollSIPStatusesActivityParams{
+				BatchUUID:        batchUUID,
+				ExpectedSIPCount: 2,
+				ExpectedStatus:   enums.SIPStatusValidated,
+			},
+			mock: func(r *ingestfake.MockServiceMockRecorder) {
+				r.ListSips(mockutil.Context(), payload).
+					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
+						{UUID: sip1UUID, Status: enums.SIPStatusCanceled.String()},
+						{UUID: sip2UUID, Status: enums.SIPStatusValidated.String()},
+					}}, nil)
+			},
+			want: &activities.PollSIPStatusesActivityResult{AllExpectedStatus: false},
+		},
+		{
+			name: "Continues polling when SIPs are not in a final status",
+			params: &activities.PollSIPStatusesActivityParams{
+				BatchUUID:        batchUUID,
+				ExpectedSIPCount: 2,
+				ExpectedStatus:   enums.SIPStatusValidated,
+			},
+			mock: func(r *ingestfake.MockServiceMockRecorder) {
+				// First call: SIPs in progress.
+				r.ListSips(mockutil.Context(), payload).
+					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
+						{UUID: sip1UUID, Status: enums.SIPStatusProcessing.String()},
+						{UUID: sip2UUID, Status: enums.SIPStatusQueued.String()},
+					}}, nil)
+				// Second call: one SIP validated and the other in progress.
+				r.ListSips(mockutil.Context(), payload).
+					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
+						{UUID: sip1UUID, Status: enums.SIPStatusValidated.String()},
+						{UUID: sip2UUID, Status: enums.SIPStatusProcessing.String()},
+					}}, nil)
+				// Third call: SIPs validated.
+				r.ListSips(mockutil.Context(), payload).
+					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
+						{UUID: sip1UUID, Status: enums.SIPStatusValidated.String()},
+						{UUID: sip2UUID, Status: enums.SIPStatusValidated.String()},
+					}}, nil)
+			},
+			want: &activities.PollSIPStatusesActivityResult{AllExpectedStatus: true},
+		},
+		{
+			name: "Fails when SIP count doesn't match expected",
+			params: &activities.PollSIPStatusesActivityParams{
+				BatchUUID:        batchUUID,
+				ExpectedSIPCount: 3,
+				ExpectedStatus:   enums.SIPStatusValidated,
+			},
+			mock: func(r *ingestfake.MockServiceMockRecorder) {
+				r.ListSips(mockutil.Context(), payload).
+					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
+						{UUID: sip1UUID, Status: enums.SIPStatusValidated.String()},
+						{UUID: sip2UUID, Status: enums.SIPStatusValidated.String()},
+					}}, nil)
+			},
+			wantErr: "check SIP statuses: expected 3 SIPs but found 2",
+		},
+		{
+			name: "Fails when ListSips returns an error",
+			params: &activities.PollSIPStatusesActivityParams{
+				BatchUUID:        batchUUID,
+				ExpectedSIPCount: 2,
+				ExpectedStatus:   enums.SIPStatusValidated,
+			},
+			mock: func(r *ingestfake.MockServiceMockRecorder) {
+				r.ListSips(mockutil.Context(), payload).
+					Return(nil, fmt.Errorf("persistence error"))
+			},
+			wantErr: "check SIP statuses: list SIPs: persistence error",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			ingestsvc := ingestfake.NewMockService(gomock.NewController(t))
+			if tt.mock != nil {
+				tt.mock(ingestsvc.EXPECT())
+			}
+
+			env.RegisterActivityWithOptions(
+				activities.NewPollSIPStatusesActivity(ingestsvc, time.Microsecond).Execute,
+				temporalsdk_activity.RegisterOptions{Name: activities.PollSIPStatusesActivityName},
+			)
+
+			enc, err := env.ExecuteActivity(activities.PollSIPStatusesActivityName, tt.params)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+
+			var res activities.PollSIPStatusesActivityResult
+			err = enc.Get(&res)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, &res, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
This activity will be used in the batch workflow to poll for all SIP statuses at two points, waiting for all SIPs to reach the "validated" and the "ingested" statuses.

Refs #1405.