### PR TITLE
Fix concurrency issues with Archivematica and a3m

### DIFF
--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -223,13 +223,12 @@ func main() {
 
 	// Activity worker.
 	{
-		logger.V(1).Info("a3m worker config", "capacity", cfg.A3m.Capacity)
-
 		done := make(chan struct{})
 		workerOpts := temporalsdk_worker.Options{
-			DisableWorkflowWorker:              true,
-			EnableSessionWorker:                true,
-			MaxConcurrentSessionExecutionSize:  cfg.A3m.Capacity,
+			DisableWorkflowWorker: true,
+			EnableSessionWorker:   true,
+			// Allow only one concurrent session as a3m is not concurrency safe.
+			MaxConcurrentSessionExecutionSize:  1,
 			MaxConcurrentActivityExecutionSize: 1,
 			Interceptors: []temporalsdk_interceptor.WorkerInterceptor{
 				temporal_tools.NewLoggerInterceptor(logger),

--- a/enduro.toml
+++ b/enduro.toml
@@ -173,9 +173,9 @@ user = ""
 apiKey = ""
 processingConfig = "automated"
 
-# capacity limits the number of transfers a worker can process at one time
-# (default: 1)
-capacity = 1
+# capacity limits the number of transfers a worker can start in AM at one time
+# (default: 20)
+capacity = 20
 
 # pollInterval is the time to wait between AM polling requests in a string
 # format compatible with https://pkg.go.dev/time#ParseDuration (Default: 10s).

--- a/enduro.toml
+++ b/enduro.toml
@@ -143,13 +143,12 @@ retentionPeriod = "0"
 [preservation]
 taskqueue = "a3m"
 
+# a3m configuration. There is no capacity setting here like there is for AM, as
+# a3m is not concurrency safe. To enable parallel processing, deploy multiple
+# a3m workers with separate a3m instances.
 [a3m]
 address = "127.0.0.1:7000"
 shareDir = "/home/a3m/.local/share/a3m/share"
-
-# capacity limits the number of transfers a worker can process at one time
-# (default: 1)
-capacity = 1
 
 [a3m.processing]
 AssignUuidsToDirectories = true

--- a/internal/a3m/config.go
+++ b/internal/a3m/config.go
@@ -16,10 +16,6 @@ type Config struct {
 	ShareDir string
 	Address  string
 
-	// Capacity sets the maximum number of worker sessions the worker can
-	// handle at one time (default: 1).
-	Capacity int
-
 	Processing
 }
 

--- a/internal/am/config.go
+++ b/internal/am/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	ZipPIP bool
 
 	// Capacity sets the maximum number of worker sessions the worker can
-	// handle at one time (default: 1).
+	// handle at one time (default: 20).
 	Capacity int
 
 	// PollInterval is the time to wait between poll requests to the AM API.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,7 +100,7 @@ func Read(config *Configuration, configFile string) (found bool, configFileUsed 
 	v.AddConfigPath("/etc")
 	v.SetConfigName("enduro")
 	v.SetDefault("a3m.processing", a3m.ProcessingDefault)
-	v.SetDefault("am.capacity", 1)
+	v.SetDefault("am.capacity", 20)
 	v.SetDefault("am.pollInterval", 10*time.Second)
 	v.SetDefault("api.listen", "127.0.0.1:9000")
 	v.SetDefault("debugListen", "127.0.0.1:9001")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,7 +99,6 @@ func Read(config *Configuration, configFile string) (found bool, configFileUsed 
 	v.AddConfigPath("$HOME/.config/")
 	v.AddConfigPath("/etc")
 	v.SetConfigName("enduro")
-	v.SetDefault("a3m.capacity", 1)
 	v.SetDefault("a3m.processing", a3m.ProcessingDefault)
 	v.SetDefault("am.capacity", 1)
 	v.SetDefault("am.pollInterval", 10*time.Second)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -89,7 +89,7 @@ func TestConfig(t *testing.T) {
 
 		// Valued defaults.
 		assert.Equal(t, c.A3m.Processing, a3m.ProcessingDefault)
-		assert.Equal(t, c.AM.Capacity, 1)
+		assert.Equal(t, c.AM.Capacity, 20)
 		assert.Equal(t, c.AM.PollInterval, 10*time.Second)
 		assert.Equal(t, c.AM.ZipPIP, false)
 		assert.Equal(t, c.API.Listen, "127.0.0.1:9000")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -88,7 +88,6 @@ func TestConfig(t *testing.T) {
 		assert.Equal(t, c.Database.DSN, "")
 
 		// Valued defaults.
-		assert.Equal(t, c.A3m.Capacity, 1)
 		assert.Equal(t, c.A3m.Processing, a3m.ProcessingDefault)
 		assert.Equal(t, c.AM.Capacity, 1)
 		assert.Equal(t, c.AM.PollInterval, 10*time.Second)

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -220,17 +220,18 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 	expectations["setStatus"](s, params)
 
 	// Archivematica specific expectations.
+	baseName := filepath.Base(extractPath)
 	s.env.OnActivity(
 		am.UploadTransferActivityName,
 		sessionCtx,
-		&am.UploadTransferActivityParams{SourcePath: extractPath + "/" + key},
-	).Return(&am.UploadTransferActivityResult{RemoteRelativePath: key}, nil)
+		&am.UploadTransferActivityParams{SourcePath: extractPath + "/"},
+	).Return(&am.UploadTransferActivityResult{RemoteRelativePath: baseName}, nil)
 	s.env.OnActivity(
 		am.StartTransferActivityName,
 		sessionCtx,
 		&am.StartTransferActivityParams{
 			Name:         sipName,
-			RelativePath: key,
+			RelativePath: filepath.Join(baseName, key),
 			ZipPIP:       true,
 		},
 	).Return(&am.StartTransferActivityResult{TransferID: transferID.String()}, nil)
@@ -264,7 +265,7 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 	s.env.OnActivity(
 		am.DeleteTransferActivityName,
 		sessionCtx,
-		&am.DeleteTransferActivityParams{Destination: key},
+		&am.DeleteTransferActivityParams{Destination: baseName},
 	).Return(nil, nil)
 
 	expectations["updateSIPProcessing"](s, params)
@@ -555,7 +556,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPAM() {
 	s.env.OnActivity(
 		am.UploadTransferActivityName,
 		sessionCtx,
-		&am.UploadTransferActivityParams{SourcePath: extractPath + "/transfer.zip"},
+		&am.UploadTransferActivityParams{SourcePath: extractPath + "/"},
 	).Return(nil, fmt.Errorf("AM error"))
 
 	params.removePaths = []string{tempPath, extractPath + "/transfer.zip"}


### PR DESCRIPTION
- Remove capacity configuration from a3m.
- Prevent file collisions in AM transfer source.
- Increase default AM capacity to 10.

Refs #1459 and #1405.