### PR TITLE
Wait for SIPs validation in Batch workflow

### DIFF
--- a/internal/workflow/policies.go
+++ b/internal/workflow/policies.go
@@ -67,3 +67,18 @@ func withLocalActivityOpts(ctx temporalsdk_workflow.Context) temporalsdk_workflo
 		},
 	})
 }
+
+// withActivityOptsForHeartbeatedPolling returns a workflow context with activity
+// options suited for long-running activities that poll with heartbeats.
+func withActivityOptsForHeartbeatedPolling(ctx temporalsdk_workflow.Context) temporalsdk_workflow.Context {
+	return temporalsdk_workflow.WithActivityOptions(ctx, temporalsdk_workflow.ActivityOptions{
+		StartToCloseTimeout:    forever,
+		ScheduleToCloseTimeout: forever,
+		HeartbeatTimeout:       time.Minute,
+		RetryPolicy: &temporalsdk_temporal.RetryPolicy{
+			InitialInterval:    time.Minute,
+			BackoffCoefficient: 1,
+			MaximumAttempts:    10,
+		},
+	})
+}


### PR DESCRIPTION
Poll for SIP statuses until they are all validated or in a final status, signal processing workflows to continue or stop processing. Poll for SIP statuses until they are all ingested or in another final status, update final Batch status based on the final SIP statuses.

Comes from #1456. Refs #1405.