### PR TITLE
Disable login form in Grafana

### DIFF
--- a/hack/kube/overlays/observability/grafana.yaml
+++ b/hack/kube/overlays/observability/grafana.yaml
@@ -47,6 +47,8 @@ data:
     [server]
     domain = ''
     root_url = http://localhost:7490
+    [auth]
+    disable_login_form = true
     [users]
     default_theme = system
     [dashboards]
@@ -54,6 +56,7 @@ data:
     [auth.generic_oauth]
     enabled = true
     name = Keycloak
+    auto_login = true
     allow_sign_up = true
     client_id = grafana
     client_secret = wi8sSTRwP5lA2NuogV5bL6GmIyzVF2HP


### PR DESCRIPTION
This change disables the Grafana username/password login form and redirects users directly to the Keycloak authentication flow.