### PR TITLE
Strip Go binaries by default, with opt‑out for debug builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,7 @@ builds:
   flags:
   - -trimpath
   ldflags:
+  - -s
   - -X "github.com/artefactual-sdps/enduro/internal/version.Long={{ .Version }}-t{{ .ShortCommit }}"
   - -X "github.com/artefactual-sdps/enduro/internal/version.Short={{ .Version }}"
   - -X "github.com/artefactual-sdps/enduro/internal/version.GitCommit={{ .Commit }}"
@@ -34,6 +35,7 @@ builds:
   flags:
   - -trimpath
   ldflags:
+  - -s
   - -X "github.com/artefactual-sdps/enduro/internal/version.Long={{ .Version }}-t{{ .ShortCommit }}"
   - -X "github.com/artefactual-sdps/enduro/internal/version.Short={{ .Version }}"
   - -X "github.com/artefactual-sdps/enduro/internal/version.GitCommit={{ .Commit }}"
@@ -50,6 +52,7 @@ builds:
   flags:
   - -trimpath
   ldflags:
+  - -s
   - -X "github.com/artefactual-sdps/enduro/internal/version.Long={{ .Version }}-t{{ .ShortCommit }}"
   - -X "github.com/artefactual-sdps/enduro/internal/version.Short={{ .Version }}"
   - -X "github.com/artefactual-sdps/enduro/internal/version.GitCommit={{ .Commit }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,14 @@ ARG VERSION_PATH
 ARG VERSION_LONG
 ARG VERSION_SHORT
 ARG VERSION_GIT_HASH
+ARG STRIP=1
 RUN --mount=type=cache,target=/go/pkg/mod \
 	--mount=type=cache,target=/root/.cache/go-build \
+	ldflags="-X '${VERSION_PATH}.Long=${VERSION_LONG}' -X '${VERSION_PATH}.Short=${VERSION_SHORT}' -X '${VERSION_PATH}.GitCommit=${VERSION_GIT_HASH}'" && \
+	if [ "$STRIP" = "1" ]; then ldflags="-s $ldflags"; fi && \
 	go build \
 	-trimpath \
-	-ldflags="-X '${VERSION_PATH}.Long=${VERSION_LONG}' -X '${VERSION_PATH}.Short=${VERSION_SHORT}' -X '${VERSION_PATH}.GitCommit=${VERSION_GIT_HASH}'" \
+	-ldflags="$ldflags" \
 	-o /out/enduro \
 	./cmd/enduro
 
@@ -28,11 +31,14 @@ ARG VERSION_PATH
 ARG VERSION_LONG
 ARG VERSION_SHORT
 ARG VERSION_GIT_HASH
+ARG STRIP=1
 RUN --mount=type=cache,target=/go/pkg/mod \
 	--mount=type=cache,target=/root/.cache/go-build \
+	ldflags="-X '${VERSION_PATH}.Long=${VERSION_LONG}' -X '${VERSION_PATH}.Short=${VERSION_SHORT}' -X '${VERSION_PATH}.GitCommit=${VERSION_GIT_HASH}'" && \
+	if [ "$STRIP" = "1" ]; then ldflags="-s $ldflags"; fi && \
 	go build \
 	-trimpath \
-	-ldflags="-X '${VERSION_PATH}.Long=${VERSION_LONG}' -X '${VERSION_PATH}.Short=${VERSION_SHORT}' -X '${VERSION_PATH}.GitCommit=${VERSION_GIT_HASH}'" \
+	-ldflags="$ldflags" \
 	-o /out/enduro-a3m-worker \
 	./cmd/enduro-a3m-worker
 
@@ -41,11 +47,14 @@ ARG VERSION_PATH
 ARG VERSION_LONG
 ARG VERSION_SHORT
 ARG VERSION_GIT_HASH
+ARG STRIP=1
 RUN --mount=type=cache,target=/go/pkg/mod \
 	--mount=type=cache,target=/root/.cache/go-build \
+	ldflags="-X '${VERSION_PATH}.Long=${VERSION_LONG}' -X '${VERSION_PATH}.Short=${VERSION_SHORT}' -X '${VERSION_PATH}.GitCommit=${VERSION_GIT_HASH}'" && \
+	if [ "$STRIP" = "1" ]; then ldflags="-s $ldflags"; fi && \
 	go build \
 	-trimpath \
-	-ldflags="-X '${VERSION_PATH}.Long=${VERSION_LONG}' -X '${VERSION_PATH}.Short=${VERSION_SHORT}' -X '${VERSION_PATH}.GitCommit=${VERSION_GIT_HASH}'" \
+	-ldflags="$ldflags" \
 	-o /out/enduro-am-worker \
 	./cmd/enduro-am-worker
 

--- a/hack/build_dist.sh
+++ b/hack/build_dist.sh
@@ -8,6 +8,7 @@
 set -eu
 
 MODULE_PATH="${MODULE_PATH:-github.com/artefactual-sdps/enduro}"
+STRIP="${STRIP:-1}"
 
 IFS=".$IFS" read -r major minor patch < internal/version/VERSION.txt
 version_path=${MODULE_PATH}/internal/version
@@ -36,5 +37,8 @@ EOF
 fi
 
 ldflags="-X ${VERSION_PATH}.Long=${LONG} -X ${VERSION_PATH}.Short=${SHORT} -X ${VERSION_PATH}.GitCommit=${GIT_HASH}"
+if [ "$STRIP" = "1" ]; then
+	ldflags="-s $ldflags"
+fi
 
 exec go build -ldflags "$ldflags" "$@"

--- a/hack/build_docker.sh
+++ b/hack/build_docker.sh
@@ -41,6 +41,7 @@ DEFAULT_IMAGE_NAME="${IMAGE_NAME}:${2:-${VERSION_SHORT}}"
 TILT_EXPECTED_REF=${EXPECTED_REF:-}
 IMAGE_NAME="${TILT_EXPECTED_REF:-$DEFAULT_IMAGE_NAME}"
 BUILD_OPTS="${BUILD_OPTS:-}"
+STRIP="${STRIP:-1}"
 
 GO_VERSION=$(grep "^go " go.mod | awk '{print $2}')
 if [ -z "$GO_VERSION" ]; then
@@ -57,5 +58,6 @@ env DOCKER_BUILDKIT=1 docker build \
 	--build-arg="VERSION_LONG=$VERSION_LONG" \
 	--build-arg="VERSION_SHORT=$VERSION_SHORT" \
 	--build-arg="VERSION_GIT_HASH=$VERSION_GIT_HASH" \
+	--build-arg="STRIP=$STRIP" \
 	$BUILD_OPTS \
 	$FOLDER


### PR DESCRIPTION
### Summary
- Added optional stripping (`-s`) to builds to reduce binary size while preserving normal runtime behavior.
- Introduced `STRIP=1` (default) in `hack/build_dist.sh` and Docker builds; set `STRIP=0` to keep full symbols when needed.

### Why
- The project ships three Go binaries, and unstripped builds were ~150MB each due to full symbol/DWARF data.
- Stripping is a low risk optimization for release artifacts; debuggable builds remain available via a toggle.

### Results
- `enduro`: 164MB → 138MB (‑26MB)
- `enduro-a3m-worker`: 148MB → 125MB (‑23MB)
- `enduro-am-worker`: 148MB → 125MB (‑23MB)

### Notes
- Stack traces still include function/file/line info because `pclntab` remains; only DWARF/symbol tables are removed.
- Use `STRIP=0` when you need Delve/core‑dump analysis or richer external profiling.