### PR TITLE
Add more config unit tests

### DIFF
--- a/internal/a3m/config.go
+++ b/internal/a3m/config.go
@@ -20,7 +20,7 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
-	if c.AipCompressionAlgorithm < minCompressionLevel || c.AipCompressionLevel > maxCompressionLevel {
+	if c.AipCompressionLevel < minCompressionLevel || c.AipCompressionLevel > maxCompressionLevel {
 		return fmt.Errorf(
 			"AipCompressionLevel: %d is outside valid range (%d to %d)",
 			c.AipCompressionLevel,

--- a/internal/a3m/config_test.go
+++ b/internal/a3m/config_test.go
@@ -1,0 +1,61 @@
+package a3m_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+
+	"github.com/artefactual-sdps/enduro/internal/config"
+)
+
+func TestConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		name    string
+		config  string
+		wantErr string
+	}
+
+	for _, tc := range []test{
+		{
+			name: "Valid config passes validation",
+			config: `[a3m.processing]
+aipCompressionLevel = 0
+`,
+		},
+		{
+			name: "Error if AipCompressionLevel is less than minimum",
+			config: `[a3m.processing]
+aipCompressionLevel = -1`,
+			wantErr: "failed to validate the provided config: AipCompressionLevel: -1 is outside valid range (0 to 9)",
+		},
+		{
+			name: "Error if AipCompressionLevel is greater than maximum",
+			config: `[a3m.processing]
+aipCompressionLevel = 10`,
+			wantErr: "failed to validate the provided config: AipCompressionLevel: 10 is outside valid range (0 to 9)",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := fs.NewDir(t, "",
+				fs.WithFile("enduro.toml", tc.config),
+			)
+			configFile := tmpDir.Join("enduro.toml")
+
+			var c config.Configuration
+			found, configFileUsed, err := config.Read(&c, configFile)
+			if tc.wantErr != "" {
+				assert.Error(t, err, tc.wantErr)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Equal(t, found, true)
+			assert.Equal(t, configFileUsed, configFile)
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,14 +4,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/artefactual-sdps/temporal-activities/bagcreate"
 	"github.com/google/uuid"
 	"go.artefactual.dev/tools/bucket"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"
 
 	"github.com/artefactual-sdps/enduro/internal/a3m"
+	"github.com/artefactual-sdps/enduro/internal/am"
+	"github.com/artefactual-sdps/enduro/internal/api"
 	"github.com/artefactual-sdps/enduro/internal/api/auth"
 	"github.com/artefactual-sdps/enduro/internal/config"
+	"github.com/artefactual-sdps/enduro/internal/ingest"
+	"github.com/artefactual-sdps/enduro/internal/pres"
+	"github.com/artefactual-sdps/enduro/internal/storage"
 	"github.com/artefactual-sdps/enduro/internal/temporal"
 )
 
@@ -29,148 +35,211 @@ defaultPermanentLocationId = "f2cc963f-c14d-4eaa-b950-bd207189a1f1"
 rolesMapping = '{"admin": ["*"], "operator": ["ingest:sips:list", "ingest:sips:workflows:list", "ingest:sips:read", "ingest:sips:upload"], "readonly": ["ingest:sips:list", "ingest:sips:workflows:list", "ingest:sips:read"]}'
 `
 
-func TestConfig(t *testing.T) {
+func TestConfigRead(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Loads toml configs", func(t *testing.T) {
-		t.Parallel()
-
-		tmpDir := fs.NewDir(
-			t, "",
-			fs.WithFile(
-				"enduro-config.toml",
-				testConfig,
-			),
-		)
-		configFile := tmpDir.Join("enduro-config.toml")
-
-		var c config.Configuration
-		found, configFileUsed, err := config.Read(&c, configFile)
-
-		assert.NilError(t, err)
-		assert.Equal(t, found, true)
-		assert.Equal(t, configFileUsed, configFile)
-		assert.Equal(t, c.Temporal.Address, "host:port")
-
-		// Test that a UUID config is decoded correctly.
-		assert.Equal(t, c.Storage.DefaultPermanentLocationID, uuid.MustParse("f2cc963f-c14d-4eaa-b950-bd207189a1f1"))
-
-		// Test that a map[string][]string config is decoded correctly.
-		assert.DeepEqual(t, c.API.Auth.OIDC.ABAC.RolesMapping, map[string][]string{
-			"admin": {"*"},
-			"operator": {
-				auth.IngestSIPSListAttr,
-				auth.IngestSIPSWorkflowsListAttr,
-				auth.IngestSIPSReadAttr,
-				auth.IngestSIPSUploadAttr,
+	type test struct {
+		name    string
+		config  string
+		want    config.Configuration
+		wantErr string
+	}
+	for _, tc := range []test{
+		{
+			name:   "Loads TOML configs",
+			config: testConfig,
+			want: config.Configuration{
+				Debug:       true,
+				DebugListen: "127.0.0.1:9001",
+				A3m: a3m.Config{
+					Processing: a3m.ProcessingDefault,
+				},
+				AM: am.Config{
+					Capacity:     20,
+					PollInterval: 10 * time.Second,
+				},
+				API: api.Config{
+					Listen: "127.0.0.1:9000",
+					Auth: auth.Config{
+						OIDC: &auth.OIDCConfig{
+							ABAC: auth.OIDCABACConfig{
+								RolesMapping: map[string][]string{
+									"admin":    {"*"},
+									"operator": {"ingest:sips:list", "ingest:sips:workflows:list", "ingest:sips:read", "ingest:sips:upload"},
+									"readonly": {"ingest:sips:list", "ingest:sips:workflows:list", "ingest:sips:read"},
+								},
+							},
+						},
+					},
+					CORSOrigin: "127.0.0.1:9000",
+				},
+				BagIt: bagcreate.Config{
+					ChecksumAlgorithm: "sha512",
+				},
+				Preservation: pres.Config{
+					TaskQueue: "a3m",
+				},
+				Storage: storage.Config{
+					TaskQueue:                  "global",
+					DefaultPermanentLocationID: uuid.MustParse("f2cc963f-c14d-4eaa-b950-bd207189a1f1"),
+				},
+				Temporal: temporal.Config{
+					Address:   "host:port",
+					TaskQueue: "global",
+				},
+				Upload: ingest.UploadConfig{
+					MaxSize: 4294967296,
+				},
 			},
-			"readonly": {
-				auth.IngestSIPSListAttr,
-				auth.IngestSIPSWorkflowsListAttr,
-				auth.IngestSIPSReadAttr,
+		},
+		{
+			name: "Sets default values for missing config options",
+			want: config.Configuration{
+				DebugListen: "127.0.0.1:9001",
+				A3m: a3m.Config{
+					Processing: a3m.ProcessingDefault,
+				},
+				AM: am.Config{
+					Capacity:     20,
+					PollInterval: 10 * time.Second,
+				},
+				API: api.Config{
+					Listen:     "127.0.0.1:9000",
+					CORSOrigin: "127.0.0.1:9000",
+				},
+				BagIt: bagcreate.Config{
+					ChecksumAlgorithm: "sha512",
+				},
+				Preservation: pres.Config{
+					TaskQueue: "a3m",
+				},
+				Storage: storage.Config{
+					TaskQueue: "global",
+				},
+				Temporal: temporal.Config{
+					TaskQueue: "global",
+				},
+				Upload: ingest.UploadConfig{
+					MaxSize: 4294967296,
+				},
 			},
+		},
+		{
+			name:    "Returns error if config is invalid",
+			config:  "debug = not-a-boolean",
+			wantErr: "failed to read configuration file: While parsing config: toml: expected 'nan'",
+		},
+		{
+			name: "Returns error if string to UUID hook fails",
+			config: `[storage]
+defaultPermanentLocationId = "not-a-uuid"`,
+			wantErr: `failed to unmarshal configuration: 1 error(s) decoding:
+
+* error decoding 'Storage.DefaultPermanentLocationID': invalid UUID length: 10`,
+		},
+		{
+			name: "Returns error if string to map hook fails",
+			config: `[api.auth.oidc.abac]
+rolesMapping = "not-a-json"`,
+			wantErr: `failed to unmarshal configuration: 1 error(s) decoding:
+
+* error decoding 'API.Auth.OIDC.ABAC.RolesMapping': invalid character 'o' in literal null (expecting 'u')`,
+		},
+		{
+			name: "Returns error if validation fails",
+			config: `[a3m.processing]
+aipCompressionLevel = 10`,
+			wantErr: "failed to validate the provided config: AipCompressionLevel: 10 is outside valid range (0 to 9)",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := fs.NewDir(t, "",
+				fs.WithFile("enduro-config.toml", tc.config),
+			)
+			configFile := tmpDir.Join("enduro-config.toml")
+
+			var c config.Configuration
+			found, configFileUsed, err := config.Read(&c, configFile)
+			if tc.wantErr != "" {
+				assert.Error(t, err, tc.wantErr)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Equal(t, found, true)
+			assert.Equal(t, configFileUsed, configFile)
+			assert.DeepEqual(t, c, tc.want)
 		})
-	})
-
-	t.Run("Sets default configs", func(t *testing.T) {
-		t.Parallel()
-
-		var c config.Configuration
-		found, configFileUsed, err := config.Read(&c, "")
-
-		assert.NilError(t, err)
-		assert.Equal(t, found, false)
-		assert.Equal(t, configFileUsed, "")
-
-		// Zero value defaults.
-		assert.Equal(t, c.Verbosity, 0)
-		assert.Equal(t, c.Debug, false)
-		assert.Equal(t, c.Database.DSN, "")
-
-		// Valued defaults.
-		assert.Equal(t, c.A3m.Processing, a3m.ProcessingDefault)
-		assert.Equal(t, c.AM.Capacity, 20)
-		assert.Equal(t, c.AM.PollInterval, 10*time.Second)
-		assert.Equal(t, c.AM.ZipPIP, false)
-		assert.Equal(t, c.API.Listen, "127.0.0.1:9000")
-		assert.Equal(t, c.BagIt.ChecksumAlgorithm, "sha512")
-		assert.Equal(t, c.DebugListen, "127.0.0.1:9001")
-		assert.Equal(t, c.Preservation.TaskQueue, temporal.A3mWorkerTaskQueue)
-		assert.Equal(t, c.Storage.TaskQueue, temporal.GlobalTaskQueue)
-		assert.Equal(t, c.Temporal.TaskQueue, temporal.GlobalTaskQueue)
-		assert.Equal(t, c.ValidatePREMIS.Enabled, false)
-		assert.Equal(t, c.ValidatePREMIS.XSDPath, "")
-		assert.Equal(t, c.Upload.MaxSize, int64(4294967296))
-	})
+	}
 }
 
 func TestConfigValidate(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Returns error if config is invalid", func(t *testing.T) {
-		t.Parallel()
-
-		c := config.Configuration{
-			InternalStorage: config.InternalStorageConfig{
-				Bucket: bucket.Config{
-					URL:    "s3blob://my-bucket",
-					Bucket: "my-bucket",
-					Region: "planet-earth",
+	type test struct {
+		name    string
+		config  config.Configuration
+		wantErr string
+	}
+	for _, tc := range []test{
+		{
+			name: "Returns error if bucket URL and other options are both provided",
+			config: config.Configuration{
+				InternalStorage: config.InternalStorageConfig{
+					Bucket: bucket.Config{
+						URL:    "s3blob://my-bucket",
+						Bucket: "my-bucket",
+						Region: "planet-earth",
+					},
 				},
 			},
-		}
-		err := c.Validate()
-		assert.ErrorContains(
-			t,
-			err,
-			"the [internalStorage] URL option and the other configuration options are mutually exclusive",
-		)
-	})
-
-	t.Run("Returns error if azure credentials are missing", func(t *testing.T) {
-		t.Parallel()
-
-		c := config.Configuration{
-			InternalStorage: config.InternalStorageConfig{
-				Bucket: bucket.Config{
-					URL: "azblob://my-bucket",
+			wantErr: "the [internalStorage] URL option and the other configuration options are mutually exclusive",
+		},
+		{
+			name: "Returns error if azure credentials are missing",
+			config: config.Configuration{
+				InternalStorage: config.InternalStorageConfig{
+					Bucket: bucket.Config{
+						URL: "azblob://my-bucket",
+					},
 				},
 			},
-		}
-		err := c.Validate()
-		assert.ErrorContains(
-			t,
-			err,
-			"the [internalStorage] Azure credentials are undefined",
-		)
-	})
-
-	t.Run("Validates if only URL is provided", func(t *testing.T) {
-		t.Parallel()
-
-		c := config.Configuration{
-			InternalStorage: config.InternalStorageConfig{
-				Bucket: bucket.Config{
-					URL: "s3blob://my-bucket",
+			wantErr: "the [internalStorage] Azure credentials are undefined",
+		},
+		{
+			name: "Validates if only URL is provided",
+			config: config.Configuration{
+				InternalStorage: config.InternalStorageConfig{
+					Bucket: bucket.Config{
+						URL: "s3blob://my-bucket",
+					},
 				},
 			},
-		}
-		err := c.Validate()
-		assert.NilError(t, err)
-	})
-
-	t.Run("Validates if only bucket options are provided", func(t *testing.T) {
-		t.Parallel()
-
-		c := config.Configuration{
-			InternalStorage: config.InternalStorageConfig{
-				Bucket: bucket.Config{
-					Bucket: "my-bucket",
-					Region: "planet-earth",
+		},
+		{
+			name: "Validates if only bucket options are provided",
+			config: config.Configuration{
+				InternalStorage: config.InternalStorageConfig{
+					Bucket: bucket.Config{
+						Bucket: "my-bucket",
+						Region: "planet-earth",
+					},
 				},
 			},
-		}
-		err := c.Validate()
-		assert.NilError(t, err)
-	})
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.config.Validate()
+			if tc.wantErr != "" {
+				assert.Error(t, err, tc.wantErr)
+				return
+			}
+
+			assert.NilError(t, err)
+		})
+	}
 }


### PR DESCRIPTION
- Add tests for `a3m.Config.Validate()` method
- Fix bug in `a3m.Config.Validate()` method
- Convert existing `config.Configuration` tests to matrix based tests
- Add more unit tests for `config.Configuration.Read()` method