### PR TITLE
Move ingest storage config

### DIFF
--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -285,7 +285,7 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: removepaths.Name},
 		)
 
-		storageClient := ingest.NewStorageClient(tp, cfg.Storage.EnduroAddress)
+		storageClient := ingest.NewStorageClient(tp, cfg.Ingest.Storage.Address)
 		w.RegisterActivityWithOptions(
 			activities.NewUploadActivity(storageClient).Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.UploadActivityName},

--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -321,7 +321,7 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: am.PollIngestActivityName},
 		)
 
-		storageClient := ingest.NewStorageClient(tp, cfg.Storage.EnduroAddress)
+		storageClient := ingest.NewStorageClient(tp, cfg.Ingest.Storage.Address)
 		w.RegisterActivityWithOptions(
 			activities.NewCreateStorageAIPActivity(storageClient).Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.CreateStorageAIPActivityName},

--- a/docs/src/admin-manual/configuration.md
+++ b/docs/src/admin-manual/configuration.md
@@ -527,7 +527,7 @@ workflowType = "create aip"
   values are "create aip" and "create and review aip". The latter review
   workflow also only works if [a3m] is the configured [preservation engine].
 
-### Storage endpoint
+### Ingest storage settings
 
 This element configures the Enduro storage service API endpoint. Even when using
 [Archivematica] as the [preservation engine] (which includes the AM
@@ -538,12 +538,12 @@ AMSS. Otherwise, this configures the primary local storage service when using
 **Default values**:
 
 ```toml
-[storage]
-enduroAddress = "enduro.enduro-sdps:9002"
+[ingest.storage]
+address = "enduro.enduro-sdps:9002"
 defaultPermanentLocationId = "f2cc963f-c14d-4eaa-b950-bd207189a1f1"
 ```
 
-* `enduroAddress`: Defines the address and port for the storage API endpoint.
+* `address`: Defines the address and port for the storage API endpoint.
 * `defaultPermanentLocationId`: The UUID of the storage location used for
   permanent AIP storage in automated workflows. The default value provided
   represents the first permanent location defined in the

--- a/enduro.toml
+++ b/enduro.toml
@@ -307,6 +307,20 @@ samplingRatio = 1.0
 # taskQueue = "postbatch"
 # workflowName = "postbatch"
 
+# [ingest.storage] configures ingest as a client of the storage API.
+# Use this section for cross-domain integration values:
+# - the address of the storage API
+# - which permanent location ingest targets by default
+[ingest.storage]
+address = "enduro.enduro-sdps:9002"
+
+# defaultPermanentLocationId is the UUID of the storage location used for
+# permanent AIP storage in the "auto-approve" processing workflow.
+# The value of "e0ed8b2a-8ae2-4546-b5d8-f0090919df04" represents the AIP
+# storage location UUID defined in the enduro-am-secret.yaml and created
+# in the mysql-create-amss-location-job.yaml Kubernetes manifest.
+defaultPermanentLocationId = "e0ed8b2a-8ae2-4546-b5d8-f0090919df04"
+
 #########################################################################
 #                                                                       #
 #                     STORAGE SERVICE CONFIGURATION                     #
@@ -315,15 +329,16 @@ samplingRatio = 1.0
 #                                                                       #
 #########################################################################
 
+# [storage] configures the storage service itself (service-owned behavior).
+# Keep this separate from [ingest.storage]: ingest consumes the storage API,
+# while [storage] defines how the storage domain runs internally.
 [storage]
-enduroAddress = "enduro.enduro-sdps:9002"
-
-# defaultPermanentLocationId is the UUID of the storage location used for
-# permanent AIP storage in the "auto-approve" processing workflow.
-# The value of "e0ed8b2a-8ae2-4546-b5d8-f0090919df04" represents the AIP
-# storage location UUID defined in the enduro-am-secret.yaml and created
-# in the mysql-create-amss-location-job.yaml Kubernetes manifest.
-defaultPermanentLocationId = "e0ed8b2a-8ae2-4546-b5d8-f0090919df04"
+# taskQueue is the Temporal queue used by storage workflows and activities.
+# Default: "global".
+# Note: storage does not currently define its own Temporal address/namespace.
+# It reuses the ingest domain Temporal configuration and client. This is not
+# ideal and should be changed in the future.
+taskQueue = "global"
 
 [storage.database]
 driver = "mysql"

--- a/hack/kube/overlays/dev-a3m/enduro-patch.yaml
+++ b/hack/kube/overlays/dev-a3m/enduro-patch.yaml
@@ -10,5 +10,5 @@ spec:
           env:
             - name: ENDURO_PRESERVATION_TASKQUEUE
               value: "a3m"
-            - name: ENDURO_STORAGE_DEFAULTPERMANENTLOCATIONID
+            - name: ENDURO_INGEST_STORAGE_DEFAULTPERMANENTLOCATIONID
               value: "f2cc963f-c14d-4eaa-b950-bd207189a1f1"

--- a/hack/kube/overlays/dev-am/enduro-am.yaml
+++ b/hack/kube/overlays/dev-am/enduro-am.yaml
@@ -55,7 +55,7 @@ spec:
               value: $(MYSQL_USER):$(MYSQL_PASSWORD)@tcp(mysql.enduro-sdps:3306)/enduro
             - name: ENDURO_STORAGE_DATABASE_DSN
               value: $(MYSQL_USER):$(MYSQL_PASSWORD)@tcp(mysql.enduro-sdps:3306)/enduro_storage
-            - name: ENDURO_STORAGE_DEFAULTPERMANENTLOCATIONID
+            - name: ENDURO_INGEST_STORAGE_DEFAULTPERMANENTLOCATIONID
               valueFrom:
                 secretKeyRef:
                   name: enduro-am-secret

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ type Configuration struct {
 	Database        db.Config
 	Event           event.Config
 	ExtractActivity archiveextract.Config
+	Ingest          ingest.Config
 	Preservation    pres.Config
 	SIPSource       sipsource.Config
 	Storage         storage.Config

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,7 +28,7 @@ debugListen = "127.0.0.1:9001"
 [temporal]
 address = "host:port"
 
-[storage]
+[ingest.storage]
 defaultPermanentLocationId = "f2cc963f-c14d-4eaa-b950-bd207189a1f1"
 
 [api.auth.oidc.abac]
@@ -76,12 +76,16 @@ func TestConfigRead(t *testing.T) {
 				BagIt: bagcreate.Config{
 					ChecksumAlgorithm: "sha512",
 				},
+				Ingest: ingest.Config{
+					Storage: ingest.StorageConfig{
+						DefaultPermanentLocationID: uuid.MustParse("f2cc963f-c14d-4eaa-b950-bd207189a1f1"),
+					},
+				},
 				Preservation: pres.Config{
 					TaskQueue: "a3m",
 				},
 				Storage: storage.Config{
-					TaskQueue:                  "global",
-					DefaultPermanentLocationID: uuid.MustParse("f2cc963f-c14d-4eaa-b950-bd207189a1f1"),
+					TaskQueue: "global",
 				},
 				Temporal: temporal.Config{
 					Address:   "host:port",
@@ -131,11 +135,11 @@ func TestConfigRead(t *testing.T) {
 		},
 		{
 			name: "Returns error if string to UUID hook fails",
-			config: `[storage]
+			config: `[ingest.storage]
 defaultPermanentLocationId = "not-a-uuid"`,
 			wantErr: `failed to unmarshal configuration: 1 error(s) decoding:
 
-* error decoding 'Storage.DefaultPermanentLocationID': invalid UUID length: 10`,
+* error decoding 'Ingest.Storage.DefaultPermanentLocationID': invalid UUID length: 10`,
 		},
 		{
 			name: "Returns error if string to map hook fails",

--- a/internal/ingest/config.go
+++ b/internal/ingest/config.go
@@ -1,0 +1,12 @@
+package ingest
+
+import "github.com/google/uuid"
+
+type Config struct {
+	Storage StorageConfig
+}
+
+type StorageConfig struct {
+	Address                    string
+	DefaultPermanentLocationID uuid.UUID
+}

--- a/internal/ingest/storage_client.go
+++ b/internal/ingest/storage_client.go
@@ -51,7 +51,7 @@ type StorageClient interface {
 
 var _ StorageClient = (*goastorage.Client)(nil)
 
-func NewStorageClient(tp trace.TracerProvider, enduroAddress string) StorageClient {
+func NewStorageClient(tp trace.TracerProvider, address string) StorageClient {
 	httpClient := cleanhttp.DefaultPooledClient()
 	httpClient.Transport = otelhttp.NewTransport(
 		httpClient.Transport,
@@ -63,7 +63,7 @@ func NewStorageClient(tp trace.TracerProvider, enduroAddress string) StorageClie
 
 	storageHTTPClient := goahttpstorage.NewClient(
 		"http",
-		enduroAddress,
+		address,
 		httpClient,
 		goahttp.RequestEncoder,
 		goahttp.ResponseDecoder,

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -1,19 +1,15 @@
 package storage
 
 import (
-	"github.com/google/uuid"
-
 	"github.com/artefactual-sdps/enduro/internal/event"
 )
 
 type Config struct {
-	TaskQueue                  string
-	EnduroAddress              string
-	DefaultPermanentLocationID uuid.UUID
-	Internal                   LocationConfig
-	Database                   Database
-	Event                      event.Config
-	AIPDeletion                AIPDeletionConfig
+	TaskQueue   string
+	Internal    LocationConfig
+	Database    Database
+	Event       event.Config
+	AIPDeletion AIPDeletionConfig
 }
 
 type Database struct {

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -653,7 +653,7 @@ func (w *ProcessingWorkflow) transferA3m(
 	if state.req.Type == enums.WorkflowTypeCreateAip {
 		reviewResult = &ingest.ReviewPerformedSignal{
 			Accepted:   true,
-			LocationID: &w.cfg.Storage.DefaultPermanentLocationID,
+			LocationID: &w.cfg.Ingest.Storage.DefaultPermanentLocationID,
 		}
 	} else {
 		// Set SIP to pending status.
@@ -977,7 +977,7 @@ func (w *ProcessingWorkflow) transferAM(
 				Name:       state.sip.name,
 				AIPID:      state.aip.id,
 				ObjectKey:  state.aip.id,
-				LocationID: &w.cfg.Storage.DefaultPermanentLocationID,
+				LocationID: &w.cfg.Ingest.Storage.DefaultPermanentLocationID,
 				Status:     "stored",
 			}).
 			Get(activityOpts, nil)

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/ingest"
 	"github.com/artefactual-sdps/enduro/internal/premis"
 	"github.com/artefactual-sdps/enduro/internal/pres"
-	"github.com/artefactual-sdps/enduro/internal/storage"
 	"github.com/artefactual-sdps/enduro/internal/temporal"
 	"github.com/artefactual-sdps/enduro/internal/workflow/activities"
 	"github.com/artefactual-sdps/enduro/internal/workflow/localact"
@@ -45,7 +44,7 @@ func (s *ProcessingWorkflowTestSuite) TestConfirmation() {
 	s.SetupWorkflowTest(config.Configuration{
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
-		Storage:      storage.Config{DefaultPermanentLocationID: locationID},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
 	})
 
 	// Signal handler that mimics SIP/AIP confirmation.
@@ -100,7 +99,7 @@ func (s *ProcessingWorkflowTestSuite) TestRejection() {
 	s.SetupWorkflowTest(config.Configuration{
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
-		Storage:      storage.Config{DefaultPermanentLocationID: locationID},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
 	})
 
 	// Signal handler that mimics SIP/AIP rejection.
@@ -150,7 +149,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 	s.SetupWorkflowTest(config.Configuration{
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
-		Storage:      storage.Config{DefaultPermanentLocationID: locationID},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
 	})
 
 	params := defaultParams()
@@ -183,7 +182,7 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 	s.SetupWorkflowTest(config.Configuration{
 		AM:             am.Config{ZipPIP: true, TransferDeadline: time.Second},
 		Preservation:   pres.Config{TaskQueue: temporal.AmWorkerTaskQueue},
-		Storage:        storage.Config{DefaultPermanentLocationID: amssLocationID},
+		Ingest:         ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: amssLocationID}},
 		ValidatePREMIS: premis.Config{Enabled: true, XSDPath: "/home/enduro/premis.xsd"},
 	})
 
@@ -294,7 +293,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	s.SetupWorkflowTest(config.Configuration{
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
-		Storage:      storage.Config{DefaultPermanentLocationID: locationID},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
 		ChildWorkflows: childwf.Configs{
 			{
 				Type:         enums.ChildWorkflowTypePreprocessing,
@@ -401,7 +400,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
 
-		Storage: storage.Config{DefaultPermanentLocationID: locationID},
+		Ingest: ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
 		ChildWorkflows: childwf.Configs{
 			{
 				Type:         enums.ChildWorkflowTypePreprocessing,
@@ -464,7 +463,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPA3m() {
 	s.SetupWorkflowTest(config.Configuration{
 		A3m:            a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation:   pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
-		Storage:        storage.Config{DefaultPermanentLocationID: locationID},
+		Ingest:         ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
 		ValidatePREMIS: premis.Config{Enabled: true, XSDPath: "/home/enduro/premis.xsd"},
 	})
 
@@ -530,7 +529,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPAM() {
 	s.SetupWorkflowTest(config.Configuration{
 		AM:           am.Config{ZipPIP: true},
 		Preservation: pres.Config{TaskQueue: temporal.AmWorkerTaskQueue},
-		Storage:      storage.Config{DefaultPermanentLocationID: amssLocationID},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: amssLocationID}},
 	})
 
 	params := defaultParams()
@@ -575,7 +574,7 @@ func (s *ProcessingWorkflowTestSuite) TestInternalUpload() {
 	s.SetupWorkflowTest(config.Configuration{
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
-		Storage:      storage.Config{DefaultPermanentLocationID: locationID},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
 	})
 
 	params := defaultParams()
@@ -636,7 +635,7 @@ func (s *ProcessingWorkflowTestSuite) TestInternalUploadError() {
 	s.SetupWorkflowTest(config.Configuration{
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
-		Storage:      storage.Config{DefaultPermanentLocationID: locationID},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
 		ChildWorkflows: childwf.Configs{
 			{
 				Type:         enums.ChildWorkflowTypePreprocessing,
@@ -711,7 +710,7 @@ func (s *ProcessingWorkflowTestSuite) TestSIPSourceUpload() {
 	s.SetupWorkflowTest(config.Configuration{
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
-		Storage:      storage.Config{DefaultPermanentLocationID: locationID},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
 	})
 
 	params := defaultParams()
@@ -772,7 +771,7 @@ func (s *ProcessingWorkflowTestSuite) TestSIPDeletionError() {
 	s.SetupWorkflowTest(config.Configuration{
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
-		Storage:      storage.Config{DefaultPermanentLocationID: locationID},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
 	})
 
 	params := defaultParams()
@@ -826,7 +825,7 @@ func (s *ProcessingWorkflowTestSuite) TestBatchSignalDoNotContinue() {
 	s.SetupWorkflowTest(config.Configuration{
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
-		Storage:      storage.Config{DefaultPermanentLocationID: locationID},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
 	})
 
 	params := defaultParams()


### PR DESCRIPTION
Move storage API integration settings out of `[storage]` and into `[ingest.storage]` so ingest concerns are configured in the ingest domain. Rename `enduroAddress` to `address`. Keep `[storage]` for storage service settings and add `taskQueue` with default.

Refs #1494, follow-up to #1506.