### PR TITLE
Support multiple API OIDC token verifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,9 @@ atlas-hash: tool-atlas # @HELP Recalculate the migration hashes.
 auth: HOST ?= http://keycloak:7470/realms/artefactual
 auth: CLIENT ?= enduro
 auth: SCOPES ?= openid,email,profile,enduro
+auth: CLIENT_SECRET ?=
 auth: # @HELP Get an API access token from a Keycloak provider.
-	go run ./hack/auth/main.go $(HOST) $(CLIENT) $(SCOPES)
+	CLIENT_SECRET="$(CLIENT_SECRET)" go run ./hack/auth/main.go "$(HOST)" "$(CLIENT)" "$(SCOPES)"
 
 db: # @HELP Opens the MySQL shell connected to the enduro development database.
 db:

--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -197,7 +197,7 @@ func main() {
 	var tokenVerifier auth.TokenVerifier
 	{
 		if cfg.API.Auth.Enabled {
-			tokenVerifier, err = auth.NewOIDCTokenVerifier(ctx, cfg.API.Auth.OIDC)
+			tokenVerifier, err = auth.NewOIDCTokenVerifiers(ctx, cfg.API.Auth.OIDC)
 			if err != nil {
 				logger.Error(err, "Error connecting to OIDC provider.")
 				os.Exit(1)

--- a/docs/src/admin-manual/configuration.md
+++ b/docs/src/admin-manual/configuration.md
@@ -211,25 +211,31 @@ obtaining an access token from the provider.
 
 ```toml
 [api.auth]
-enabled = true
+enabled = false
 ```
 
-#### OIDC authentication provider configuration
+#### OIDC authentication providers configuration
 
-This setting block is used to configure the OpenID Connect ([OIDC]) provider
-when API authentication is [enabled](#enable-api-authentication). The default
-value assumes that [Keycloak] will be used for handling OIDC single sign-on
-requests.
+These setting blocks are used to configure the OpenID Connect ([OIDC])
+providers used for access token verification when API authentication is
+[enabled](#enable-api-authentication). Multiple OIDC providers can be
+configured with a TOML array-of-tables syntax with the same structure. When
+API authentication is enabled, at least one OIDC provider must be configured to
+verify tokens.
 
 For more details on OIDC configuration, consult the [OIDC specification].
 
-**Default values**:
+**Example configuration**:
 
 ```toml
-[api.auth.oidc]
-providerURL = "http://keycloak:7470/realms/artefactual"
+[[api.auth.oidc]]
+providerURL = "https://idp-public.example.com/realms/enduro"
 clientID = "enduro"
-skipEmailVerifiedCheck = false
+
+[[api.auth.oidc]]
+providerURL = "https://idp-public.example.com/realms/enduro"
+clientID = "enduro-s2s"
+skipEmailVerifiedCheck = true
 ```
 
 * `providerURL`: Defines the OIDC provider URL. This parameter is required when
@@ -246,16 +252,23 @@ skipEmailVerifiedCheck = false
   tokens or UserInfo responses for the verified email claim. When set to
   **true**, this check is skipped.
 
-#### Enable Attribute Based Access Control for the API OIDC authentication
+##### Enable Attribute Based Access Control for the API OIDC authentication
 
 Enduro uses Attribute Based Access Control ([ABAC]) to manage permissions and
-access. When ABAC is enabled for the API, it will check a configurable
+access. When ABAC is enabled for an OIDC verifier, it will check a configurable
 multivalue claim against the defined required attributes based on each
 endpoint's configuration.
 
-**Default values**:
+For each verifier, add a matching `[api.auth.oidc.abac]` section immediately
+after the verifier configuration if ABAC is needed.
+
+**Example configuration**:
 
 ```toml
+[[api.auth.oidc]]
+providerURL = "https://idp-public.example.com/realms/enduro"
+clientID = "enduro"
+
 [api.auth.oidc.abac]
 enabled = true
 claimPath = "enduro"
@@ -263,6 +276,11 @@ claimPathSeparator = ""
 claimValuePrefix = ""
 useRoles = false
 rolesMapping =
+
+[[api.auth.oidc]]
+providerURL = "https://idp-public.example.com/realms/enduro"
+clientID = "enduro-s2s"
+skipEmailVerifiedCheck = true
 ```
 
 * `enabled`: Set to `true` to enable ABAC, or `false` to disable ABAC.
@@ -1282,7 +1300,6 @@ workflowName = "postbatch"
 [Dashboard configuration]: ../admin-manual/dashboard-config.md
 [Gibibytes]: https://www.difference.wiki/gigabyte-vs-gibibyte/
 [GoLang]: https://go.dev/
-[Keycloak]: https://www.keycloak.org/
 [METS]: https://www.loc.gov/standards/mets/
 [MinIO]: https://www.min.io
 [OIDC]: https://en.wikipedia.org/wiki/OpenID#OpenID_Connect_(OIDC)

--- a/docs/src/admin-manual/iac.md
+++ b/docs/src/admin-manual/iac.md
@@ -30,11 +30,26 @@ corsOrigin = "http://localhost"
 [api.auth]
 # Enable API authentication. OIDC is the only protocol supported at the
 # moment. When enabled the API verifies the access token submitted with
-# each request. The API client is responsible for obtaining an access
-# token from the provider.
+# each request. Clients are responsible for obtaining an access token
+# from a configured OIDC provider below.
 enabled = true
 
-[api.auth.oidc]
+# Multiple OIDC providers are supported. Add one `[[api.auth.oidc]]` table
+# per provider/client pair. For each provider/client pair add an
+# `[api.auth.oidc.abac]` section if ABAC is needed. Example:
+#
+# [[api.auth.oidc]]
+# providerURL = "http://keycloak:7470/realms/artefactual"
+# clientID = "enduro"
+# [api.auth.oidc.abac]
+# enabled = true
+# claimPath = "attributes.enduro"
+# claimPathSeparator = "."
+#
+# [[api.auth.oidc]]
+# providerURL = "http://keycloak:7470/realms/artefactual-internal"
+# clientID = "enduro-s2s"
+[[api.auth.oidc]]
 # OIDC provider URL. Required when auth. is enabled.
 providerURL = "http://keycloak:7470/realms/artefactual"
 # OIDC client ID. The client ID must be included in the `aud` claim of

--- a/docs/src/dev-manual/testing-api.md
+++ b/docs/src/dev-manual/testing-api.md
@@ -29,6 +29,12 @@ from a different provider. For example:
 make auth HOST=http://example.com CLIENT=enduro SCOPES=openid,email,profile
 ```
 
+To use the client credentials flow, set `CLIENT_SECRET`:
+
+```sh
+make auth CLIENT=enduro-s2s CLIENT_SECRET=uSh7f2r4j2U5wA9d7mJ3xP6nQ8cT1vL0
+```
+
 After authentication, the script will output the token payload for inspection
 and its encoded value for API authentication.
 

--- a/enduro.toml
+++ b/enduro.toml
@@ -28,11 +28,26 @@ corsOrigin = "http://localhost"
 [api.auth]
 # Enable API authentication. OIDC is the only protocol supported at the
 # moment. When enabled the API verifies the access token submitted with
-# each request. The API client is responsible for obtaining an access
-# token from the provider.
+# each request. Clients are responsible for obtaining an access token
+# from a configured OIDC provider below.
 enabled = true
 
-[api.auth.oidc]
+# Multiple OIDC providers are supported. Add one `[[api.auth.oidc]]` table
+# per provider/client pair. For each provider/client pair add an
+# `[api.auth.oidc.abac]` section if ABAC is needed. Example:
+#
+# [[api.auth.oidc]]
+# providerURL = "http://keycloak:7470/realms/artefactual"
+# clientID = "enduro"
+# [api.auth.oidc.abac]
+# enabled = true
+# claimPath = "attributes.enduro"
+# claimPathSeparator = "."
+#
+# [[api.auth.oidc]]
+# providerURL = "http://keycloak:7470/realms/artefactual-internal"
+# clientID = "enduro-s2s"
+[[api.auth.oidc]]
 # OIDC provider URL. Required when auth. is enabled.
 providerURL = "http://keycloak:7470/realms/artefactual"
 # OIDC client ID. The client ID must be included in the `aud` claim of
@@ -73,6 +88,12 @@ useRoles = false
 # Example:
 # rolesMapping = '{"admin": ["*"], "operator": ["ingest:sips:list", "ingest:sips:read", "ingest:sips:upload", "ingest:sips:workflows:list"], "readonly": ["ingest:sips:list", "ingest:sips:read", "ingest:sips:workflows:list"]}'
 rolesMapping = ""
+
+# Secondary verifier for service to service tokens (client credentials).
+[[api.auth.oidc]]
+providerURL = "http://keycloak:7470/realms/artefactual"
+clientID = "enduro-s2s"
+skipEmailVerifiedCheck = true
 
 [api.auth.ticket.redis]
 address = "redis://redis.enduro-sdps:6379"

--- a/hack/kube/components/dev/keycloak.yaml
+++ b/hack/kube/components/dev/keycloak.yaml
@@ -224,6 +224,27 @@ data:
           ]
         },
         {
+          "id": "1de2ff7e-b7f7-4262-8194-4aaf51a1d824",
+          "clientId": "enduro-s2s",
+          "name": "Enduro S2S",
+          "enabled": true,
+          "secret": "uSh7f2r4j2U5wA9d7mJ3xP6nQ8cT1vL0",
+          "protocol": "openid-connect",
+          "serviceAccountsEnabled": true,
+          "protocolMappers": [
+            {
+              "id": "65d4c2f1-c16d-4763-b519-9fc772c897c5",
+              "name": "access-token-aud",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-audience-mapper",
+              "config": {
+                "included.client.audience": "enduro-s2s",
+                "access.token.claim": "true"
+              }
+            }
+          ]
+        },
+        {
           "id": "fa523562-823d-4a8d-9214-e237a20fd599",
           "clientId": "temporal",
           "name": "Temporal",

--- a/internal/api/auth/config_test.go
+++ b/internal/api/auth/config_test.go
@@ -27,22 +27,42 @@ func TestConfig(t *testing.T) {
 			name: "Passes validation (enabled, ABAC disabled)",
 			config: &auth.Config{
 				Enabled: true,
-				OIDC: &auth.OIDCConfig{
+				OIDC: auth.OIDCConfigs{{
 					ProviderURL: "http://keycloak:7470/realms/artefactual",
 					ClientID:    "enduro",
-				},
+				}},
 			},
 		},
 		{
 			name: "Passes validation (enabled, ABAC enabled)",
 			config: &auth.Config{
 				Enabled: true,
-				OIDC: &auth.OIDCConfig{
+				OIDC: auth.OIDCConfigs{{
 					ProviderURL: "http://keycloak:7470/realms/artefactual",
 					ClientID:    "enduro",
 					ABAC: auth.OIDCABACConfig{
 						Enabled:   true,
 						ClaimPath: "enduro",
+					},
+				}},
+			},
+		},
+		{
+			name: "Passes validation (enabled, multiple OIDC configs)",
+			config: &auth.Config{
+				Enabled: true,
+				OIDC: auth.OIDCConfigs{
+					{
+						ProviderURL: "http://keycloak:7470/realms/artefactual",
+						ClientID:    "enduro",
+						ABAC: auth.OIDCABACConfig{
+							Enabled:   true,
+							ClaimPath: "enduro",
+						},
+					},
+					{
+						ProviderURL: "http://keycloak:7470/realms/artefactual-internal",
+						ClientID:    "enduro-s2s",
 					},
 				},
 			},
@@ -52,29 +72,55 @@ func TestConfig(t *testing.T) {
 			config: &auth.Config{
 				Enabled: true,
 			},
-			wantErr: "missing OIDC configuration with API auth. enabled",
+			wantErr: "OIDC configuration required when API auth is enabled",
 		},
 		{
-			name: "Fails validation (missing OIDC config values)",
+			name: "Fails validation (missing OIDC provider URL)",
 			config: &auth.Config{
 				Enabled: true,
-				OIDC:    &auth.OIDCConfig{},
+				OIDC:    auth.OIDCConfigs{{}},
 			},
-			wantErr: "missing OIDC configuration with API auth. enabled",
+			wantErr: "OIDC provider URL required",
 		},
 		{
-			name: "Fails validation (missing OIDC ABAC config values)",
+			name: "Fails validation (missing OIDC client ID)",
 			config: &auth.Config{
 				Enabled: true,
-				OIDC: &auth.OIDCConfig{
+				OIDC: auth.OIDCConfigs{{
+					ProviderURL: "http://keycloak:7470/realms/artefactual",
+				}},
+			},
+			wantErr: "OIDC client ID required",
+		},
+		{
+			name: "Fails validation (missing OIDC ABAC claim path)",
+			config: &auth.Config{
+				Enabled: true,
+				OIDC: auth.OIDCConfigs{{
 					ProviderURL: "http://keycloak:7470/realms/artefactual",
 					ClientID:    "enduro",
 					ABAC: auth.OIDCABACConfig{
 						Enabled: true,
 					},
-				},
+				}},
 			},
-			wantErr: "missing OIDC ABAC claim path with ABAC enabled",
+			wantErr: "OIDC ABAC claim path required when ABAC is enabled",
+		},
+		{
+			name: "Fails validation (missing OIDC ABAC roles mapping)",
+			config: &auth.Config{
+				Enabled: true,
+				OIDC: auth.OIDCConfigs{{
+					ProviderURL: "http://keycloak:7470/realms/artefactual",
+					ClientID:    "enduro",
+					ABAC: auth.OIDCABACConfig{
+						Enabled:   true,
+						ClaimPath: "enduro",
+						UseRoles:  true,
+					},
+				}},
+			},
+			wantErr: "OIDC ABAC roles mapping required when use roles is enabled",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/storage/service_test.go
+++ b/internal/storage/service_test.go
@@ -78,7 +78,7 @@ func setUpService(t *testing.T, attrs *setUpAttrs) storage.Service {
 		persistenceMock:    psMock,
 		temporalClient:     &tc,
 		temporalClientMock: tcMock,
-		tokenVerifier:      &auth.OIDCTokenVerifier{},
+		tokenVerifier:      auth.OIDCTokenVerifiers{},
 	}
 	if attrs.logger != nil {
 		params.logger = attrs.logger
@@ -140,7 +140,7 @@ func TestNewService(t *testing.T) {
 			nil,
 			nil,
 			event.NewServiceNop[*goastorage.StorageEvent](),
-			&auth.OIDCTokenVerifier{},
+			auth.OIDCTokenVerifiers{},
 			nil,
 			nil,
 			nil,


### PR DESCRIPTION
Switch API auth from a single OIDC config to OIDCConfigs so the API
can verify access tokens from multiple provider/client pairs.

Build one verifier per OIDC config and evaluate them in order. Return
the first successful claims result, return ErrUnauthorized when all
verifiers fail authorization checks, and join non-authorization errors
when no verifier succeeds.

Update auth config validation to require at least one OIDC entry and
validate ABAC settings per entry. Refresh tests, sample config, and docs
to show `[[api.auth.oidc]]` usage and per-verifier ABAC configuration.

Also:

- Add service to service client to Keycloak

  Add a new OIDC secret client to the Keycloak configuration enabling
  service accounts for service to service authentication.

- Allow client credentials flow in `make auth`

  Allow setting CLIENT_SECRET and use the client credentials flow when
  it's set, fallback to the existing auth code flow if it's unset.

Refs #1494.