### PR TITLE
Add AutoApprove and SkipReport flags to AIP deletion workflow

### DIFF
--- a/internal/storage/workflow.go
+++ b/internal/storage/workflow.go
@@ -30,6 +30,7 @@ type StorageDeleteWorkflowRequest struct {
 	UserIss     string
 	TaskQueue   string
 	AutoApprove bool
+	SkipReport  bool
 }
 
 type DeletionDecisionSignal struct {

--- a/internal/storage/workflow.go
+++ b/internal/storage/workflow.go
@@ -23,12 +23,13 @@ const (
 )
 
 type StorageDeleteWorkflowRequest struct {
-	AIPID     uuid.UUID
-	Reason    string
-	UserEmail string
-	UserSub   string
-	UserIss   string
-	TaskQueue string
+	AIPID       uuid.UUID
+	Reason      string
+	UserEmail   string
+	UserSub     string
+	UserIss     string
+	TaskQueue   string
+	AutoApprove bool
 }
 
 type DeletionDecisionSignal struct {

--- a/internal/storage/workflows/delete.go
+++ b/internal/storage/workflows/delete.go
@@ -92,7 +92,7 @@ func (w *StorageDeleteWorkflow) Execute(
 
 		// Generate AIP deletion report.
 		// TODO: Create a task to capture possible errors during report generation.
-		if aipStatus == enums.AIPStatusDeleted && workflowStatus == enums.WorkflowStatusDone {
+		if aipStatus == enums.AIPStatusDeleted && workflowStatus == enums.WorkflowStatusDone && !req.SkipReport {
 			if err := w.generateAIPDeletionReport(ctx, req.AIPID, locationSource); err != nil {
 				workflowStatus = enums.WorkflowStatusError
 				e = errors.Join(e, err)

--- a/internal/storage/workflows/delete_test.go
+++ b/internal/storage/workflows/delete_test.go
@@ -335,7 +335,7 @@ func TestStorageDeleteWorkflow(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("Create and auto-approve deletion request", func(t *testing.T) {
+	t.Run("Create and auto-approve deletion request with report generation skipped", func(t *testing.T) {
 		t.Parallel()
 
 		req := storage.StorageDeleteWorkflowRequest{
@@ -346,6 +346,7 @@ func TestStorageDeleteWorkflow(t *testing.T) {
 			UserIss:     "issuer",
 			TaskQueue:   "global",
 			AutoApprove: true,
+			SkipReport:  true,
 		}
 
 		signal := storage.DeletionDecisionSignal{
@@ -449,20 +450,6 @@ func TestStorageDeleteWorkflow(t *testing.T) {
 				),
 			},
 		).Return(nil)
-
-		s.env.OnActivity(
-			activities.AIPDeletionReportActivityName,
-			mock.AnythingOfType("*context.timerCtx"),
-			&activities.AIPDeletionReportActivityParams{
-				AIPID:          s.aip.UUID,
-				LocationSource: enums.LocationSourceAmss,
-			},
-		).Return(
-			&activities.AIPDeletionReportActivityResult{
-				Key: fmt.Sprintf("aip_deletion_report_%s.pdf", s.aip.UUID),
-			},
-			nil,
-		)
 
 		s.env.OnActivity(
 			storage.CompleteWorkflowLocalActivity,


### PR DESCRIPTION
I decided to keep them separated, at some point we may want auto-approval with report generation.

Refs #1513.