### PR TITLE
Clear ingested SIPs when canceling batches

### DIFF
--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -517,6 +517,15 @@ func main() {
 			activities.NewPollSIPStatusesActivity(ingestsvc, time.Second*60).Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.PollSIPStatusesActivityName},
 		)
+		storageClient, err := ingest.NewStorageClient(ctx, tp, cfg.Ingest.Storage)
+		if err != nil {
+			logger.Error(err, "Error setting up storage API client.")
+			os.Exit(1)
+		}
+		w.RegisterActivityWithOptions(
+			activities.NewClearIngestedSIPsActivity(ingestsvc, storageClient, time.Second*60).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.ClearIngestedSIPsActivityName},
+		)
 
 		// Storage workflows and activities.
 		w.RegisterWorkflowWithOptions(

--- a/enduro.toml
+++ b/enduro.toml
@@ -408,7 +408,7 @@ redisChannel = "enduro-storage-events"
 # Archivematica's Storage Service for AMSS locations. When set to false (default),
 # AIP deletions in AMSS locations require manual approval in AMSS. When set to true,
 # they are automatically approved by Enduro, this requires AMSS v0.25.0 or later.
-approveAMSS = false
+approveAMSS = true
 
 # reportTemplatePath specifies the path to the template file used to generate
 # AIP deletion reports. If reportTemplatePath is empty or omitted, AIP deletion 

--- a/internal/workflow/activities/clear_ingested_sips.go
+++ b/internal/workflow/activities/clear_ingested_sips.go
@@ -1,0 +1,207 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+	"go.artefactual.dev/tools/ref"
+	"go.artefactual.dev/tools/temporal"
+	goa "goa.design/goa/v3/pkg"
+
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
+	"github.com/artefactual-sdps/enduro/internal/enums"
+	"github.com/artefactual-sdps/enduro/internal/ingest"
+	storage_enums "github.com/artefactual-sdps/enduro/internal/storage/enums"
+)
+
+const ClearIngestedSIPsActivityName = "clear-ingested-sips-activity"
+
+type ClearIngestedSIPsActivity struct {
+	ingestsvc     ingest.Service
+	storageClient ingest.StorageClient
+	pollInterval  time.Duration
+}
+
+type ClearIngestedSIPsActivityParams struct {
+	BatchUUID uuid.UUID
+}
+
+type ClearIngestedSIPsActivityResult struct{}
+
+func NewClearIngestedSIPsActivity(
+	ingestsvc ingest.Service,
+	storageClient ingest.StorageClient,
+	pollInterval time.Duration,
+) *ClearIngestedSIPsActivity {
+	return &ClearIngestedSIPsActivity{
+		ingestsvc:     ingestsvc,
+		storageClient: storageClient,
+		pollInterval:  pollInterval,
+	}
+}
+
+func (a *ClearIngestedSIPsActivity) Execute(
+	ctx context.Context,
+	params *ClearIngestedSIPsActivityParams,
+) (*ClearIngestedSIPsActivityResult, error) {
+	h := temporal.StartAutoHeartbeat(ctx)
+	defer h.Stop()
+
+	logger := temporal.GetLogger(ctx)
+	logger.V(1).Info("Executing ClearIngestedSIPsActivity", "params", params)
+
+	// Paginate through all SIPs in the batch.
+	var sipCount int
+	var errs error
+	var aipIDs []string
+	for {
+		result, err := a.ingestsvc.ListSips(ctx, &goaingest.ListSipsPayload{
+			BatchUUID: ref.New(params.BatchUUID.String()),
+			Limit:     ref.New(1000),
+			Offset:    ref.New(sipCount),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list SIPs: %v", err)
+		}
+
+		sipCount += len(result.Items)
+		if sipCount == 0 {
+			return nil, fmt.Errorf("list SIPs: no SIPs found")
+		}
+
+		for _, sip := range result.Items {
+			status, err := enums.ParseSIPStatus(sip.Status)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("parse SIP %q status: %v", sip.UUID.String(), err))
+				continue
+			}
+
+			// Ignore SIPs that are not ingested or canceled.
+			if status != enums.SIPStatusIngested && status != enums.SIPStatusCanceled {
+				continue
+			}
+
+			// If the SIP was ingested, mark it as canceled.
+			if status == enums.SIPStatusIngested {
+				if err := a.ingestsvc.SetStatus(ctx, sip.UUID, enums.SIPStatusCanceled); err != nil {
+					errs = errors.Join(
+						errs, fmt.Errorf("set SIP %q status to canceled: %v", sip.UUID.String(), err),
+					)
+					continue
+				}
+			}
+
+			// Ignore SIPs that don't have an AIP UUID.
+			if sip.AipUUID == nil || *sip.AipUUID == "" {
+				continue
+			}
+
+			// Request deletion of the AIP.
+			if err := a.deleteAIP(ctx, params.BatchUUID, *sip.AipUUID); err != nil {
+				errs = errors.Join(errs, err)
+				continue
+			}
+
+			// Keep track of the AIP IDs for polling.
+			aipIDs = append(aipIDs, *sip.AipUUID)
+		}
+
+		if result.Page == nil || sipCount >= result.Page.Total {
+			break
+		}
+	}
+
+	if len(aipIDs) == 0 {
+		return &ClearIngestedSIPsActivityResult{}, errs
+	}
+
+	// Poll the status of the AIPs until they are all deleted.
+	if err := a.waitForAIPsDeleted(ctx, aipIDs); err != nil {
+		errs = errors.Join(errs, err)
+	}
+
+	return &ClearIngestedSIPsActivityResult{}, errs
+}
+
+// deleteAIP requests deletion of the AIP with the given ID.
+// If the AIP is already deleted, it returns nil.
+func (a *ClearIngestedSIPsActivity) deleteAIP(ctx context.Context, batchUUID uuid.UUID, aipID string) error {
+	err := a.storageClient.AipDeletionAuto(ctx, &goastorage.AipDeletionAutoPayload{
+		UUID:       aipID,
+		Reason:     fmt.Sprintf("Batch %s canceled", batchUUID),
+		SkipReport: ref.New(true),
+	})
+	if err != nil {
+		if isAIPNotStoredError(err) {
+			return nil
+		}
+		return fmt.Errorf("request AIP %q deletion: %v", aipID, err)
+	}
+
+	return nil
+}
+
+func isAIPNotStoredError(err error) bool {
+	var serviceErr *goa.ServiceError
+	if !errors.As(err, &serviceErr) {
+		return false
+	}
+
+	return serviceErr.Name == "not_valid" && serviceErr.Message == "AIP is not stored"
+}
+
+// waitForAIPsDeleted polls the status of the AIPs with the given IDs
+// until they are all deleted or the context is canceled.
+func (a *ClearIngestedSIPsActivity) waitForAIPsDeleted(ctx context.Context, aipIDs []string) error {
+	ticker := time.NewTicker(a.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			done, err := a.checkAIPStatuses(ctx, aipIDs)
+			if err != nil {
+				return err
+			}
+			if done {
+				return nil
+			}
+		}
+	}
+}
+
+// checkAIPStatuses checks the status of the AIPs with the given IDs.
+// It returns true if all AIPs are deleted, false otherwise.
+func (a *ClearIngestedSIPsActivity) checkAIPStatuses(ctx context.Context, aipIDs []string) (bool, error) {
+	var errs error
+	for _, aipID := range aipIDs {
+		aip, err := a.storageClient.ShowAip(ctx, &goastorage.ShowAipPayload{UUID: aipID})
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("show AIP %q: %v", aipID, err))
+			continue
+		}
+
+		unexpectedAIPStatuses := []string{
+			storage_enums.AIPStatusStored.String(),
+			storage_enums.AIPStatusPending.String(),
+			storage_enums.AIPStatusUnspecified.String(),
+		}
+		if slices.Contains(unexpectedAIPStatuses, aip.Status) {
+			errs = errors.Join(errs, fmt.Errorf("AIP %q could not be deleted", aipID))
+			continue
+		}
+
+		if aip.Status != storage_enums.AIPStatusDeleted.String() {
+			return false, nil
+		}
+	}
+
+	return true, errs
+}

--- a/internal/workflow/activities/clear_ingested_sips_test.go
+++ b/internal/workflow/activities/clear_ingested_sips_test.go
@@ -1,0 +1,267 @@
+package activities_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"go.artefactual.dev/tools/mockutil"
+	"go.artefactual.dev/tools/ref"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
+	"github.com/artefactual-sdps/enduro/internal/enums"
+	ingestfake "github.com/artefactual-sdps/enduro/internal/ingest/fake"
+	storage_enums "github.com/artefactual-sdps/enduro/internal/storage/enums"
+	"github.com/artefactual-sdps/enduro/internal/workflow/activities"
+)
+
+func TestClearIngestedSIPsActivity(t *testing.T) {
+	t.Parallel()
+
+	batchUUID := uuid.New()
+	sipUUID1 := uuid.New()
+	sipUUID2 := uuid.New()
+	sipUUID3 := uuid.New()
+	sipUUID4 := uuid.New()
+	aipID1 := uuid.New().String()
+	aipID2 := uuid.New().String()
+	aipID3 := uuid.New().String()
+	aipID4 := uuid.New().String()
+
+	listPayload := func(offset int) *goaingest.ListSipsPayload {
+		return &goaingest.ListSipsPayload{
+			BatchUUID: ref.New(batchUUID.String()),
+			Limit:     ref.New(1000),
+			Offset:    ref.New(offset),
+		}
+	}
+
+	aipDeletionPayload := func(aipID string) *goastorage.AipDeletionAutoPayload {
+		return &goastorage.AipDeletionAutoPayload{
+			UUID:       aipID,
+			Reason:     fmt.Sprintf("Batch %s canceled", batchUUID),
+			SkipReport: ref.New(true),
+		}
+	}
+
+	type test struct {
+		name    string
+		params  *activities.ClearIngestedSIPsActivityParams
+		mock    func(*ingestfake.MockServiceMockRecorder, *ingestfake.MockStorageClientMockRecorder)
+		wantErr []string
+	}
+	for _, tt := range []test{
+		{
+			name:   "Clears ingested and canceled SIPs with pagination",
+			params: &activities.ClearIngestedSIPsActivityParams{BatchUUID: batchUUID},
+			mock: func(i *ingestfake.MockServiceMockRecorder, s *ingestfake.MockStorageClientMockRecorder) {
+				i.ListSips(mockutil.Context(), listPayload(0)).
+					Return(&goaingest.SIPs{
+						Items: []*goaingest.SIP{
+							{
+								UUID:    sipUUID1,
+								Status:  enums.SIPStatusIngested.String(),
+								AipUUID: ref.New(aipID1),
+							},
+							{
+								UUID:   sipUUID2,
+								Status: enums.SIPStatusProcessing.String(),
+							},
+						},
+						Page: &goaingest.EnduroPage{Total: 3},
+					}, nil)
+				i.SetStatus(mockutil.Context(), sipUUID1, enums.SIPStatusCanceled).Return(nil)
+				s.AipDeletionAuto(mockutil.Context(), aipDeletionPayload(aipID1)).Return(nil)
+
+				i.ListSips(mockutil.Context(), listPayload(2)).
+					Return(&goaingest.SIPs{
+						Items: []*goaingest.SIP{
+							{
+								UUID:    sipUUID3,
+								Status:  enums.SIPStatusCanceled.String(),
+								AipUUID: ref.New(aipID2),
+							},
+						},
+						Page: &goaingest.EnduroPage{Total: 3},
+					}, nil)
+				s.AipDeletionAuto(mockutil.Context(), aipDeletionPayload(aipID2)).Return(nil)
+
+				s.ShowAip(mockutil.Context(), &goastorage.ShowAipPayload{UUID: aipID1}).
+					Return(&goastorage.AIP{Status: storage_enums.AIPStatusProcessing.String()}, nil)
+				s.ShowAip(mockutil.Context(), &goastorage.ShowAipPayload{UUID: aipID1}).
+					Return(&goastorage.AIP{Status: storage_enums.AIPStatusDeleted.String()}, nil)
+				s.ShowAip(mockutil.Context(), &goastorage.ShowAipPayload{UUID: aipID2}).
+					Return(&goastorage.AIP{Status: storage_enums.AIPStatusDeleted.String()}, nil)
+			},
+		},
+		{
+			name:   "Returns an error when listing SIPs fails",
+			params: &activities.ClearIngestedSIPsActivityParams{BatchUUID: batchUUID},
+			mock: func(i *ingestfake.MockServiceMockRecorder, _ *ingestfake.MockStorageClientMockRecorder) {
+				i.ListSips(mockutil.Context(), listPayload(0)).Return(nil, errors.New("persistence error"))
+			},
+			wantErr: []string{"list SIPs: persistence error"},
+		},
+		{
+			name:   "Continues when deletion request returns AIP is not stored",
+			params: &activities.ClearIngestedSIPsActivityParams{BatchUUID: batchUUID},
+			mock: func(i *ingestfake.MockServiceMockRecorder, s *ingestfake.MockStorageClientMockRecorder) {
+				i.ListSips(mockutil.Context(), listPayload(0)).
+					Return(&goaingest.SIPs{
+						Items: []*goaingest.SIP{
+							{
+								UUID:    sipUUID1,
+								Status:  enums.SIPStatusCanceled.String(),
+								AipUUID: ref.New(aipID1),
+							},
+						},
+						Page: &goaingest.EnduroPage{Total: 1},
+					}, nil)
+				s.AipDeletionAuto(mockutil.Context(), aipDeletionPayload(aipID1)).
+					Return(goastorage.MakeNotValid(errors.New("AIP is not stored")))
+				s.ShowAip(mockutil.Context(), &goastorage.ShowAipPayload{UUID: aipID1}).
+					Return(&goastorage.AIP{Status: storage_enums.AIPStatusDeleted.String()}, nil)
+			},
+		},
+		{
+			name:   "Aggregates parse, status update, and deletion wait errors",
+			params: &activities.ClearIngestedSIPsActivityParams{BatchUUID: batchUUID},
+			mock: func(i *ingestfake.MockServiceMockRecorder, s *ingestfake.MockStorageClientMockRecorder) {
+				i.ListSips(mockutil.Context(), listPayload(0)).
+					Return(&goaingest.SIPs{
+						Items: []*goaingest.SIP{
+							{
+								UUID:   sipUUID1,
+								Status: "invalid",
+							},
+							{
+								UUID:    sipUUID2,
+								Status:  enums.SIPStatusIngested.String(),
+								AipUUID: ref.New(aipID1),
+							},
+							{
+								UUID:    sipUUID3,
+								Status:  enums.SIPStatusCanceled.String(),
+								AipUUID: ref.New(aipID2),
+							},
+						},
+						Page: &goaingest.EnduroPage{Total: 3},
+					}, nil)
+				i.SetStatus(mockutil.Context(), sipUUID2, enums.SIPStatusCanceled).
+					Return(errors.New("status update failed"))
+				s.AipDeletionAuto(mockutil.Context(), aipDeletionPayload(aipID2)).Return(nil)
+				s.ShowAip(mockutil.Context(), &goastorage.ShowAipPayload{UUID: aipID2}).
+					Return(&goastorage.AIP{Status: storage_enums.AIPStatusStored.String()}, nil)
+			},
+			wantErr: []string{
+				fmt.Sprintf("parse SIP %q status: invalid is not a valid SIPStatus", sipUUID1.String()),
+				fmt.Sprintf("set SIP %q status to canceled: status update failed", sipUUID2.String()),
+				fmt.Sprintf("AIP %q could not be deleted", aipID2),
+			},
+		},
+		{
+			name:   "Aggregates deletion and AIP status check errors",
+			params: &activities.ClearIngestedSIPsActivityParams{BatchUUID: batchUUID},
+			mock: func(i *ingestfake.MockServiceMockRecorder, s *ingestfake.MockStorageClientMockRecorder) {
+				i.ListSips(mockutil.Context(), listPayload(0)).
+					Return(&goaingest.SIPs{
+						Items: []*goaingest.SIP{
+							{
+								UUID:    sipUUID1,
+								Status:  enums.SIPStatusCanceled.String(),
+								AipUUID: ref.New(aipID1),
+							},
+							{
+								UUID:    sipUUID2,
+								Status:  enums.SIPStatusCanceled.String(),
+								AipUUID: ref.New(aipID2),
+							},
+							{
+								UUID:    sipUUID3,
+								Status:  enums.SIPStatusCanceled.String(),
+								AipUUID: ref.New(aipID3),
+							},
+							{
+								UUID:    sipUUID4,
+								Status:  enums.SIPStatusCanceled.String(),
+								AipUUID: ref.New(aipID4),
+							},
+						},
+						Page: &goaingest.EnduroPage{Total: 4},
+					}, nil)
+				s.AipDeletionAuto(mockutil.Context(), aipDeletionPayload(aipID1)).
+					Return(errors.New("deletion request failed"))
+				s.AipDeletionAuto(mockutil.Context(), aipDeletionPayload(aipID2)).
+					Return(errors.New("deletion request failed"))
+				s.AipDeletionAuto(mockutil.Context(), aipDeletionPayload(aipID3)).Return(nil)
+				s.AipDeletionAuto(mockutil.Context(), aipDeletionPayload(aipID4)).Return(nil)
+				s.ShowAip(mockutil.Context(), &goastorage.ShowAipPayload{UUID: aipID3}).
+					Return(nil, errors.New("status lookup failed"))
+				s.ShowAip(mockutil.Context(), &goastorage.ShowAipPayload{UUID: aipID4}).
+					Return(&goastorage.AIP{Status: storage_enums.AIPStatusStored.String()}, nil)
+			},
+			wantErr: []string{
+				fmt.Sprintf("request AIP %q deletion:", aipID1),
+				"deletion request failed",
+				fmt.Sprintf("request AIP %q deletion:", aipID2),
+				fmt.Sprintf("show AIP %q: status lookup failed", aipID3),
+				fmt.Sprintf("AIP %q could not be deleted", aipID4),
+			},
+		},
+		{
+			name:   "Skips canceled SIP without AIP UUID",
+			params: &activities.ClearIngestedSIPsActivityParams{BatchUUID: batchUUID},
+			mock: func(i *ingestfake.MockServiceMockRecorder, _ *ingestfake.MockStorageClientMockRecorder) {
+				i.ListSips(mockutil.Context(), listPayload(0)).
+					Return(&goaingest.SIPs{
+						Items: []*goaingest.SIP{
+							{
+								UUID:   sipUUID1,
+								Status: enums.SIPStatusCanceled.String(),
+							},
+						},
+						Page: &goaingest.EnduroPage{Total: 1},
+					}, nil)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			ingestsvc := ingestfake.NewMockService(gomock.NewController(t))
+			storageClient := ingestfake.NewMockStorageClient(gomock.NewController(t))
+			if tt.mock != nil {
+				tt.mock(ingestsvc.EXPECT(), storageClient.EXPECT())
+			}
+
+			env.RegisterActivityWithOptions(
+				activities.NewClearIngestedSIPsActivity(ingestsvc, storageClient, time.Microsecond).Execute,
+				temporalsdk_activity.RegisterOptions{Name: activities.ClearIngestedSIPsActivityName},
+			)
+
+			enc, err := env.ExecuteActivity(activities.ClearIngestedSIPsActivityName, tt.params)
+			if len(tt.wantErr) > 0 {
+				assert.Assert(t, err != nil)
+				for _, wantErr := range tt.wantErr {
+					assert.ErrorContains(t, err, wantErr)
+				}
+				return
+			}
+			assert.NilError(t, err)
+
+			var res activities.ClearIngestedSIPsActivityResult
+			err = enc.Get(&res)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, &res, &activities.ClearIngestedSIPsActivityResult{})
+		})
+	}
+}


### PR DESCRIPTION
Run a cleanup activity after canceled batch workflows complete so ingested SIPs are marked as canceled and their stored AIPs are deleted. The activity paginates SIPs, skips non-relevant SIPs, requests AIP deletions, and polls storage until deletions finish while aggregating errors.

Refs #1483.