### PR TITLE
Add `SIPID` to the preprocessing workflow params

### DIFF
--- a/internal/childwf/preprocessing.go
+++ b/internal/childwf/preprocessing.go
@@ -1,8 +1,13 @@
 package childwf
 
+import "github.com/google/uuid"
+
 type PreprocessingParams struct {
 	// Relative path to the shared path.
 	RelativePath string
+
+	// SIPID is the identifier of the SIP being processed.
+	SIPID uuid.UUID
 }
 
 type PreprocessingResult struct {

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -1030,7 +1030,7 @@ func (w *ProcessingWorkflow) preprocessing(ctx temporalsdk_workflow.Context, sta
 	err = temporalsdk_workflow.ExecuteChildWorkflow(
 		preCtx,
 		cfg.WorkflowName,
-		childwf.PreprocessingParams{RelativePath: relPath},
+		childwf.PreprocessingParams{RelativePath: relPath, SIPID: state.sip.uuid},
 	).Get(preCtx, &ppResult)
 	if err != nil {
 		return err

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -323,6 +323,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 		internalCtx,
 		&childwf.PreprocessingParams{
 			RelativePath: strings.TrimPrefix(prepDownloadPath+"/"+key, prepSharedPath),
+			SIPID:        sipUUID,
 		},
 	).Return(
 		&childwf.PreprocessingResult{
@@ -424,6 +425,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 		internalCtx,
 		&childwf.PreprocessingParams{
 			RelativePath: strings.TrimPrefix(prepDownloadPath+"/"+key, prepSharedPath),
+			SIPID:        sipUUID,
 		},
 	).Return(
 		&childwf.PreprocessingResult{


### PR DESCRIPTION
This is required for the CVA preprocessing workflow for https://github.com/artefactual-sdps/cva-enduro-workflows/issues/1