### PR TITLE
Make EmailLinkedText react to text prop changes

### DIFF
--- a/dashboard/src/components/EmailLinkedText.vue
+++ b/dashboard/src/components/EmailLinkedText.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from "vue";
+
 const props = defineProps<{
   text: string;
 }>();
@@ -8,7 +10,7 @@ const splitRegex = new RegExp(`(${emailPattern})`, "g");
 const testRegex = new RegExp(`^${emailPattern}$`);
 
 // Split text into alternating parts: text / email / text / email...
-const parts = props.text.split(splitRegex);
+const parts = computed(() => props.text.split(splitRegex));
 
 function isEmail(part: string): boolean {
   return testRegex.test(part);

--- a/dashboard/src/components/__tests__/EmailLinkedText.test.ts
+++ b/dashboard/src/components/__tests__/EmailLinkedText.test.ts
@@ -75,4 +75,22 @@ describe("EmailLinkedText.vue", () => {
       `"<span>Write to <a href="mailto:me@example.com">me@example.com</a></span>"`,
     );
   });
+
+  it("updates rendered links when text prop changes", async () => {
+    wrapper = mount(EmailLinkedText, {
+      props: {
+        text: "Contact alpha@example.com",
+      },
+    });
+
+    await wrapper.setProps({
+      text: "Contact beta@example.com",
+    });
+
+    const link = wrapper.find("a");
+    expect(link.exists()).toBe(true);
+    expect(link.attributes("href")).toBe("mailto:beta@example.com");
+    expect(wrapper.text()).toContain("beta@example.com");
+    expect(wrapper.text()).not.toContain("alpha@example.com");
+  });
 });


### PR DESCRIPTION
Compute the split parts so updates to the text prop are reflected after mount. This fixes stale task note rendering during live updates.

Refs #1449.