### PR TITLE
Allow unauth auto-approve AIP deletion

### DIFF
--- a/internal/api/auth/claims.go
+++ b/internal/api/auth/claims.go
@@ -8,11 +8,12 @@ import (
 )
 
 type Claims struct {
-	Email         string `json:"email,omitempty"`
-	EmailVerified bool   `json:"email_verified,omitempty"`
-	Name          string `json:"name,omitempty"`
-	Iss           string `json:"iss,omitempty"`
-	Sub           string `json:"sub,omitempty"`
+	Email             string `json:"email,omitempty"`
+	EmailVerified     bool   `json:"email_verified,omitempty"`
+	PreferredUsername string `json:"preferred_username,omitempty"`
+	Name              string `json:"name,omitempty"`
+	Iss               string `json:"iss,omitempty"`
+	Sub               string `json:"sub,omitempty"`
 	// The attributes are parsed from a configured claim and added here,
 	// they are needed in the JSON representation for the MarshalBinary and
 	// UnmarshalBinary methods below. We use the `enduro_internal_attributes`
@@ -57,6 +58,22 @@ func (c *Claims) CheckAttributes(required []string) bool {
 	}
 
 	return true
+}
+
+// DisplayName returns the email claim if available, falling back to the
+// preferred username and then to the name. It returns an empty string if none
+// are set.
+func (c *Claims) DisplayName() string {
+	if c == nil {
+		return ""
+	}
+	if c.Email != "" {
+		return c.Email
+	}
+	if c.PreferredUsername != "" {
+		return c.PreferredUsername
+	}
+	return c.Name
 }
 
 type contextUserClaimsType struct{}

--- a/internal/api/auth/claims_test.go
+++ b/internal/api/auth/claims_test.go
@@ -42,11 +42,12 @@ func TestMarshalBinary(t *testing.T) {
 	t.Parallel()
 
 	claims := &auth.Claims{
-		Email:         "user@example.com",
-		EmailVerified: true,
-		Name:          "Test User",
-		Iss:           "issuer",
-		Sub:           "subject",
+		Email:             "user@example.com",
+		EmailVerified:     true,
+		PreferredUsername: "Preferred username",
+		Name:              "Test User",
+		Iss:               "issuer",
+		Sub:               "subject",
 	}
 
 	data, err := claims.MarshalBinary()
@@ -148,6 +149,57 @@ func TestCheckAttributes(t *testing.T) {
 			t.Parallel()
 
 			assert.Equal(t, tt.claims.CheckAttributes(tt.attributes), tt.want)
+		})
+	}
+}
+
+func TestDisplayName(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		name   string
+		claims *auth.Claims
+		want   string
+	}
+	for _, tt := range []test{
+		{
+			name: "Returns email when all fields are set",
+			claims: &auth.Claims{
+				Email:             "user@example.com",
+				PreferredUsername: "jdoe",
+				Name:              "John Doe",
+			},
+			want: "user@example.com",
+		},
+		{
+			name: "Falls back to preferred username when email is empty",
+			claims: &auth.Claims{
+				PreferredUsername: "jdoe",
+				Name:              "John Doe",
+			},
+			want: "jdoe",
+		},
+		{
+			name: "Falls back to name when email and preferred username are empty",
+			claims: &auth.Claims{
+				Name: "John Doe",
+			},
+			want: "John Doe",
+		},
+		{
+			name:   "Returns empty string when no fields are set",
+			claims: &auth.Claims{},
+			want:   "",
+		},
+		{
+			name: "Returns empty string for nil claims",
+			want: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.claims.DisplayName(), tt.want)
 		})
 	}
 }

--- a/internal/storage/deletion_request.go
+++ b/internal/storage/deletion_request.go
@@ -17,8 +17,8 @@ func checkClaims(claims *auth.Claims) error {
 	if claims == nil {
 		return goastorage.MakeNotValid(errors.New("authentication is required"))
 	}
-	if claims.Email == "" {
-		return goastorage.MakeNotValid(errors.New("email claim is required"))
+	if claims.DisplayName() == "" {
+		return goastorage.MakeNotValid(errors.New("email, preferred_username, or name claim is required"))
 	}
 	if claims.Sub == "" {
 		return goastorage.MakeNotValid(errors.New("sub claim is required"))
@@ -43,9 +43,9 @@ func (s *serviceImpl) AipDeletionAuto(ctx context.Context, payload *goastorage.A
 		}
 	} else {
 		claims = &auth.Claims{
-			Email: "auto-approve@enduro.sys",
-			Sub:   "unauthenticated",
-			Iss:   "unauthenticated",
+			Name: "Enduro-auto-approve",
+			Sub:  "unauthenticated",
+			Iss:  "unauthenticated",
 		}
 	}
 
@@ -95,7 +95,7 @@ func (s *serviceImpl) requestAIPDeletion(
 		AIPID:       aipID,
 		Reason:      reason,
 		TaskQueue:   s.config.TaskQueue,
-		UserEmail:   claims.Email,
+		UserEmail:   claims.DisplayName(),
 		UserSub:     claims.Sub,
 		UserIss:     claims.Iss,
 		AutoApprove: autoApprove,
@@ -150,7 +150,7 @@ func (s *serviceImpl) ReviewAipDeletion(ctx context.Context, payload *goastorage
 
 	signal := DeletionDecisionSignal{
 		Status:    status,
-		UserEmail: claims.Email,
+		UserEmail: claims.DisplayName(),
 		UserSub:   claims.Sub,
 		UserIss:   claims.Iss,
 	}
@@ -206,7 +206,7 @@ func (s *serviceImpl) CancelAipDeletion(
 		DeletionDecisionSignalName,
 		DeletionDecisionSignal{
 			Status:    enums.DeletionRequestStatusCanceled,
-			UserEmail: claims.Email,
+			UserEmail: claims.DisplayName(),
 			UserSub:   claims.Sub,
 			UserIss:   claims.Iss,
 		},

--- a/internal/storage/deletion_request.go
+++ b/internal/storage/deletion_request.go
@@ -35,8 +35,22 @@ func (s *serviceImpl) AipDeletionAuto(ctx context.Context, payload *goastorage.A
 		payload = &goastorage.AipDeletionAutoPayload{}
 	}
 
+	// Authentication can be disabled for auto-approve.
+	claims := auth.UserClaimsFromContext(ctx)
+	if claims != nil {
+		if err := checkClaims(claims); err != nil {
+			return err
+		}
+	} else {
+		claims = &auth.Claims{
+			Email: "auto-approve@enduro.sys",
+			Sub:   "unauthenticated",
+			Iss:   "unauthenticated",
+		}
+	}
+
 	skipReport := payload.SkipReport != nil && *payload.SkipReport
-	return s.requestAIPDeletion(ctx, payload.UUID, payload.Reason, true, skipReport)
+	return s.requestAIPDeletion(ctx, payload.UUID, payload.Reason, claims, true, skipReport)
 }
 
 func (s *serviceImpl) RequestAipDeletion(ctx context.Context, payload *goastorage.RequestAipDeletionPayload) error {
@@ -44,22 +58,23 @@ func (s *serviceImpl) RequestAipDeletion(ctx context.Context, payload *goastorag
 		payload = &goastorage.RequestAipDeletionPayload{}
 	}
 
-	return s.requestAIPDeletion(ctx, payload.UUID, payload.Reason, false, false)
-}
-
-func (s *serviceImpl) requestAIPDeletion(
-	ctx context.Context,
-	aipUUID string,
-	reason string,
-	autoApprove bool,
-	skipReport bool,
-) error {
 	// Authentication must be enabled for now.
 	claims := auth.UserClaimsFromContext(ctx)
 	if err := checkClaims(claims); err != nil {
 		return err
 	}
 
+	return s.requestAIPDeletion(ctx, payload.UUID, payload.Reason, claims, false, false)
+}
+
+func (s *serviceImpl) requestAIPDeletion(
+	ctx context.Context,
+	aipUUID string,
+	reason string,
+	claims *auth.Claims,
+	autoApprove bool,
+	skipReport bool,
+) error {
 	aipID, err := uuid.Parse(aipUUID)
 	if err != nil {
 		return goastorage.MakeNotValid(errors.New("invalid UUID"))

--- a/internal/storage/deletion_request_test.go
+++ b/internal/storage/deletion_request_test.go
@@ -25,67 +25,160 @@ import (
 func TestAipDeletionAuto(t *testing.T) {
 	t.Parallel()
 
-	type test struct {
-		name       string
-		payload    *goastorage.AipDeletionAutoPayload
-		skipReport bool
-	}
-
-	for _, tt := range []test{
+	for _, tt := range []struct {
+		name    string
+		claims  *auth.Claims
+		payload *goastorage.AipDeletionAutoPayload
+		mock    func(context.Context, *fake.MockStorage, *temporalsdk_mocks.Client)
+		wantErr string
+	}{
 		{
 			name: "Requests auto-approved AIP deletion",
+			claims: &auth.Claims{
+				Email: "requester@example.com",
+				Iss:   "issuer",
+				Sub:   "subject",
+			},
 			payload: &goastorage.AipDeletionAutoPayload{
 				UUID:   aipID.String(),
 				Reason: "Reason",
 			},
+			mock: func(ctx context.Context, s *fake.MockStorage, tc *temporalsdk_mocks.Client) {
+				s.EXPECT().ReadAIP(ctx, aipID).Return(
+					&goastorage.AIP{Status: enums.AIPStatusStored.String()},
+					nil,
+				)
+				tc.On(
+					"ExecuteWorkflow",
+					mock.AnythingOfType("*context.timerCtx"),
+					temporalsdk_client.StartWorkflowOptions{
+						ID:                    fmt.Sprintf("%s-%s", storage.StorageDeleteWorkflowName, aipID),
+						TaskQueue:             "global",
+						WorkflowIDReusePolicy: temporalapi_enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+					},
+					storage.StorageDeleteWorkflowName,
+					&storage.StorageDeleteWorkflowRequest{
+						AIPID:       aipID,
+						Reason:      "Reason",
+						UserEmail:   "requester@example.com",
+						UserIss:     "issuer",
+						UserSub:     "subject",
+						TaskQueue:   "global",
+						AutoApprove: true,
+						SkipReport:  false,
+					},
+				).Return(nil, nil)
+			},
 		},
 		{
 			name: "Requests auto-approved AIP deletion with report skipped",
+			claims: &auth.Claims{
+				Email: "requester@example.com",
+				Iss:   "issuer",
+				Sub:   "subject",
+			},
 			payload: &goastorage.AipDeletionAutoPayload{
 				UUID:       aipID.String(),
 				Reason:     "Reason",
 				SkipReport: ref.New(true),
 			},
-			skipReport: true,
+			mock: func(ctx context.Context, s *fake.MockStorage, tc *temporalsdk_mocks.Client) {
+				s.EXPECT().ReadAIP(ctx, aipID).Return(
+					&goastorage.AIP{Status: enums.AIPStatusStored.String()},
+					nil,
+				)
+				tc.On(
+					"ExecuteWorkflow",
+					mock.AnythingOfType("*context.timerCtx"),
+					temporalsdk_client.StartWorkflowOptions{
+						ID:                    fmt.Sprintf("%s-%s", storage.StorageDeleteWorkflowName, aipID),
+						TaskQueue:             "global",
+						WorkflowIDReusePolicy: temporalapi_enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+					},
+					storage.StorageDeleteWorkflowName,
+					&storage.StorageDeleteWorkflowRequest{
+						AIPID:       aipID,
+						Reason:      "Reason",
+						UserEmail:   "requester@example.com",
+						UserIss:     "issuer",
+						UserSub:     "subject",
+						TaskQueue:   "global",
+						AutoApprove: true,
+						SkipReport:  true,
+					},
+				).Return(nil, nil)
+			},
+		},
+		{
+			name: "Requests auto-approved AIP deletion when not authenticated",
+			payload: &goastorage.AipDeletionAutoPayload{
+				UUID:   aipID.String(),
+				Reason: "Reason",
+			},
+			mock: func(ctx context.Context, s *fake.MockStorage, tc *temporalsdk_mocks.Client) {
+				s.EXPECT().ReadAIP(ctx, aipID).Return(
+					&goastorage.AIP{Status: enums.AIPStatusStored.String()},
+					nil,
+				)
+				tc.On(
+					"ExecuteWorkflow",
+					mock.AnythingOfType("*context.timerCtx"),
+					temporalsdk_client.StartWorkflowOptions{
+						ID:                    fmt.Sprintf("%s-%s", storage.StorageDeleteWorkflowName, aipID),
+						TaskQueue:             "global",
+						WorkflowIDReusePolicy: temporalapi_enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+					},
+					storage.StorageDeleteWorkflowName,
+					&storage.StorageDeleteWorkflowRequest{
+						AIPID:       aipID,
+						Reason:      "Reason",
+						UserEmail:   "auto-approve@enduro.sys",
+						UserIss:     "unauthenticated",
+						UserSub:     "unauthenticated",
+						TaskQueue:   "global",
+						AutoApprove: true,
+						SkipReport:  false,
+					},
+				).Return(nil, nil)
+			},
+		},
+		{
+			name:    "Fails to request auto-approved AIP deletion (missing email claim)",
+			claims:  &auth.Claims{},
+			wantErr: "email claim is required",
+		},
+		{
+			name: "Fails to request auto-approved AIP deletion (missing sub claim)",
+			claims: &auth.Claims{
+				Email: "requester@example.com",
+			},
+			wantErr: "sub claim is required",
+		},
+		{
+			name: "Fails to request auto-approved AIP deletion (missing iss claim)",
+			claims: &auth.Claims{
+				Email: "requester@example.com",
+				Sub:   "subject",
+			},
+			wantErr: "iss claim is required",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := auth.WithUserClaims(context.Background(), &auth.Claims{
-				Email: "requester@example.com",
-				Iss:   "issuer",
-				Sub:   "subject",
-			})
+			ctx := auth.WithUserClaims(context.Background(), tt.claims)
 			attrs := &setUpAttrs{}
 			svc := setUpService(t, attrs)
 
-			attrs.persistenceMock.EXPECT().ReadAIP(ctx, aipID).Return(
-				&goastorage.AIP{Status: enums.AIPStatusStored.String()},
-				nil,
-			)
-			attrs.temporalClientMock.On(
-				"ExecuteWorkflow",
-				mock.AnythingOfType("*context.timerCtx"),
-				temporalsdk_client.StartWorkflowOptions{
-					ID:                    fmt.Sprintf("%s-%s", storage.StorageDeleteWorkflowName, aipID),
-					TaskQueue:             "global",
-					WorkflowIDReusePolicy: temporalapi_enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
-				},
-				storage.StorageDeleteWorkflowName,
-				&storage.StorageDeleteWorkflowRequest{
-					AIPID:       aipID,
-					Reason:      "Reason",
-					UserEmail:   "requester@example.com",
-					UserIss:     "issuer",
-					UserSub:     "subject",
-					TaskQueue:   "global",
-					AutoApprove: true,
-					SkipReport:  tt.skipReport,
-				},
-			).Return(nil, nil)
+			if tt.mock != nil {
+				tt.mock(ctx, attrs.persistenceMock, attrs.temporalClientMock)
+			}
 
 			err := svc.AipDeletionAuto(ctx, tt.payload)
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				return
+			}
 			assert.NilError(t, err)
 		})
 	}

--- a/internal/storage/deletion_request_test.go
+++ b/internal/storage/deletion_request_test.go
@@ -132,7 +132,7 @@ func TestAipDeletionAuto(t *testing.T) {
 					&storage.StorageDeleteWorkflowRequest{
 						AIPID:       aipID,
 						Reason:      "Reason",
-						UserEmail:   "auto-approve@enduro.sys",
+						UserEmail:   "Enduro-auto-approve",
 						UserIss:     "unauthenticated",
 						UserSub:     "unauthenticated",
 						TaskQueue:   "global",
@@ -143,9 +143,9 @@ func TestAipDeletionAuto(t *testing.T) {
 			},
 		},
 		{
-			name:    "Fails to request auto-approved AIP deletion (missing email claim)",
+			name:    "Fails to request auto-approved AIP deletion (missing claims)",
 			claims:  &auth.Claims{},
-			wantErr: "email claim is required",
+			wantErr: "email, preferred_username, or name claim is required",
 		},
 		{
 			name: "Fails to request auto-approved AIP deletion (missing sub claim)",
@@ -201,9 +201,9 @@ func TestRequestAipDeletion(t *testing.T) {
 			wantErr: "authentication is required",
 		},
 		{
-			name:    "Fails to request AIP deletion (missing email claim)",
+			name:    "Fails to request AIP deletion (missing claims)",
 			claims:  &auth.Claims{},
-			wantErr: "email claim is required",
+			wantErr: "email, preferred_username, or name claim is required",
 		},
 		{
 			name: "Fails to request AIP deletion (missing sub claim)",
@@ -382,9 +382,9 @@ func TestReviewAipDeletion(t *testing.T) {
 			wantErr: "authentication is required",
 		},
 		{
-			name:    "Fails to review AIP deletion (missing email claim)",
+			name:    "Fails to review AIP deletion (missing claims)",
 			claims:  &auth.Claims{},
-			wantErr: "email claim is required",
+			wantErr: "email, preferred_username, or name claim is required",
 		},
 		{
 			name: "Fails to review AIP deletion (missing sub claim)",


### PR DESCRIPTION
Until #1493 is addressed we need to consider systems where authentication is disabled. This also allows to target the unauth internal API from the storage client in environments where an OIDC provider with the client credentials flow is not available (e.g.: Dex).

Also, allow AIP deletion requests without email claim. Consider `preferred_username` claim. Get requester/reviewer display name from the email claim if available, falling back to the preferred username and then to the name; at least one of them is required. This removes the requirement to configure an email claim for the client credentials flow, which may not be included by default in some providers.

Refs #1494, #1483 and #1513. Replaces #1523.