### PR TITLE
Bump go from 1.25.4 to 1.26.1

### DIFF
--- a/.bine.json
+++ b/.bine.json
@@ -33,7 +33,7 @@
     {
       "name": "golangci-lint",
       "url": "https://github.com/golangci/golangci-lint",
-      "version": "2.6.2",
+      "version": "2.11.2",
       "asset_pattern": "{name}-{version}-{goos}-{goarch}.tar.gz"
     },
     {

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - revive
     - tparallel
     - unparam
+    - modernize
   settings:
     gosec:
       severity: low

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,10 +9,10 @@ linters:
     - importas
     - intrange
     - misspell
+    - modernize
     - revive
     - tparallel
     - unparam
-    - modernize
   settings:
     gosec:
       severity: low

--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -451,7 +451,12 @@ func main() {
 									SIPUUID:         uuid.New(),
 									SIPName:         event.Key,
 								}
-								if err := ingest.InitProcessingWorkflow(ctx, temporalClient, cfg.Temporal.TaskQueue, &req); err != nil {
+								if err := ingest.InitProcessingWorkflow(
+									ctx,
+									temporalClient,
+									cfg.Temporal.TaskQueue,
+									&req,
+								); err != nil {
 									logger.Error(err, "Error initializing processing workflow.")
 									span.RecordError(err)
 									span.SetStatus(codes.Error, err.Error())

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/artefactual-sdps/enduro
 
-go 1.25.4
+go 1.26.1
 
 require (
 	ariga.io/atlas v0.37.0

--- a/hack/pulumi/azure-storage/go.mod
+++ b/hack/pulumi/azure-storage/go.mod
@@ -1,6 +1,6 @@
 module enduro-dev-azure-storage
 
-go 1.25.4
+go 1.26.1
 
 require (
 	github.com/pulumi/pulumi-azure-native-sdk/resources/v2 v2.90.0

--- a/hack/pulumi/azure-storage/main.go
+++ b/hack/pulumi/azure-storage/main.go
@@ -16,7 +16,7 @@ func main() {
 
 		// Create an Azure resource (Storage Account)
 		account, err := storage.NewStorageAccount(ctx, "enduro-dev-blob", &storage.StorageAccountArgs{
-			AccountName: pulumi.String("endurodev"),
+			AccountName:       pulumi.String("endurodev"),
 			ResourceGroupName: resourceGroup.Name,
 			Sku: &storage.SkuArgs{
 				Name: pulumi.String("Standard_LRS"),
@@ -29,9 +29,9 @@ func main() {
 
 		_, err = storage.NewBlobContainer(ctx, "sips", &storage.BlobContainerArgs{
 			ResourceGroupName: resourceGroup.Name,
-			AccountName: account.Name,
-			ContainerName: pulumi.String("sips"),
-		})	
+			AccountName:       account.Name,
+			ContainerName:     pulumi.String("sips"),
+		})
 		if err != nil {
 			return err
 		}

--- a/hack/pulumi/go.mod
+++ b/hack/pulumi/go.mod
@@ -1,6 +1,6 @@
 module enduro
 
-go 1.25.4
+go 1.26.1
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0

--- a/internal/api/auth/ticket_store.go
+++ b/internal/api/auth/ticket_store.go
@@ -141,13 +141,13 @@ func (s *InMemStore) GetDel(ctx context.Context, key string, value any) error {
 	// Set the value using reflection.
 	if value != nil {
 		valPtr := reflect.ValueOf(value)
-		if valPtr.Kind() != reflect.Ptr {
+		if valPtr.Kind() != reflect.Pointer {
 			return fmt.Errorf("value argument must be a pointer")
 		}
 		val := valPtr.Elem()
 		memVal := reflect.ValueOf(match.value)
 		// If stored value is a pointer, dereference it.
-		if memVal.Kind() == reflect.Ptr {
+		if memVal.Kind() == reflect.Pointer {
 			memVal = memVal.Elem()
 		}
 		if memVal.Type() != val.Type() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,7 +178,7 @@ func setCORSOriginEnv(config *Configuration) error {
 // https://github.com/go-saas/kit/blob/main/pkg/mapstructure/mapstructure.go
 func stringToUUIDHookFunc() mapstructure.DecodeHookFunc {
 	return func(f, t reflect.Type, data any) (any, error) {
-		if f.Kind() != reflect.String || t != reflect.TypeOf(uuid.UUID{}) {
+		if f.Kind() != reflect.String || t != reflect.TypeFor[uuid.UUID]() {
 			return data, nil
 		}
 
@@ -190,7 +190,7 @@ func stringToUUIDHookFunc() mapstructure.DecodeHookFunc {
 func stringToMapHookFunc() mapstructure.DecodeHookFunc {
 	return func(f, t reflect.Type, data any) (any, error) {
 		value := map[string][]string{}
-		if f.Kind() != reflect.String || t != reflect.TypeOf(value) {
+		if f.Kind() != reflect.String || t != reflect.TypeFor[map[string][]string]() {
 			return data, nil
 		}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -52,7 +52,7 @@ defaultPermanentLocationId = "f2cc963f-c14d-4eaa-b950-bd207189a1f1"
 enabled = true
 providerURL = "https://idp.example.com/realms/enduro-internal"
 clientID = "enduro-worker"
-clientSecret = "secret"
+clientSecret = "placeholder-value"
 scopes = "openid,profile"
 audience = "enduro-s2s"
 tokenExpiryLeeway = "60s"
@@ -119,11 +119,11 @@ func TestConfigRead(t *testing.T) {
 					Storage: ingest.StorageConfig{
 						Address:                    "storage-api:9000",
 						DefaultPermanentLocationID: uuid.MustParse("f2cc963f-c14d-4eaa-b950-bd207189a1f1"),
-						OIDC: ingest.StorageOIDCConfig{
+						OIDC: ingest.StorageOIDCConfig{ // #nosec G101 -- test-only placeholder credential.
 							Enabled:                 true,
 							ProviderURL:             "https://idp.example.com/realms/enduro-internal",
 							ClientID:                "enduro-worker",
-							ClientSecret:            "secret",
+							ClientSecret:            "placeholder-value",
 							Scopes:                  []string{"openid", "profile"},
 							Audience:                "enduro-s2s",
 							TokenExpiryLeeway:       60 * time.Second,

--- a/internal/datatypes/batch.go
+++ b/internal/datatypes/batch.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"go.artefactual.dev/tools/ref"
 
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
 	"github.com/artefactual-sdps/enduro/internal/db"
@@ -40,13 +39,13 @@ func (b *Batch) Goa() *goaingest.Batch {
 		CreatedAt:  db.FormatTime(b.CreatedAt),
 	}
 	if !b.StartedAt.IsZero() {
-		col.StartedAt = ref.New(b.StartedAt.Format(time.RFC3339))
+		col.StartedAt = new(b.StartedAt.Format(time.RFC3339))
 	}
 	if !b.CompletedAt.IsZero() {
-		col.CompletedAt = ref.New(b.CompletedAt.Format(time.RFC3339))
+		col.CompletedAt = new(b.CompletedAt.Format(time.RFC3339))
 	}
 	if b.Uploader != nil {
-		col.UploaderUUID = ref.New(b.Uploader.UUID)
+		col.UploaderUUID = new(b.Uploader.UUID)
 		if b.Uploader.Email != "" {
 			col.UploaderEmail = &b.Uploader.Email
 		}

--- a/internal/datatypes/sip.go
+++ b/internal/datatypes/sip.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"go.artefactual.dev/tools/ref"
 
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
 	"github.com/artefactual-sdps/enduro/internal/db"
@@ -57,16 +56,16 @@ func (s *SIP) Goa() *goaingest.SIP {
 		CompletedAt: db.FormatOptionalTime(s.CompletedAt),
 	}
 	if s.AIPID.Valid {
-		col.AipUUID = ref.New(s.AIPID.UUID.String())
+		col.AipUUID = new(s.AIPID.UUID.String())
 	}
 	if s.FailedAs != "" {
-		col.FailedAs = ref.New(s.FailedAs.String())
+		col.FailedAs = new(s.FailedAs.String())
 	}
 	if s.FailedKey != "" {
-		col.FailedKey = ref.New(s.FailedKey)
+		col.FailedKey = new(s.FailedKey)
 	}
 	if s.Uploader != nil {
-		col.UploaderUUID = ref.New(s.Uploader.UUID)
+		col.UploaderUUID = new(s.Uploader.UUID)
 		if s.Uploader.Email != "" {
 			col.UploaderEmail = &s.Uploader.Email
 		}
@@ -75,9 +74,9 @@ func (s *SIP) Goa() *goaingest.SIP {
 		}
 	}
 	if s.Batch != nil {
-		col.BatchUUID = ref.New(s.Batch.UUID)
-		col.BatchIdentifier = ref.New(s.Batch.Identifier)
-		col.BatchStatus = ref.New(s.Batch.Status.String())
+		col.BatchUUID = new(s.Batch.UUID)
+		col.BatchIdentifier = new(s.Batch.Identifier)
+		col.BatchStatus = new(s.Batch.Status.String())
 	}
 
 	return &col

--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -2,8 +2,6 @@ package fsutil
 
 import (
 	"errors"
-	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,47 +47,6 @@ func Move(src, dst string) error {
 	}
 
 	return err
-}
-
-// SetFileModes recursively sets the file mode of root and its contents.
-func SetFileModes(root string, dirMode, fileMode fs.FileMode) error {
-	info, err := os.Stat(root)
-	if err != nil {
-		return err
-	}
-
-	if !info.IsDir() {
-		if err := os.Chmod(root, fileMode); err != nil {
-			return fmt.Errorf("set permissions: %v", err)
-		}
-
-		return nil
-	}
-
-	scopedRoot, err := os.OpenRoot(root)
-	if err != nil {
-		return err
-	}
-	defer scopedRoot.Close()
-
-	return fs.WalkDir(scopedRoot.FS(), ".",
-		func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-
-			mode := fileMode
-			if d.IsDir() {
-				mode = dirMode
-			}
-
-			if err := scopedRoot.Chmod(path, mode); err != nil {
-				return fmt.Errorf("set permissions: %v", err)
-			}
-
-			return nil
-		},
-	)
 }
 
 // FileExists returns true if a file (or directory) exists at path.  If a file

--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -16,8 +16,8 @@ var Renamer = os.Rename
 
 func BaseNoExt(path string) string {
 	base := filepath.Base(path)
-	if idx := strings.IndexByte(base, '.'); idx != -1 {
-		return base[:idx]
+	if before, _, ok := strings.Cut(base, "."); ok {
+		return before
 	}
 	return base
 }
@@ -53,18 +53,37 @@ func Move(src, dst string) error {
 
 // SetFileModes recursively sets the file mode of root and its contents.
 func SetFileModes(root string, dirMode, fileMode fs.FileMode) error {
-	return filepath.WalkDir(root,
-		func(path string, d os.DirEntry, err error) error {
+	info, err := os.Stat(root)
+	if err != nil {
+		return err
+	}
+
+	if !info.IsDir() {
+		if err := os.Chmod(root, fileMode); err != nil {
+			return fmt.Errorf("set permissions: %v", err)
+		}
+
+		return nil
+	}
+
+	scopedRoot, err := os.OpenRoot(root)
+	if err != nil {
+		return err
+	}
+	defer scopedRoot.Close()
+
+	return fs.WalkDir(scopedRoot.FS(), ".",
+		func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
 
-			mode := fs.FileMode(fileMode)
+			mode := fileMode
 			if d.IsDir() {
-				mode = fs.FileMode(dirMode)
+				mode = dirMode
 			}
 
-			if err := os.Chmod(path, mode); err != nil {
+			if err := scopedRoot.Chmod(path, mode); err != nil {
 				return fmt.Errorf("set permissions: %v", err)
 			}
 

--- a/internal/fsutil/fsutil_test.go
+++ b/internal/fsutil/fsutil_test.go
@@ -112,31 +112,6 @@ func TestMove(t *testing.T) {
 	})
 }
 
-func TestSetFileModes(t *testing.T) {
-	td := fs.NewDir(t, "enduro-test-fsutil",
-		fs.WithDir("transfer", fs.WithMode(0o755),
-			fs.WithFile("test1", "I'm a test file.", fs.WithMode(0o644)),
-			fs.WithDir("subdir", fs.WithMode(0o755),
-				fs.WithFile("test2", "Another test file.", fs.WithMode(0o644)),
-			),
-		),
-	)
-
-	err := fsutil.SetFileModes(td.Join("transfer"), 0o700, 0o600)
-	assert.NilError(t, err)
-	assert.Assert(t, fs.Equal(
-		td.Path(),
-		fs.Expected(t,
-			fs.WithDir("transfer", fs.WithMode(0o700),
-				fs.WithFile("test1", "I'm a test file.", fs.WithMode(0o600)),
-				fs.WithDir("subdir", fs.WithMode(0o700),
-					fs.WithFile("test2", "Another test file.", fs.WithMode(0o600)),
-				),
-			),
-		),
-	))
-}
-
 func TestFileExists(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ingest/config_test.go
+++ b/internal/ingest/config_test.go
@@ -53,28 +53,28 @@ func TestStorageOIDCConfigValidate(t *testing.T) {
 		},
 		{
 			name: "Passes validation with provider URL and client credentials",
-			cfg: ingest.StorageOIDCConfig{
+			cfg: ingest.StorageOIDCConfig{ // #nosec G101 -- test-only placeholder credential.
 				Enabled:      true,
 				ProviderURL:  "https://idp.example.com/realms/enduro",
 				ClientID:     "enduro-worker",
-				ClientSecret: "secret",
+				ClientSecret: "placeholder-value",
 			},
 		},
 		{
 			name: "Passes validation with token URL and client credentials",
-			cfg: ingest.StorageOIDCConfig{
+			cfg: ingest.StorageOIDCConfig{ // #nosec G101 -- test-only placeholder credential.
 				Enabled:      true,
 				TokenURL:     "https://idp.example.com/token",
 				ClientID:     "enduro-worker",
-				ClientSecret: "secret",
+				ClientSecret: "placeholder-value",
 			},
 		},
 		{
 			name: "Fails validation when both providerURL and tokenURL are missing",
-			cfg: ingest.StorageOIDCConfig{
+			cfg: ingest.StorageOIDCConfig{ // #nosec G101 -- test-only placeholder credential.
 				Enabled:      true,
 				ClientID:     "enduro-worker",
-				ClientSecret: "secret",
+				ClientSecret: "placeholder-value",
 			},
 			wantErr: "missing OIDC providerURL or tokenURL with storage OIDC auth. enabled",
 		},
@@ -88,22 +88,22 @@ func TestStorageOIDCConfigValidate(t *testing.T) {
 		},
 		{
 			name: "Fails validation with invalid retry attempts",
-			cfg: ingest.StorageOIDCConfig{
+			cfg: ingest.StorageOIDCConfig{ // #nosec G101 -- test-only placeholder credential.
 				Enabled:          true,
 				ProviderURL:      "https://idp.example.com/realms/enduro",
 				ClientID:         "enduro-worker",
-				ClientSecret:     "secret",
+				ClientSecret:     "placeholder-value",
 				RetryMaxAttempts: -1,
 			},
 			wantErr: "invalid storage OIDC retry max attempts, value must be >= 0",
 		},
 		{
 			name: "Fails validation with invalid retry backoff coefficient",
-			cfg: ingest.StorageOIDCConfig{
+			cfg: ingest.StorageOIDCConfig{ // #nosec G101 -- test-only placeholder credential.
 				Enabled:                 true,
 				ProviderURL:             "https://idp.example.com/realms/enduro",
 				ClientID:                "enduro-worker",
-				ClientSecret:            "secret",
+				ClientSecret:            "placeholder-value",
 				RetryBackoffCoefficient: 0.5,
 				RetryMaxAttempts:        3,
 				RetryInitialInterval:    1 * time.Millisecond,

--- a/internal/ingest/convert.go
+++ b/internal/ingest/convert.go
@@ -230,10 +230,10 @@ func sipSourceObjectsToGoa(objects []*sipsource.Object) goaingest.SIPSourceObjec
 		r[i] = &goaingest.SIPSourceObject{Key: object.Key, IsDir: object.IsDir}
 
 		if object.Size != 0 {
-			r[i].Size = ref.New(object.Size)
+			r[i].Size = new(object.Size)
 		}
 		if !object.ModTime.IsZero() {
-			r[i].ModTime = ref.New(object.ModTime.Format(time.RFC3339))
+			r[i].ModTime = new(object.ModTime.Format(time.RFC3339))
 		}
 	}
 

--- a/internal/ingest/download_sip_test.go
+++ b/internal/ingest/download_sip_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	"go.artefactual.dev/tools/ref"
 	"go.uber.org/mock/gomock"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/memblob"
@@ -137,7 +136,7 @@ func TestDownloadSipRequest(t *testing.T) {
 				ts.EXPECT().SetEx(ctx, "Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk", nil, time.Second*5).Return(nil)
 			},
 			wantRes: &goaingest.DownloadSipRequestResult{
-				Ticket: ref.New("Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk"),
+				Ticket: new("Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk"),
 			},
 		},
 	} {
@@ -192,7 +191,7 @@ func TestDownloadSip(t *testing.T) {
 		},
 		{
 			name:    "Fails to download a SIP (invalid ticket)",
-			payload: &goaingest.DownloadSipPayload{Ticket: ref.New("invalid-ticket")},
+			payload: &goaingest.DownloadSipPayload{Ticket: new("invalid-ticket")},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
 				ts.EXPECT().GetDel(ctx, "invalid-ticket", nil).Return(auth.ErrKeyNotFound)
 			},
@@ -201,7 +200,7 @@ func TestDownloadSip(t *testing.T) {
 		{
 			name: "Fails to download a SIP (invalid UUID)",
 			payload: &goaingest.DownloadSipPayload{
-				Ticket: ref.New("valid-ticket"),
+				Ticket: new("valid-ticket"),
 				UUID:   "invalid-uuid",
 			},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
@@ -212,7 +211,7 @@ func TestDownloadSip(t *testing.T) {
 		{
 			name: "Fails to download a SIP (SIP not found)",
 			payload: &goaingest.DownloadSipPayload{
-				Ticket: ref.New("valid-ticket"),
+				Ticket: new("valid-ticket"),
 				UUID:   sipUUID.String(),
 			},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
@@ -224,7 +223,7 @@ func TestDownloadSip(t *testing.T) {
 		{
 			name: "Fails to download a SIP (persistence error)",
 			payload: &goaingest.DownloadSipPayload{
-				Ticket: ref.New("valid-ticket"),
+				Ticket: new("valid-ticket"),
 				UUID:   sipUUID.String(),
 			},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
@@ -236,7 +235,7 @@ func TestDownloadSip(t *testing.T) {
 		{
 			name: "Fails to download a SIP (missing failed values)",
 			payload: &goaingest.DownloadSipPayload{
-				Ticket: ref.New("valid-ticket"),
+				Ticket: new("valid-ticket"),
 				UUID:   sipUUID.String(),
 			},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
@@ -248,7 +247,7 @@ func TestDownloadSip(t *testing.T) {
 		{
 			name: "Fails to download a SIP (SIP file not found)",
 			payload: &goaingest.DownloadSipPayload{
-				Ticket: ref.New("valid-ticket"),
+				Ticket: new("valid-ticket"),
 				UUID:   sipUUID.String(),
 			},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
@@ -265,7 +264,7 @@ func TestDownloadSip(t *testing.T) {
 		{
 			name: "Downloads a SIP",
 			payload: &goaingest.DownloadSipPayload{
-				Ticket: ref.New("valid-ticket"),
+				Ticket: new("valid-ticket"),
 				UUID:   sipUUID.String(),
 			},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {

--- a/internal/ingest/event_test.go
+++ b/internal/ingest/event_test.go
@@ -3,7 +3,6 @@ package ingest_test
 import (
 	"testing"
 
-	"go.artefactual.dev/tools/ref"
 	"gotest.tools/v3/assert"
 
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
@@ -35,7 +34,7 @@ func TestEventSerializer(t *testing.T) {
 
 	serializer := &ingest.EventSerializer{}
 	originalEvent := &goaingest.IngestEvent{
-		Value: &goaingest.IngestPingEvent{Message: ref.New("test")},
+		Value: &goaingest.IngestPingEvent{Message: new("test")},
 	}
 
 	data, err := serializer.Marshal(originalEvent)

--- a/internal/ingest/goa.go
+++ b/internal/ingest/goa.go
@@ -311,7 +311,7 @@ func (w *ingestImpl) ListSipSourceObjects(
 	}
 
 	if page.NextToken != nil {
-		res.Next = ref.New(string(page.NextToken))
+		res.Next = new(string(page.NextToken))
 	}
 
 	return res, nil

--- a/internal/ingest/goa_batch_test.go
+++ b/internal/ingest/goa_batch_test.go
@@ -34,7 +34,7 @@ func TestAddBatch(t *testing.T) {
 	batchUUID := uuid.MustParse("52fdfc07-2182-454f-963f-5f0f9a621d72")
 	userUUID := uuid.MustParse("9566c74d-1003-4c4d-bbbb-0407d1e2c649")
 	keys := []string{"sip1.zip", "sip2.zip", "sip3.zip"}
-	identifier := ref.New("custom-identifier")
+	identifier := new("custom-identifier")
 	batch := &datatypes.Batch{
 		UUID:       batchUUID,
 		Identifier: fmt.Sprintf("Batch-%s", batchUUID.String()),
@@ -281,11 +281,11 @@ func TestShowBatch(t *testing.T) {
 				Status:        enums.BatchStatusIngested.String(),
 				SipsCount:     3,
 				CreatedAt:     createdAt.Format(time.RFC3339),
-				StartedAt:     ref.New(startedAt.Format(time.RFC3339)),
-				CompletedAt:   ref.New(completedAt.Format(time.RFC3339)),
-				UploaderUUID:  ref.New(userUUID),
-				UploaderEmail: ref.New("nobody@example.com"),
-				UploaderName:  ref.New("Test User"),
+				StartedAt:     new(startedAt.Format(time.RFC3339)),
+				CompletedAt:   new(completedAt.Format(time.RFC3339)),
+				UploaderUUID:  new(userUUID),
+				UploaderEmail: new("nobody@example.com"),
+				UploaderName:  new("Test User"),
 			},
 		},
 	} {
@@ -483,11 +483,11 @@ func TestListBatches(t *testing.T) {
 						SipsCount:     2,
 						Status:        enums.BatchStatusIngested.String(),
 						CreatedAt:     "2024-09-25T09:31:10Z",
-						StartedAt:     ref.New("2024-09-25T09:31:11Z"),
-						CompletedAt:   ref.New("2024-09-25T09:31:12Z"),
-						UploaderUUID:  ref.New(uploaderUUID),
-						UploaderEmail: ref.New("uploader@example.com"),
-						UploaderName:  ref.New("Test Uploader"),
+						StartedAt:     new("2024-09-25T09:31:11Z"),
+						CompletedAt:   new("2024-09-25T09:31:12Z"),
+						UploaderUUID:  new(uploaderUUID),
+						UploaderEmail: new("uploader@example.com"),
+						UploaderName:  new("Test Uploader"),
 					},
 					{
 						UUID:       batchUUID2,
@@ -495,7 +495,7 @@ func TestListBatches(t *testing.T) {
 						SipsCount:  3,
 						Status:     enums.BatchStatusProcessing.String(),
 						CreatedAt:  "2024-10-01T17:13:26Z",
-						StartedAt:  ref.New("2024-10-01T17:13:27Z"),
+						StartedAt:  new("2024-10-01T17:13:27Z"),
 					},
 					{
 						UUID:       batchUUID3,
@@ -514,25 +514,25 @@ func TestListBatches(t *testing.T) {
 		{
 			name: "Returns filtered batches",
 			payload: &goaingest.ListBatchesPayload{
-				Identifier:          ref.New("Batch 1"),
-				EarliestCreatedTime: ref.New("2024-09-25T09:30:00Z"),
-				LatestCreatedTime:   ref.New("2024-09-25T09:40:00Z"),
-				Status:              ref.New(enums.BatchStatusIngested.String()),
-				UploaderUUID:        ref.New("0b075937-458c-43d9-b46c-222a072d62a9"),
-				Limit:               ref.New(10),
-				Offset:              ref.New(1),
+				Identifier:          new("Batch 1"),
+				EarliestCreatedTime: new("2024-09-25T09:30:00Z"),
+				LatestCreatedTime:   new("2024-09-25T09:40:00Z"),
+				Status:              new(enums.BatchStatusIngested.String()),
+				UploaderUUID:        new("0b075937-458c-43d9-b46c-222a072d62a9"),
+				Limit:               new(10),
+				Offset:              new(1),
 			},
 			mockRecorder: func(mr *persistence_fake.MockServiceMockRecorder) {
 				mr.ListBatches(
 					mockutil.Context(),
 					&persistence.BatchFilter{
-						Identifier: ref.New("Batch 1"),
+						Identifier: new("Batch 1"),
 						Status:     ref.New(enums.BatchStatusIngested),
 						CreatedAt: &timerange.Range{
 							Start: time.Date(2024, 9, 25, 9, 30, 0, 0, time.UTC),
 							End:   time.Date(2024, 9, 25, 9, 40, 0, 0, time.UTC),
 						},
-						UploaderID: ref.New(uuid.MustParse("0b075937-458c-43d9-b46c-222a072d62a9")),
+						UploaderID: new(uuid.MustParse("0b075937-458c-43d9-b46c-222a072d62a9")),
 						Sort:       entfilter.NewSort().AddCol("id", true),
 						Page: persistence.Page{
 							Limit:  10,
@@ -553,11 +553,11 @@ func TestListBatches(t *testing.T) {
 						SipsCount:     2,
 						Status:        enums.BatchStatusIngested.String(),
 						CreatedAt:     "2024-09-25T09:31:10Z",
-						StartedAt:     ref.New("2024-09-25T09:31:11Z"),
-						CompletedAt:   ref.New("2024-09-25T09:31:12Z"),
-						UploaderUUID:  ref.New(uploaderUUID),
-						UploaderEmail: ref.New("uploader@example.com"),
-						UploaderName:  ref.New("Test Uploader"),
+						StartedAt:     new("2024-09-25T09:31:11Z"),
+						CompletedAt:   new("2024-09-25T09:31:12Z"),
+						UploaderUUID:  new(uploaderUUID),
+						UploaderEmail: new("uploader@example.com"),
+						UploaderName:  new("Test Uploader"),
 					},
 				},
 				Page: &goaingest.EnduroPage{
@@ -569,13 +569,13 @@ func TestListBatches(t *testing.T) {
 		{
 			name: "Errors on an internal service error",
 			payload: &goaingest.ListBatchesPayload{
-				Identifier: ref.New("Batch 42"),
+				Identifier: new("Batch 42"),
 			},
 			mockRecorder: func(mr *persistence_fake.MockServiceMockRecorder) {
 				mr.ListBatches(
 					mockutil.Context(),
 					&persistence.BatchFilter{
-						Identifier: ref.New("Batch 42"),
+						Identifier: new("Batch 42"),
 						Sort:       entfilter.NewSort().AddCol("id", true),
 					},
 				).Return(nil, nil, persistence.ErrInternal)
@@ -585,36 +585,36 @@ func TestListBatches(t *testing.T) {
 		{
 			name: "Errors on a bad uploader_uuid",
 			payload: &goaingest.ListBatchesPayload{
-				UploaderUUID: ref.New("invalid"),
+				UploaderUUID: new("invalid"),
 			},
 			wantErr: "uploader_uuid: invalid UUID",
 		},
 		{
 			name: "Errors on a bad status",
 			payload: &goaingest.ListBatchesPayload{
-				Status: ref.New("meditating"),
+				Status: new("meditating"),
 			},
 			wantErr: "status: invalid value",
 		},
 		{
 			name: "Errors on a bad earliest_created_time",
 			payload: &goaingest.ListBatchesPayload{
-				EarliestCreatedTime: ref.New("2024-15-15T25:83:52Z"),
+				EarliestCreatedTime: new("2024-15-15T25:83:52Z"),
 			},
 			wantErr: "created at: time range: cannot parse start time",
 		},
 		{
 			name: "Errors on a bad latest_created_time",
 			payload: &goaingest.ListBatchesPayload{
-				LatestCreatedTime: ref.New("2024-15-15T25:83:52Z"),
+				LatestCreatedTime: new("2024-15-15T25:83:52Z"),
 			},
 			wantErr: "created at: time range: cannot parse end time",
 		},
 		{
 			name: "Errors on a bad created at range",
 			payload: &goaingest.ListBatchesPayload{
-				EarliestCreatedTime: ref.New("2024-10-01T17:43:52Z"),
-				LatestCreatedTime:   ref.New("2023-10-01T17:43:52Z"),
+				EarliestCreatedTime: new("2024-10-01T17:43:52Z"),
+				LatestCreatedTime:   new("2023-10-01T17:43:52Z"),
 			},
 			wantErr: "created at: time range: end cannot be before start",
 		},

--- a/internal/ingest/goa_test.go
+++ b/internal/ingest/goa_test.go
@@ -423,34 +423,34 @@ func TestListSIPs(t *testing.T) {
 				Items: goaingest.SIPCollection{
 					{
 						UUID:          sipUUID1,
-						Name:          ref.New("Test SIP 1"),
+						Name:          new("Test SIP 1"),
 						Status:        enums.SIPStatusIngested.String(),
-						AipUUID:       ref.New("e2ace0da-8697-453d-9ea1-4c9b62309e54"),
+						AipUUID:       new("e2ace0da-8697-453d-9ea1-4c9b62309e54"),
 						CreatedAt:     "2024-09-25T09:31:10Z",
-						StartedAt:     ref.New("2024-09-25T09:31:11Z"),
-						CompletedAt:   ref.New("2024-09-25T09:31:12Z"),
-						UploaderUUID:  ref.New(uuid.MustParse("0b075937-458c-43d9-b46c-222a072d62a9")),
-						UploaderEmail: ref.New("uploader@example.com"),
-						UploaderName:  ref.New("Test Uploader"),
+						StartedAt:     new("2024-09-25T09:31:11Z"),
+						CompletedAt:   new("2024-09-25T09:31:12Z"),
+						UploaderUUID:  new(uuid.MustParse("0b075937-458c-43d9-b46c-222a072d62a9")),
+						UploaderEmail: new("uploader@example.com"),
+						UploaderName:  new("Test Uploader"),
 					},
 					{
 						UUID:        sipUUID2,
-						Name:        ref.New("Test SIP 2"),
+						Name:        new("Test SIP 2"),
 						Status:      enums.SIPStatusProcessing.String(),
-						AipUUID:     ref.New("ffdb12f4-1735-4022-b746-a9bf4a32109b"),
+						AipUUID:     new("ffdb12f4-1735-4022-b746-a9bf4a32109b"),
 						CreatedAt:   "2024-10-01T17:13:26Z",
-						StartedAt:   ref.New("2024-10-01T17:13:27Z"),
-						CompletedAt: ref.New("2024-10-01T17:13:28Z"),
+						StartedAt:   new("2024-10-01T17:13:27Z"),
+						CompletedAt: new("2024-10-01T17:13:28Z"),
 					},
 					{
 						UUID:        sipUUID3,
-						Name:        ref.New("Test SIP 3"),
+						Name:        new("Test SIP 3"),
 						Status:      enums.SIPStatusError.String(),
 						CreatedAt:   "2024-10-01T17:13:26Z",
-						StartedAt:   ref.New("2024-10-01T17:13:27Z"),
-						CompletedAt: ref.New("2024-10-01T17:13:28Z"),
-						FailedAs:    ref.New(enums.SIPFailedAsSIP.String()),
-						FailedKey:   ref.New("failed-key"),
+						StartedAt:   new("2024-10-01T17:13:27Z"),
+						CompletedAt: new("2024-10-01T17:13:28Z"),
+						FailedAs:    new(enums.SIPFailedAsSIP.String()),
+						FailedKey:   new("failed-key"),
 					},
 				},
 				Page: &goaingest.EnduroPage{
@@ -462,29 +462,29 @@ func TestListSIPs(t *testing.T) {
 		{
 			name: "Returns filtered SIPs",
 			payload: &goaingest.ListSipsPayload{
-				Name:                ref.New("Test SIP 1"),
-				AipUUID:             ref.New("e2ace0da-8697-453d-9ea1-4c9b62309e54"),
-				EarliestCreatedTime: ref.New("2024-09-25T09:30:00Z"),
-				LatestCreatedTime:   ref.New("2024-09-25T09:40:00Z"),
-				Status:              ref.New(enums.SIPStatusIngested.String()),
-				BatchUUID:           ref.New("ffdb12f4-1735-4022-b746-a9bf4a32109b"),
-				UploaderUUID:        ref.New("0b075937-458c-43d9-b46c-222a072d62a9"),
-				Limit:               ref.New(10),
-				Offset:              ref.New(1),
+				Name:                new("Test SIP 1"),
+				AipUUID:             new("e2ace0da-8697-453d-9ea1-4c9b62309e54"),
+				EarliestCreatedTime: new("2024-09-25T09:30:00Z"),
+				LatestCreatedTime:   new("2024-09-25T09:40:00Z"),
+				Status:              new(enums.SIPStatusIngested.String()),
+				BatchUUID:           new("ffdb12f4-1735-4022-b746-a9bf4a32109b"),
+				UploaderUUID:        new("0b075937-458c-43d9-b46c-222a072d62a9"),
+				Limit:               new(10),
+				Offset:              new(1),
 			},
 			mockRecorder: func(mr *persistence_fake.MockServiceMockRecorder) {
 				mr.ListSIPs(
 					mockutil.Context(),
 					&persistence.SIPFilter{
-						Name:  ref.New("Test SIP 1"),
-						AIPID: ref.New(uuid.MustParse("e2ace0da-8697-453d-9ea1-4c9b62309e54")),
+						Name:  new("Test SIP 1"),
+						AIPID: new(uuid.MustParse("e2ace0da-8697-453d-9ea1-4c9b62309e54")),
 						CreatedAt: &timerange.Range{
 							Start: time.Date(2024, 9, 25, 9, 30, 0, 0, time.UTC),
 							End:   time.Date(2024, 9, 25, 9, 40, 0, 0, time.UTC),
 						},
 						Status:     ref.New(enums.SIPStatusIngested),
-						BatchID:    ref.New(uuid.MustParse("ffdb12f4-1735-4022-b746-a9bf4a32109b")),
-						UploaderID: ref.New(uuid.MustParse("0b075937-458c-43d9-b46c-222a072d62a9")),
+						BatchID:    new(uuid.MustParse("ffdb12f4-1735-4022-b746-a9bf4a32109b")),
+						UploaderID: new(uuid.MustParse("0b075937-458c-43d9-b46c-222a072d62a9")),
 						Sort:       entfilter.NewSort().AddCol("id", true),
 						Page: persistence.Page{
 							Limit:  10,
@@ -501,15 +501,15 @@ func TestListSIPs(t *testing.T) {
 				Items: goaingest.SIPCollection{
 					{
 						UUID:          sipUUID1,
-						Name:          ref.New("Test SIP 1"),
+						Name:          new("Test SIP 1"),
 						Status:        enums.SIPStatusIngested.String(),
-						AipUUID:       ref.New("e2ace0da-8697-453d-9ea1-4c9b62309e54"),
+						AipUUID:       new("e2ace0da-8697-453d-9ea1-4c9b62309e54"),
 						CreatedAt:     "2024-09-25T09:31:10Z",
-						StartedAt:     ref.New("2024-09-25T09:31:11Z"),
-						CompletedAt:   ref.New("2024-09-25T09:31:12Z"),
-						UploaderUUID:  ref.New(uuid.MustParse("0b075937-458c-43d9-b46c-222a072d62a9")),
-						UploaderEmail: ref.New("uploader@example.com"),
-						UploaderName:  ref.New("Test Uploader"),
+						StartedAt:     new("2024-09-25T09:31:11Z"),
+						CompletedAt:   new("2024-09-25T09:31:12Z"),
+						UploaderUUID:  new(uuid.MustParse("0b075937-458c-43d9-b46c-222a072d62a9")),
+						UploaderEmail: new("uploader@example.com"),
+						UploaderName:  new("Test Uploader"),
 					},
 				},
 				Page: &goaingest.EnduroPage{
@@ -521,13 +521,13 @@ func TestListSIPs(t *testing.T) {
 		{
 			name: "Errors on an internal service error",
 			payload: &goaingest.ListSipsPayload{
-				Name: ref.New("SIP 42"),
+				Name: new("SIP 42"),
 			},
 			mockRecorder: func(mr *persistence_fake.MockServiceMockRecorder) {
 				mr.ListSIPs(
 					mockutil.Context(),
 					&persistence.SIPFilter{
-						Name: ref.New("SIP 42"),
+						Name: new("SIP 42"),
 						Sort: entfilter.NewSort().AddCol("id", true),
 					},
 				).Return(
@@ -541,50 +541,50 @@ func TestListSIPs(t *testing.T) {
 		{
 			name: "Errors on a bad aip_uuid",
 			payload: &goaingest.ListSipsPayload{
-				AipUUID: ref.New("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"),
+				AipUUID: new("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"),
 			},
 			wantErr: "aip_uuid: invalid UUID",
 		},
 		{
 			name: "Errors on a bad batch_uuid",
 			payload: &goaingest.ListSipsPayload{
-				BatchUUID: ref.New("invalid"),
+				BatchUUID: new("invalid"),
 			},
 			wantErr: "batch_uuid: invalid UUID",
 		},
 		{
 			name: "Errors on a bad uploader_uuid",
 			payload: &goaingest.ListSipsPayload{
-				UploaderUUID: ref.New("invalid"),
+				UploaderUUID: new("invalid"),
 			},
 			wantErr: "uploader_uuid: invalid UUID",
 		},
 		{
 			name: "Errors on a bad status",
 			payload: &goaingest.ListSipsPayload{
-				Status: ref.New("meditating"),
+				Status: new("meditating"),
 			},
 			wantErr: "status: invalid value",
 		},
 		{
 			name: "Errors on a bad earliest_created_time",
 			payload: &goaingest.ListSipsPayload{
-				EarliestCreatedTime: ref.New("2024-15-15T25:83:52Z"),
+				EarliestCreatedTime: new("2024-15-15T25:83:52Z"),
 			},
 			wantErr: "created at: time range: cannot parse start time",
 		},
 		{
 			name: "Errors on a bad latest_created_time",
 			payload: &goaingest.ListSipsPayload{
-				LatestCreatedTime: ref.New("2024-15-15T25:83:52Z"),
+				LatestCreatedTime: new("2024-15-15T25:83:52Z"),
 			},
 			wantErr: "created at: time range: cannot parse end time",
 		},
 		{
 			name: "Errors on a bad created at range",
 			payload: &goaingest.ListSipsPayload{
-				EarliestCreatedTime: ref.New("2024-10-01T17:43:52Z"),
-				LatestCreatedTime:   ref.New("2023-10-01T17:43:52Z"),
+				EarliestCreatedTime: new("2024-10-01T17:43:52Z"),
+				LatestCreatedTime:   new("2023-10-01T17:43:52Z"),
 			},
 			wantErr: "created at: time range: end cannot be before start",
 		},
@@ -682,17 +682,17 @@ func TestListUsers(t *testing.T) {
 		{
 			name: "Filters users",
 			payload: &goaingest.ListUsersPayload{
-				Email:  ref.New("user1@example.com"),
-				Name:   ref.New("User One"),
-				Limit:  ref.New(10),
-				Offset: ref.New(0),
+				Email:  new("user1@example.com"),
+				Name:   new("User One"),
+				Limit:  new(10),
+				Offset: new(0),
 			},
 			mockRecorder: func(mr *persistence_fake.MockServiceMockRecorder) {
 				mr.ListUsers(
 					mockutil.Context(),
 					&persistence.UserFilter{
-						Email: ref.New("user1@example.com"),
-						Name:  ref.New("User One"),
+						Email: new("user1@example.com"),
+						Name:  new("User One"),
 						Page: persistence.Page{
 							Limit:  10,
 							Offset: 0,
@@ -722,27 +722,27 @@ func TestListUsers(t *testing.T) {
 		{
 			name: "Returns error on email validation error",
 			payload: &goaingest.ListUsersPayload{
-				Email: ref.New(longStr),
+				Email: new(longStr),
 			},
 			wantErr: "email: exceeds maximum length of 255",
 		},
 		{
 			name: "Returns error on name validation error",
 			payload: &goaingest.ListUsersPayload{
-				Name: ref.New(longStr),
+				Name: new(longStr),
 			},
 			wantErr: "name: exceeds maximum length of 255",
 		},
 		{
 			name: "Returns error on internal service error",
 			payload: &goaingest.ListUsersPayload{
-				Email: ref.New("user1@example.com"),
+				Email: new("user1@example.com"),
 			},
 			mockRecorder: func(mr *persistence_fake.MockServiceMockRecorder) {
 				mr.ListUsers(
 					mockutil.Context(),
 					&persistence.UserFilter{
-						Email: ref.New("user1@example.com"),
+						Email: new("user1@example.com"),
 					},
 				).Return(
 					nil,
@@ -804,7 +804,7 @@ func TestListSIPSourceObjects(t *testing.T) {
 			name: "Returns SIP source objects with a next page value",
 			payload: &goaingest.ListSipSourceObjectsPayload{
 				UUID:  sourceID.String(),
-				Limit: ref.New(10),
+				Limit: new(10),
 			},
 			mockRecorder: func(mr *sipsource_fake.MockSIPSourceMockRecorder) {
 				mr.ListObjects(
@@ -828,20 +828,20 @@ func TestListSIPSourceObjects(t *testing.T) {
 				Objects: goaingest.SIPSourceObjectCollection{
 					{
 						Key:     "object1",
-						Size:    ref.New(int64(1234)),
-						ModTime: ref.New(modTime.Format(time.RFC3339)),
+						Size:    new(int64(1234)),
+						ModTime: new(modTime.Format(time.RFC3339)),
 					},
 				},
 				Limit: 10,
-				Next:  ref.New("next-token"),
+				Next:  new("next-token"),
 			},
 		},
 		{
 			name: "Returns SIP source objects when a cursor value is provided",
 			payload: &goaingest.ListSipSourceObjectsPayload{
 				UUID:   sourceID.String(),
-				Limit:  ref.New(10),
-				Cursor: ref.New("page-token"),
+				Limit:  new(10),
+				Cursor: new("page-token"),
 			},
 			mockRecorder: func(mr *sipsource_fake.MockSIPSourceMockRecorder) {
 				mr.ListObjects(
@@ -865,8 +865,8 @@ func TestListSIPSourceObjects(t *testing.T) {
 				Objects: goaingest.SIPSourceObjectCollection{
 					{
 						Key:     "object2",
-						Size:    ref.New(int64(5678)),
-						ModTime: ref.New(modTime.Format(time.RFC3339)),
+						Size:    new(int64(5678)),
+						ModTime: new(modTime.Format(time.RFC3339)),
 					},
 				},
 				Limit: 10,
@@ -891,8 +891,8 @@ func TestListSIPSourceObjects(t *testing.T) {
 			name: "Returns an error when a bad cursor token is provided",
 			payload: &goaingest.ListSipSourceObjectsPayload{
 				UUID:   sourceID.String(),
-				Limit:  ref.New(10),
-				Cursor: ref.New("bad-token"),
+				Limit:  new(10),
+				Cursor: new("bad-token"),
 			},
 			mockRecorder: func(mr *sipsource_fake.MockSIPSourceMockRecorder) {
 				mr.ListObjects(

--- a/internal/ingest/monitor.go
+++ b/internal/ingest/monitor.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"go.artefactual.dev/tools/ref"
-
 	"github.com/artefactual-sdps/enduro/internal/api/auth"
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
 )
@@ -54,7 +52,7 @@ func (svc *ingestImpl) Monitor(
 	defer sub.Close()
 
 	// Say hello to be nice.
-	event := &goaingest.IngestPingEvent{Message: ref.New("Hello")}
+	event := &goaingest.IngestPingEvent{Message: new("Hello")}
 	if err := stream.Send(&goaingest.IngestEvent{Value: event}); err != nil {
 		// Consider send errors as client disconnections.
 		svc.logger.V(1).Info("Failed to send hello event.", "err", err)
@@ -73,7 +71,7 @@ func (svc *ingestImpl) Monitor(
 			return nil
 
 		case <-ticker.C:
-			event := &goaingest.IngestPingEvent{Message: ref.New("Ping")}
+			event := &goaingest.IngestPingEvent{Message: new("Ping")}
 			if err := stream.Send(&goaingest.IngestEvent{Value: event}); err != nil {
 				// Consider send errors as client disconnections.
 				svc.logger.V(1).Info("Failed to send ping event.", "err", err)

--- a/internal/ingest/monitor_test.go
+++ b/internal/ingest/monitor_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"go.artefactual.dev/tools/ref"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 
@@ -40,7 +39,7 @@ func TestMonitorRequest(t *testing.T) {
 					Request(ctx, claims).
 					Return("ticket", nil)
 			},
-			want: &goaingest.MonitorRequestResult{Ticket: ref.New("ticket")},
+			want: &goaingest.MonitorRequestResult{Ticket: new("ticket")},
 		},
 		{
 			name: "Returns empty result when no ticket is provided",
@@ -110,7 +109,7 @@ func TestMonitor(t *testing.T) {
 	t.Parallel()
 
 	testUUID := uuid.New()
-	ticket := ref.New("ticket")
+	ticket := new("ticket")
 	successMock := func(tp *authfake.MockTicketProvider, ctx context.Context, ticket *string, claims *auth.Claims) {
 		tp.EXPECT().
 			Check(ctx, ticket, &auth.Claims{}).
@@ -133,7 +132,7 @@ func TestMonitor(t *testing.T) {
 		{Value: &goaingest.BatchUpdatedEvent{UUID: testUUID}},
 	}
 	allWantEvents := []any{
-		&goaingest.IngestPingEvent{Message: ref.New("Hello")},
+		&goaingest.IngestPingEvent{Message: new("Hello")},
 		&goaingest.SIPCreatedEvent{UUID: testUUID},
 		&goaingest.SIPUpdatedEvent{UUID: testUUID},
 		&goaingest.SIPStatusUpdatedEvent{UUID: testUUID},
@@ -181,7 +180,7 @@ func TestMonitor(t *testing.T) {
 			mock:   successMock,
 			events: allEvents,
 			wantEvents: []any{
-				&goaingest.IngestPingEvent{Message: ref.New("Hello")},
+				&goaingest.IngestPingEvent{Message: new("Hello")},
 			},
 		},
 		{
@@ -194,7 +193,7 @@ func TestMonitor(t *testing.T) {
 			mock:   successMock,
 			events: allEvents,
 			wantEvents: []any{
-				&goaingest.IngestPingEvent{Message: ref.New("Hello")},
+				&goaingest.IngestPingEvent{Message: new("Hello")},
 				&goaingest.SIPUpdatedEvent{UUID: testUUID},
 				&goaingest.SIPStatusUpdatedEvent{UUID: testUUID},
 			},

--- a/internal/ingest/storage_client_auth_provider_test.go
+++ b/internal/ingest/storage_client_auth_provider_test.go
@@ -127,11 +127,11 @@ func TestOIDCAccessTokenProviderAccessToken(t *testing.T) {
 
 			srv := tokenServer(t, tc.responses)
 
-			cfg := ingest.StorageOIDCConfig{
+			cfg := ingest.StorageOIDCConfig{ // #nosec G101 -- test-only placeholder credential.
 				Enabled:                 true,
 				TokenURL:                srv.URL,
 				ClientID:                "client-id",
-				ClientSecret:            "client-secret",
+				ClientSecret:            "placeholder-value",
 				RetryMaxAttempts:        3,
 				RetryInitialInterval:    time.Microsecond,
 				RetryMaxInterval:        time.Microsecond,

--- a/internal/ingest/task_test.go
+++ b/internal/ingest/task_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"go.artefactual.dev/tools/mockutil"
-	"go.artefactual.dev/tools/ref"
 	"gotest.tools/v3/assert"
 
 	"github.com/artefactual-sdps/enduro/internal/datatypes"
@@ -239,7 +238,7 @@ func TestCompleteTask(t *testing.T) {
 				id:          1,
 				status:      enums.TaskStatusDone,
 				completedAt: completedAt,
-				note:        ref.New("Reviewed and accepted"),
+				note:        new("Reviewed and accepted"),
 			},
 			mock: func(
 				svc *persistence_fake.MockService,

--- a/internal/persistence/ent/client/batch_test.go
+++ b/internal/persistence/ent/client/batch_test.go
@@ -730,7 +730,7 @@ func TestListBatches(t *testing.T) {
 				},
 			},
 			batchFilter: &persistence.BatchFilter{
-				Identifier: ref.New("small"),
+				Identifier: new("small"),
 			},
 			want: results{
 				data: []*datatypes.Batch{
@@ -931,7 +931,7 @@ func TestListBatches(t *testing.T) {
 				},
 			},
 			batchFilter: &persistence.BatchFilter{
-				UploaderID: ref.New(uploaderID2),
+				UploaderID: new(uploaderID2),
 			},
 			want: results{
 				data: []*datatypes.Batch{

--- a/internal/persistence/ent/client/sip_test.go
+++ b/internal/persistence/ent/client/sip_test.go
@@ -836,7 +836,7 @@ func TestListSIPs(t *testing.T) {
 				},
 			},
 			sipFilter: &persistence.SIPFilter{
-				Name: ref.New("small"),
+				Name: new("small"),
 			},
 			want: results{
 				data: []*datatypes.SIP{
@@ -1079,7 +1079,7 @@ func TestListSIPs(t *testing.T) {
 				},
 			},
 			sipFilter: &persistence.SIPFilter{
-				UploaderID: ref.New(uploaderID2),
+				UploaderID: new(uploaderID2),
 			},
 			want: results{
 				data: []*datatypes.SIP{
@@ -1143,7 +1143,7 @@ func TestListSIPs(t *testing.T) {
 				},
 			},
 			sipFilter: &persistence.SIPFilter{
-				BatchID: ref.New(batchID2),
+				BatchID: new(batchID2),
 			},
 			want: results{
 				data: []*datatypes.SIP{

--- a/internal/persistence/ent/client/task.go
+++ b/internal/persistence/ent/client/task.go
@@ -94,6 +94,8 @@ func (c *client) CreateTasks(ctx context.Context, tasks []*datatypes.Task) error
 			return rollback(tx, newDBErrorWithDetails(err, "create tasks"))
 		}
 
+		// Bulk insert should return one persisted task per builder so IDs can be
+		// mapped back onto the original task pointers in order.
 		if len(created) != len(batch) {
 			return rollback(
 				tx,
@@ -109,20 +111,6 @@ func (c *client) CreateTasks(ctx context.Context, tasks []*datatypes.Task) error
 		}
 
 		for i, task := range batch {
-			if i >= len(created) {
-				return rollback(
-					tx,
-					newDBErrorWithDetails(
-						fmt.Errorf(
-							"create tasks: created %d rows, expected %d",
-							len(created),
-							len(batch),
-						),
-						"create tasks",
-					),
-				)
-			}
-
 			task.ID = created[i].ID
 		}
 	}

--- a/internal/persistence/ent/client/task.go
+++ b/internal/persistence/ent/client/task.go
@@ -108,8 +108,22 @@ func (c *client) CreateTasks(ctx context.Context, tasks []*datatypes.Task) error
 			)
 		}
 
-		for i, dbt := range created {
-			batch[i].ID = dbt.ID
+		for i, task := range batch {
+			if i >= len(created) {
+				return rollback(
+					tx,
+					newDBErrorWithDetails(
+						fmt.Errorf(
+							"create tasks: created %d rows, expected %d",
+							len(created),
+							len(batch),
+						),
+						"create tasks",
+					),
+				)
+			}
+
+			task.ID = created[i].ID
 		}
 	}
 

--- a/internal/persistence/ent/client/user_test.go
+++ b/internal/persistence/ent/client/user_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"go.artefactual.dev/tools/ref"
 	"gotest.tools/v3/assert"
 
 	"github.com/artefactual-sdps/enduro/internal/datatypes"
@@ -304,7 +303,7 @@ func TestListUsers(t *testing.T) {
 		{
 			name: "Lists users filtered by Email",
 			filter: &persistence.UserFilter{
-				Email: ref.New("nobody@example.com"),
+				Email: new("nobody@example.com"),
 			},
 			want: []*datatypes.User{
 				{
@@ -325,7 +324,7 @@ func TestListUsers(t *testing.T) {
 		{
 			name: "Lists users filtered by Name",
 			filter: &persistence.UserFilter{
-				Name: ref.New("test"),
+				Name: new("test"),
 			},
 			want: []*datatypes.User{
 				{

--- a/internal/sftp/goclient.go
+++ b/internal/sftp/goclient.go
@@ -121,20 +121,26 @@ func uploadDirectory(ctx context.Context, srcPath, remoteDir string, upload *Asy
 
 	transferDir := filepath.Base(srcPath)
 
-	err := filepath.WalkDir(srcPath, func(path string, d fs.DirEntry, err error) error {
+	scopedRoot, err := os.OpenRoot(srcPath)
+	if err != nil {
+		upload.Err() <- fmt.Errorf("goclient: open source root: %v", err)
+		upload.Done() <- true
+		return
+	}
+	defer scopedRoot.Close()
+
+	err = fs.WalkDir(scopedRoot.FS(), ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		relPath, err := filepath.Rel(srcPath, path)
-		if err != nil {
-			return err
+		remotePath := sftp.Join(remoteDir, transferDir)
+		if path != "." {
+			remotePath = sftp.Join(remoteDir, transferDir, path)
 		}
-
-		remotePath := sftp.Join(remoteDir, transferDir, relPath)
 
 		if !d.IsDir() {
-			f, err := os.Open(path) // #nosec G304 -- trusted file path.
+			f, err := scopedRoot.Open(path)
 			if err != nil {
 				return err
 			}

--- a/internal/storage/activities/aip_deletion_report_test.go
+++ b/internal/storage/activities/aip_deletion_report_test.go
@@ -32,14 +32,14 @@ func expectReadAIP(msvc *fake.MockService, id uuid.UUID) {
 		Return(&goastorage.AIP{
 			UUID:         id,
 			Name:         "Test AIP",
-			LocationUUID: ref.New(uuid.MustParse("223e4567-e89b-12d3-a456-426614174000")),
+			LocationUUID: new(uuid.MustParse("223e4567-e89b-12d3-a456-426614174000")),
 		}, nil)
 }
 
 func expectListDeletionRequests(msvc *fake.MockService, aipID uuid.UUID) {
 	msvc.EXPECT().
 		ListDeletionRequests(mockutil.Context(), &persistence.DeletionRequestFilter{
-			AIPUUID: ref.New(aipID),
+			AIPUUID: new(aipID),
 			Status:  ref.New(enums.DeletionRequestStatusApproved),
 		}).
 		Return([]*types.DeletionRequest{
@@ -189,7 +189,7 @@ func TestAIPDeletionReportActivity(t *testing.T) {
 				expectReadAIP(msvc, aipID)
 				msvc.EXPECT().
 					ListDeletionRequests(mockutil.Context(), &persistence.DeletionRequestFilter{
-						AIPUUID: ref.New(aipID),
+						AIPUUID: new(aipID),
 						Status:  ref.New(enums.DeletionRequestStatusApproved),
 					}).
 					Return(nil, errors.New("internal error"))
@@ -206,7 +206,7 @@ func TestAIPDeletionReportActivity(t *testing.T) {
 				expectReadAIP(msvc, aipID)
 				msvc.EXPECT().
 					ListDeletionRequests(mockutil.Context(), &persistence.DeletionRequestFilter{
-						AIPUUID: ref.New(aipID),
+						AIPUUID: new(aipID),
 						Status:  ref.New(enums.DeletionRequestStatusApproved),
 					}).
 					Return([]*types.DeletionRequest{}, nil)

--- a/internal/storage/convert.go
+++ b/internal/storage/convert.go
@@ -3,8 +3,6 @@ package storage
 import (
 	"time"
 
-	"go.artefactual.dev/tools/ref"
-
 	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
 	"github.com/artefactual-sdps/enduro/internal/auditlog"
 	"github.com/artefactual-sdps/enduro/internal/storage/enums"
@@ -16,11 +14,11 @@ func (svc *serviceImpl) workflowToGoa(w *types.Workflow) *goastorage.AIPWorkflow
 	var startedAt, completedAt *string
 
 	if !w.StartedAt.IsZero() {
-		startedAt = ref.New(w.StartedAt.Format(time.RFC3339))
+		startedAt = new(w.StartedAt.Format(time.RFC3339))
 	}
 
 	if !w.CompletedAt.IsZero() {
-		completedAt = ref.New(w.CompletedAt.Format(time.RFC3339))
+		completedAt = new(w.CompletedAt.Format(time.RFC3339))
 	}
 
 	// Tasks are loaded separately when needed.
@@ -40,15 +38,15 @@ func (svc *serviceImpl) taskToGoa(t *types.Task) *goastorage.AIPTask {
 	var startedAt, completedAt, note *string
 
 	if !t.StartedAt.IsZero() {
-		startedAt = ref.New(t.StartedAt.Format(time.RFC3339))
+		startedAt = new(t.StartedAt.Format(time.RFC3339))
 	}
 
 	if !t.CompletedAt.IsZero() {
-		completedAt = ref.New(t.CompletedAt.Format(time.RFC3339))
+		completedAt = new(t.CompletedAt.Format(time.RFC3339))
 	}
 
 	if t.Note != "" {
-		note = ref.New(t.Note)
+		note = new(t.Note)
 	}
 
 	return &goastorage.AIPTask{

--- a/internal/storage/deletion_request_test.go
+++ b/internal/storage/deletion_request_test.go
@@ -80,7 +80,7 @@ func TestAipDeletionAuto(t *testing.T) {
 			payload: &goastorage.AipDeletionAutoPayload{
 				UUID:       aipID.String(),
 				Reason:     "Reason",
-				SkipReport: ref.New(true),
+				SkipReport: new(true),
 			},
 			mock: func(ctx context.Context, s *fake.MockStorage, tc *temporalsdk_mocks.Client) {
 				s.EXPECT().ReadAIP(ctx, aipID).Return(
@@ -459,7 +459,7 @@ func TestReviewAipDeletion(t *testing.T) {
 			mock: func(ctx context.Context, s *fake.MockStorage, tc *temporalsdk_mocks.Client) {
 				s.EXPECT().ReadAIP(ctx, aipID).Return(&goastorage.AIP{Status: enums.AIPStatusPending.String()}, nil)
 				s.EXPECT().ListDeletionRequests(ctx, &persistence.DeletionRequestFilter{
-					AIPUUID: ref.New(aipID),
+					AIPUUID: new(aipID),
 					Status:  ref.New(enums.DeletionRequestStatusPending),
 				}).Return(nil, errors.New("persistence error"))
 			},
@@ -479,7 +479,7 @@ func TestReviewAipDeletion(t *testing.T) {
 			mock: func(ctx context.Context, s *fake.MockStorage, tc *temporalsdk_mocks.Client) {
 				s.EXPECT().ReadAIP(ctx, aipID).Return(&goastorage.AIP{Status: enums.AIPStatusPending.String()}, nil)
 				s.EXPECT().ListDeletionRequests(ctx, &persistence.DeletionRequestFilter{
-					AIPUUID: ref.New(aipID),
+					AIPUUID: new(aipID),
 					Status:  ref.New(enums.DeletionRequestStatusPending),
 				}).Return([]*types.DeletionRequest{
 					{
@@ -504,7 +504,7 @@ func TestReviewAipDeletion(t *testing.T) {
 			mock: func(ctx context.Context, s *fake.MockStorage, tc *temporalsdk_mocks.Client) {
 				s.EXPECT().ReadAIP(ctx, aipID).Return(&goastorage.AIP{Status: enums.AIPStatusPending.String()}, nil)
 				s.EXPECT().ListDeletionRequests(ctx, &persistence.DeletionRequestFilter{
-					AIPUUID: ref.New(aipID),
+					AIPUUID: new(aipID),
 					Status:  ref.New(enums.DeletionRequestStatusPending),
 				}).Return([]*types.DeletionRequest{
 					{
@@ -542,7 +542,7 @@ func TestReviewAipDeletion(t *testing.T) {
 			mock: func(ctx context.Context, s *fake.MockStorage, tc *temporalsdk_mocks.Client) {
 				s.EXPECT().ReadAIP(ctx, aipID).Return(&goastorage.AIP{Status: enums.AIPStatusPending.String()}, nil)
 				s.EXPECT().ListDeletionRequests(ctx, &persistence.DeletionRequestFilter{
-					AIPUUID: ref.New(aipID),
+					AIPUUID: new(aipID),
 					Status:  ref.New(enums.DeletionRequestStatusPending),
 				}).Return([]*types.DeletionRequest{
 					{
@@ -789,7 +789,7 @@ func TestCancelAipDeletion(t *testing.T) {
 			},
 			payload: &goastorage.CancelAipDeletionPayload{
 				UUID:  aipID.String(),
-				Check: ref.New(true),
+				Check: new(true),
 			},
 			mock: func(ctx context.Context, s *fake.MockStorage, tc *temporalsdk_mocks.Client) {
 				s.EXPECT().

--- a/internal/storage/download_aip_test.go
+++ b/internal/storage/download_aip_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"go.artefactual.dev/tools/ref"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"
@@ -167,7 +166,7 @@ func TestDownloadAipRequest(t *testing.T) {
 				ts.EXPECT().SetEx(ctx, "Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk", nil, time.Second*5).Return(nil)
 			},
 			wantRes: &goastorage.DownloadAipRequestResult{
-				Ticket: ref.New("Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk"),
+				Ticket: new("Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk"),
 			},
 		},
 	} {
@@ -224,7 +223,7 @@ func TestDownloadAip(t *testing.T) {
 		},
 		{
 			name:    "Fails to download a AIP (invalid ticket)",
-			payload: &goastorage.DownloadAipPayload{Ticket: ref.New("invalid-ticket")},
+			payload: &goastorage.DownloadAipPayload{Ticket: new("invalid-ticket")},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
 				ts.EXPECT().GetDel(ctx, "invalid-ticket", nil).Return(auth.ErrKeyNotFound)
 			},
@@ -233,7 +232,7 @@ func TestDownloadAip(t *testing.T) {
 		{
 			name: "Fails to download a AIP (invalid UUID)",
 			payload: &goastorage.DownloadAipPayload{
-				Ticket: ref.New("valid-ticket"),
+				Ticket: new("valid-ticket"),
 				UUID:   "invalid-uuid",
 			},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
@@ -244,7 +243,7 @@ func TestDownloadAip(t *testing.T) {
 		{
 			name: "Fails to download a AIP (AIP not found)",
 			payload: &goastorage.DownloadAipPayload{
-				Ticket: ref.New("valid-ticket"),
+				Ticket: new("valid-ticket"),
 				UUID:   aipID.String(),
 			},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
@@ -258,7 +257,7 @@ func TestDownloadAip(t *testing.T) {
 		{
 			name: "Fails to download a AIP (persistence error)",
 			payload: &goastorage.DownloadAipPayload{
-				Ticket: ref.New("valid-ticket"),
+				Ticket: new("valid-ticket"),
 				UUID:   aipID.String(),
 			},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
@@ -272,7 +271,7 @@ func TestDownloadAip(t *testing.T) {
 		{
 			name: "Fails to download a AIP (invalid status)",
 			payload: &goastorage.DownloadAipPayload{
-				Ticket: ref.New("valid-ticket"),
+				Ticket: new("valid-ticket"),
 				UUID:   aipID.String(),
 			},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
@@ -286,7 +285,7 @@ func TestDownloadAip(t *testing.T) {
 		{
 			name: "Fails to download a AIP (AIP file not found)",
 			payload: &goastorage.DownloadAipPayload{
-				Ticket: ref.New("valid-ticket"),
+				Ticket: new("valid-ticket"),
 				UUID:   missingAIPUUID.String(),
 			},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
@@ -320,7 +319,7 @@ func TestDownloadAip(t *testing.T) {
 		{
 			name: "Downloads a AIP",
 			payload: &goastorage.DownloadAipPayload{
-				Ticket: ref.New("valid-ticket"),
+				Ticket: new("valid-ticket"),
 				UUID:   aipID.String(),
 			},
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {

--- a/internal/storage/download_deletion_report_test.go
+++ b/internal/storage/download_deletion_report_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"go.artefactual.dev/tools/mockutil"
-	"go.artefactual.dev/tools/ref"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 
@@ -83,7 +82,7 @@ func TestAipDeletionReportRequest(t *testing.T) {
 						&goastorage.AIP{
 							UUID:              aipID,
 							Status:            enums.DeletionRequestStatusPending.String(),
-							DeletionReportKey: ref.New(reportKey),
+							DeletionReportKey: new(reportKey),
 						},
 						nil,
 					)
@@ -100,7 +99,7 @@ func TestAipDeletionReportRequest(t *testing.T) {
 						&goastorage.AIP{
 							UUID:              invalidID,
 							Status:            enums.AIPStatusDeleted.String(),
-							DeletionReportKey: ref.New(fmt.Sprintf("reports/aip_deletion_report_%s", invalidID)),
+							DeletionReportKey: new(fmt.Sprintf("reports/aip_deletion_report_%s", invalidID)),
 						},
 						nil,
 					)
@@ -117,7 +116,7 @@ func TestAipDeletionReportRequest(t *testing.T) {
 						&goastorage.AIP{
 							UUID:              aipID,
 							Status:            enums.AIPStatusDeleted.String(),
-							DeletionReportKey: ref.New(reportKey),
+							DeletionReportKey: new(reportKey),
 						},
 						nil,
 					)
@@ -137,7 +136,7 @@ func TestAipDeletionReportRequest(t *testing.T) {
 						&goastorage.AIP{
 							UUID:              aipID,
 							Status:            enums.AIPStatusDeleted.String(),
-							DeletionReportKey: ref.New(reportKey),
+							DeletionReportKey: new(reportKey),
 						},
 						nil,
 					)
@@ -149,7 +148,7 @@ func TestAipDeletionReportRequest(t *testing.T) {
 				).Return(nil)
 			},
 			wantRes: &goastorage.AipDeletionReportRequestResult{
-				Ticket: ref.New("Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk"),
+				Ticket: new("Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk"),
 			},
 		},
 	} {
@@ -287,7 +286,7 @@ func TestAipDeletionReport(t *testing.T) {
 						&goastorage.AIP{
 							UUID:              aipID,
 							Status:            enums.AIPStatusDeleted.String(),
-							DeletionReportKey: ref.New("reports/missing_deletion_report.pdf"),
+							DeletionReportKey: new("reports/missing_deletion_report.pdf"),
 						},
 						nil,
 					)
@@ -312,7 +311,7 @@ func TestAipDeletionReport(t *testing.T) {
 						&goastorage.AIP{
 							UUID:              aipID,
 							Status:            enums.AIPStatusDeleted.String(),
-							DeletionReportKey: ref.New(reportKey),
+							DeletionReportKey: new(reportKey),
 						},
 						nil,
 					)

--- a/internal/storage/event_test.go
+++ b/internal/storage/event_test.go
@@ -3,7 +3,6 @@ package storage_test
 import (
 	"testing"
 
-	"go.artefactual.dev/tools/ref"
 	"gotest.tools/v3/assert"
 
 	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
@@ -35,7 +34,7 @@ func TestEventSerializer(t *testing.T) {
 
 	serializer := &storage.EventSerializer{}
 	originalEvent := &goastorage.StorageEvent{
-		Value: &goastorage.StoragePingEvent{Message: ref.New("test")},
+		Value: &goastorage.StoragePingEvent{Message: new("test")},
 	}
 
 	data, err := serializer.Marshal(originalEvent)

--- a/internal/storage/monitor.go
+++ b/internal/storage/monitor.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"go.artefactual.dev/tools/ref"
-
 	"github.com/artefactual-sdps/enduro/internal/api/auth"
 	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
 )
@@ -54,7 +52,7 @@ func (s *serviceImpl) Monitor(
 	defer sub.Close()
 
 	// Say hello to be nice.
-	event := &goastorage.StoragePingEvent{Message: ref.New("Hello")}
+	event := &goastorage.StoragePingEvent{Message: new("Hello")}
 	if err := stream.Send(&goastorage.StorageEvent{Value: event}); err != nil {
 		// Consider send errors as client disconnections.
 		s.logger.V(1).Info("Failed to send hello event.", "err", err)
@@ -73,7 +71,7 @@ func (s *serviceImpl) Monitor(
 			return nil
 
 		case <-ticker.C:
-			event := &goastorage.StoragePingEvent{Message: ref.New("Ping")}
+			event := &goastorage.StoragePingEvent{Message: new("Ping")}
 			if err := stream.Send(&goastorage.StorageEvent{Value: event}); err != nil {
 				// Consider send errors as client disconnections.
 				s.logger.V(1).Info("Failed to send ping event.", "err", err)

--- a/internal/storage/monitor_test.go
+++ b/internal/storage/monitor_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	"go.artefactual.dev/tools/ref"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 
@@ -40,7 +39,7 @@ func TestMonitorRequest(t *testing.T) {
 					Request(ctx, claims).
 					Return("ticket", nil)
 			},
-			want: &goastorage.MonitorRequestResult{Ticket: ref.New("ticket")},
+			want: &goastorage.MonitorRequestResult{Ticket: new("ticket")},
 		},
 		{
 			name: "Returns empty result when no ticket is provided",
@@ -111,7 +110,7 @@ func TestMonitor(t *testing.T) {
 	t.Parallel()
 
 	testUUID := uuid.New()
-	ticket := ref.New("ticket")
+	ticket := new("ticket")
 	successMock := func(tp *authfake.MockTicketProvider, ctx context.Context, ticket *string, claims *auth.Claims) {
 		tp.EXPECT().
 			Check(ctx, ticket, &auth.Claims{}).
@@ -134,7 +133,7 @@ func TestMonitor(t *testing.T) {
 		{Value: &goastorage.AIPTaskUpdatedEvent{UUID: testUUID}},
 	}
 	allWantEvents := []any{
-		&goastorage.StoragePingEvent{Message: ref.New("Hello")},
+		&goastorage.StoragePingEvent{Message: new("Hello")},
 		&goastorage.LocationCreatedEvent{UUID: testUUID},
 		&goastorage.AIPCreatedEvent{UUID: testUUID},
 		&goastorage.AIPUpdatedEvent{UUID: testUUID},
@@ -182,7 +181,7 @@ func TestMonitor(t *testing.T) {
 			mock:   successMock,
 			events: allEvents,
 			wantEvents: []any{
-				&goastorage.StoragePingEvent{Message: ref.New("Hello")},
+				&goastorage.StoragePingEvent{Message: new("Hello")},
 			},
 		},
 		{
@@ -195,7 +194,7 @@ func TestMonitor(t *testing.T) {
 			mock:   successMock,
 			events: allEvents,
 			wantEvents: []any{
-				&goastorage.StoragePingEvent{Message: ref.New("Hello")},
+				&goastorage.StoragePingEvent{Message: new("Hello")},
 				&goastorage.LocationCreatedEvent{UUID: testUUID},
 				&goastorage.AIPUpdatedEvent{UUID: testUUID},
 				&goastorage.AIPStatusUpdatedEvent{UUID: testUUID},

--- a/internal/storage/persistence/ent/client/client_test.go
+++ b/internal/storage/persistence/ent/client/client_test.go
@@ -112,7 +112,7 @@ func TestCreateAIP(t *testing.T) {
 				UUID:              aipID,
 				ObjectKey:         objectKey,
 				Status:            "stored",
-				LocationUUID:      ref.New(locationID),
+				LocationUUID:      new(locationID),
 				DeletionReportKey: &deletionReportKey,
 			},
 			want: &goastorage.AIP{
@@ -120,7 +120,7 @@ func TestCreateAIP(t *testing.T) {
 				UUID:              aipID,
 				ObjectKey:         objectKey,
 				Status:            "stored",
-				LocationUUID:      ref.New(locationID),
+				LocationUUID:      new(locationID),
 				CreatedAt:         fakeNow().Format(time.RFC3339),
 				DeletionReportKey: &deletionReportKey,
 			},
@@ -131,7 +131,7 @@ func TestCreateAIP(t *testing.T) {
 				Name:         "test_aip",
 				UUID:         aipID,
 				ObjectKey:    objectKey,
-				LocationUUID: ref.New(uuid.MustParse("f1508f95-cab7-447f-b6a2-e01bf7c64558")),
+				LocationUUID: new(uuid.MustParse("f1508f95-cab7-447f-b6a2-e01bf7c64558")),
 			},
 			wantErr: "Storage location not found.",
 		},
@@ -248,7 +248,7 @@ func TestListAIPs(t *testing.T) {
 					ExecX(ctx)
 			},
 			payload: &goastorage.ListAipsPayload{
-				Limit: ref.New(1),
+				Limit: new(1),
 			},
 			want: &goastorage.AIPs{
 				Items: []*goastorage.AIP{
@@ -287,7 +287,7 @@ func TestListAIPs(t *testing.T) {
 					ExecX(ctx)
 			},
 			payload: &goastorage.ListAipsPayload{
-				Offset: ref.New(1),
+				Offset: new(1),
 			},
 			want: &goastorage.AIPs{
 				Items: []*goastorage.AIP{
@@ -326,7 +326,7 @@ func TestListAIPs(t *testing.T) {
 					ExecX(ctx)
 			},
 			payload: &goastorage.ListAipsPayload{
-				Status: ref.New("stored"),
+				Status: new("stored"),
 			},
 			want: &goastorage.AIPs{
 				Items: []*goastorage.AIP{
@@ -365,7 +365,7 @@ func TestListAIPs(t *testing.T) {
 					ExecX(ctx)
 			},
 			payload: &goastorage.ListAipsPayload{
-				EarliestCreatedTime: ref.New("2025-05-07T00:00:00Z"),
+				EarliestCreatedTime: new("2025-05-07T00:00:00Z"),
 			},
 			want: &goastorage.AIPs{
 				Items: []*goastorage.AIP{
@@ -404,7 +404,7 @@ func TestListAIPs(t *testing.T) {
 					ExecX(ctx)
 			},
 			payload: &goastorage.ListAipsPayload{
-				Name: ref.New("Test AIP 1"),
+				Name: new("Test AIP 1"),
 			},
 			want: &goastorage.AIPs{
 				Items: []*goastorage.AIP{
@@ -426,14 +426,14 @@ func TestListAIPs(t *testing.T) {
 		{
 			name: "Invalid status filter",
 			payload: &goastorage.ListAipsPayload{
-				Status: ref.New("invalid_status"),
+				Status: new("invalid_status"),
 			},
 			wantErr: "status: invalid value",
 		},
 		{
 			name: "Invalid date range filter",
 			payload: &goastorage.ListAipsPayload{
-				EarliestCreatedTime: ref.New("invalid_date"),
+				EarliestCreatedTime: new("invalid_date"),
 			},
 			wantErr: "created at: time range: cannot parse start time",
 		},
@@ -522,7 +522,7 @@ func TestUpdateAIP(t *testing.T) {
 			updater: func(aip *types.AIP) (*types.AIP, error) {
 				aip.Status = enums.AIPStatusDeleted
 				aip.LocationUUID = &locID1
-				aip.DeletionReportKey = ref.New("reports/deletion_report.pdf")
+				aip.DeletionReportKey = new("reports/deletion_report.pdf")
 				return aip, nil
 			},
 			want: &types.AIP{
@@ -532,7 +532,7 @@ func TestUpdateAIP(t *testing.T) {
 				ObjectKey:         objectKey,
 				Status:            enums.AIPStatusDeleted,
 				LocationUUID:      &locID1,
-				DeletionReportKey: ref.New("reports/deletion_report.pdf"),
+				DeletionReportKey: new("reports/deletion_report.pdf"),
 			},
 		},
 		{
@@ -558,7 +558,7 @@ func TestUpdateAIP(t *testing.T) {
 			updater: func(aip *types.AIP) (*types.AIP, error) {
 				aip.Status = enums.AIPStatusDeleted
 				aip.LocationUUID = &locID2
-				aip.DeletionReportKey = ref.New("reports/deletion_report.pdf")
+				aip.DeletionReportKey = new("reports/deletion_report.pdf")
 				return aip, nil
 			},
 			want: &types.AIP{
@@ -568,7 +568,7 @@ func TestUpdateAIP(t *testing.T) {
 				ObjectKey:         objectKey,
 				Status:            enums.AIPStatusDeleted,
 				LocationUUID:      &locID2,
-				DeletionReportKey: ref.New("reports/deletion_report.pdf"),
+				DeletionReportKey: new("reports/deletion_report.pdf"),
 			},
 		},
 		{
@@ -817,17 +817,17 @@ func TestListWorkflows(t *testing.T) {
 					TemporalID:  "temporal-id-1",
 					Type:        enums.WorkflowTypeMoveAip.String(),
 					Status:      enums.WorkflowStatusDone.String(),
-					StartedAt:   ref.New(startedAt.Format(time.RFC3339)),
-					CompletedAt: ref.New(completedAt.Format(time.RFC3339)),
+					StartedAt:   new(startedAt.Format(time.RFC3339)),
+					CompletedAt: new(completedAt.Format(time.RFC3339)),
 					AipUUID:     aipID,
 					Tasks: goastorage.AIPTaskCollection{
 						{
 							UUID:         taskUUID1,
 							Name:         "Task 1",
 							Status:       enums.TaskStatusDone.String(),
-							StartedAt:    ref.New(startedAt.Format(time.RFC3339)),
-							CompletedAt:  ref.New(completedAt.Format(time.RFC3339)),
-							Note:         ref.New("Note 1"),
+							StartedAt:    new(startedAt.Format(time.RFC3339)),
+							CompletedAt:  new(completedAt.Format(time.RFC3339)),
+							Note:         new("Note 1"),
 							WorkflowUUID: workflowUUID1,
 						},
 					},
@@ -837,15 +837,15 @@ func TestListWorkflows(t *testing.T) {
 					TemporalID: "temporal-id-2",
 					Type:       enums.WorkflowTypeDeleteAip.String(),
 					Status:     enums.WorkflowStatusInProgress.String(),
-					StartedAt:  ref.New(startedAt.Format(time.RFC3339)),
+					StartedAt:  new(startedAt.Format(time.RFC3339)),
 					AipUUID:    aipID,
 					Tasks: goastorage.AIPTaskCollection{
 						{
 							UUID:         taskUUID2,
 							Name:         "Task 2",
 							Status:       enums.TaskStatusInProgress.String(),
-							StartedAt:    ref.New(startedAt.Format(time.RFC3339)),
-							Note:         ref.New("Note 2"),
+							StartedAt:    new(startedAt.Format(time.RFC3339)),
+							Note:         new("Note 2"),
 							WorkflowUUID: workflowUUID2,
 						},
 					},
@@ -861,17 +861,17 @@ func TestListWorkflows(t *testing.T) {
 					TemporalID:  "temporal-id-1",
 					Type:        enums.WorkflowTypeMoveAip.String(),
 					Status:      enums.WorkflowStatusDone.String(),
-					StartedAt:   ref.New(startedAt.Format(time.RFC3339)),
-					CompletedAt: ref.New(completedAt.Format(time.RFC3339)),
+					StartedAt:   new(startedAt.Format(time.RFC3339)),
+					CompletedAt: new(completedAt.Format(time.RFC3339)),
 					AipUUID:     aipID,
 					Tasks: goastorage.AIPTaskCollection{
 						{
 							UUID:         taskUUID1,
 							Name:         "Task 1",
 							Status:       enums.TaskStatusDone.String(),
-							StartedAt:    ref.New(startedAt.Format(time.RFC3339)),
-							CompletedAt:  ref.New(completedAt.Format(time.RFC3339)),
-							Note:         ref.New("Note 1"),
+							StartedAt:    new(startedAt.Format(time.RFC3339)),
+							CompletedAt:  new(completedAt.Format(time.RFC3339)),
+							Note:         new("Note 1"),
 							WorkflowUUID: workflowUUID1,
 						},
 					},
@@ -881,15 +881,15 @@ func TestListWorkflows(t *testing.T) {
 					TemporalID: "temporal-id-2",
 					Type:       enums.WorkflowTypeDeleteAip.String(),
 					Status:     enums.WorkflowStatusInProgress.String(),
-					StartedAt:  ref.New(startedAt.Format(time.RFC3339)),
+					StartedAt:  new(startedAt.Format(time.RFC3339)),
 					AipUUID:    aipID,
 					Tasks: goastorage.AIPTaskCollection{
 						{
 							UUID:         taskUUID2,
 							Name:         "Task 2",
 							Status:       enums.TaskStatusInProgress.String(),
-							StartedAt:    ref.New(startedAt.Format(time.RFC3339)),
-							Note:         ref.New("Note 2"),
+							StartedAt:    new(startedAt.Format(time.RFC3339)),
+							Note:         new("Note 2"),
 							WorkflowUUID: workflowUUID2,
 						},
 					},
@@ -905,15 +905,15 @@ func TestListWorkflows(t *testing.T) {
 					TemporalID: "temporal-id-2",
 					Type:       enums.WorkflowTypeDeleteAip.String(),
 					Status:     enums.WorkflowStatusInProgress.String(),
-					StartedAt:  ref.New(startedAt.Format(time.RFC3339)),
+					StartedAt:  new(startedAt.Format(time.RFC3339)),
 					AipUUID:    aipID,
 					Tasks: goastorage.AIPTaskCollection{
 						{
 							UUID:         taskUUID2,
 							Name:         "Task 2",
 							Status:       enums.TaskStatusInProgress.String(),
-							StartedAt:    ref.New(startedAt.Format(time.RFC3339)),
-							Note:         ref.New("Note 2"),
+							StartedAt:    new(startedAt.Format(time.RFC3339)),
+							Note:         new("Note 2"),
 							WorkflowUUID: workflowUUID2,
 						},
 					},
@@ -929,15 +929,15 @@ func TestListWorkflows(t *testing.T) {
 					TemporalID: "temporal-id-2",
 					Type:       enums.WorkflowTypeDeleteAip.String(),
 					Status:     enums.WorkflowStatusInProgress.String(),
-					StartedAt:  ref.New(startedAt.Format(time.RFC3339)),
+					StartedAt:  new(startedAt.Format(time.RFC3339)),
 					AipUUID:    aipID,
 					Tasks: goastorage.AIPTaskCollection{
 						{
 							UUID:         taskUUID2,
 							Name:         "Task 2",
 							Status:       enums.TaskStatusInProgress.String(),
-							StartedAt:    ref.New(startedAt.Format(time.RFC3339)),
-							Note:         ref.New("Note 2"),
+							StartedAt:    new(startedAt.Format(time.RFC3339)),
+							Note:         new("Note 2"),
 							WorkflowUUID: workflowUUID2,
 						},
 					},
@@ -978,7 +978,7 @@ func TestCreateLocation(t *testing.T) {
 		ctx,
 		&goastorage.Location{
 			Name:        "test_location",
-			Description: ref.New("location description"),
+			Description: new("location description"),
 			Source:      enums.LocationSourceMinio.String(),
 			Purpose:     enums.LocationPurposeAipStore.String(),
 			UUID:        locationID,
@@ -1012,7 +1012,7 @@ func TestCreateURLLocation(t *testing.T) {
 		ctx,
 		&goastorage.Location{
 			Name:        "test_url_location",
-			Description: ref.New("location description"),
+			Description: new("location description"),
 			Source:      enums.LocationSourceMinio.String(),
 			Purpose:     enums.LocationPurposeAipStore.String(),
 			UUID:        locationID,
@@ -1106,24 +1106,24 @@ func TestListLocations(t *testing.T) {
 	assert.DeepEqual(t, locations, goastorage.LocationCollection{
 		{
 			Name:        "Location",
-			Description: ref.New("location"),
+			Description: new("location"),
 			Source:      "minio",
 			Purpose:     "aip_store",
 			UUID:        locationIDs[0],
 			CreatedAt:   "2013-02-03T19:54:00Z",
 			Config: &goastorage.S3Config{
 				Bucket:    "perma-aips-1",
-				Endpoint:  ref.New(""),
-				PathStyle: ref.New(false),
-				Profile:   ref.New(""),
-				Key:       ref.New(""),
-				Secret:    ref.New(""),
-				Token:     ref.New(""),
+				Endpoint:  new(""),
+				PathStyle: new(false),
+				Profile:   new(""),
+				Key:       new(""),
+				Secret:    new(""),
+				Token:     new(""),
 			},
 		},
 		{
 			Name:        "Another Location",
-			Description: ref.New("another location"),
+			Description: new("another location"),
 			Source:      "minio",
 			Purpose:     "aip_store",
 			UUID:        locationIDs[1],
@@ -1137,7 +1137,7 @@ func TestListLocations(t *testing.T) {
 		},
 		{
 			Name:        "URL Location",
-			Description: ref.New("URL location"),
+			Description: new("URL location"),
 			Source:      "minio",
 			Purpose:     "unspecified",
 			UUID:        locationIDs[2],
@@ -1148,7 +1148,7 @@ func TestListLocations(t *testing.T) {
 		},
 		{
 			Name:        "AMSS Location",
-			Description: ref.New("AMSS Location"),
+			Description: new("AMSS Location"),
 			Source:      "amss",
 			Purpose:     "aip_store",
 			UUID:        locationIDs[3],
@@ -1187,19 +1187,19 @@ func TestReadLocation(t *testing.T) {
 		assert.NilError(t, err)
 		assert.DeepEqual(t, l, &goastorage.Location{
 			Name:        "test_location",
-			Description: ref.New("location description"),
+			Description: new("location description"),
 			Source:      enums.LocationSourceMinio.String(),
 			Purpose:     enums.LocationPurposeAipStore.String(),
 			UUID:        locationID,
 			CreatedAt:   "2013-02-03T19:54:00Z",
 			Config: &goastorage.S3Config{
 				Bucket:    "perma-aips-1",
-				Endpoint:  ref.New(""),
-				PathStyle: ref.New(false),
-				Profile:   ref.New(""),
-				Key:       ref.New(""),
-				Secret:    ref.New(""),
-				Token:     ref.New(""),
+				Endpoint:  new(""),
+				PathStyle: new(false),
+				Profile:   new(""),
+				Key:       new(""),
+				Secret:    new(""),
+				Token:     new(""),
 			},
 		})
 	})
@@ -1251,7 +1251,7 @@ func TestLocationAIPs(t *testing.T) {
 				UUID:         aipID,
 				Status:       "stored",
 				ObjectKey:    objectKey,
-				LocationUUID: ref.New(locationID),
+				LocationUUID: new(locationID),
 				CreatedAt:    "2013-02-03T19:54:00Z",
 			},
 		})

--- a/internal/storage/persistence/ent/client/convert.go
+++ b/internal/storage/persistence/ent/client/convert.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"go.artefactual.dev/tools/ref"
-
 	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
 	"github.com/artefactual-sdps/enduro/internal/storage/persistence/ent/db"
 	"github.com/artefactual-sdps/enduro/internal/storage/types"
@@ -87,10 +85,10 @@ func workflowAsGoa(dbw *db.Workflow) *goastorage.AIPWorkflow {
 	}
 
 	if !dbw.StartedAt.IsZero() {
-		w.StartedAt = ref.New(dbw.StartedAt.Format(time.RFC3339))
+		w.StartedAt = new(dbw.StartedAt.Format(time.RFC3339))
 	}
 	if !dbw.CompletedAt.IsZero() {
-		w.CompletedAt = ref.New(dbw.CompletedAt.Format(time.RFC3339))
+		w.CompletedAt = new(dbw.CompletedAt.Format(time.RFC3339))
 	}
 
 	if dbw.Edges.Aip != nil {
@@ -117,10 +115,10 @@ func taskAsGoa(dbt *db.Task) *goastorage.AIPTask {
 	}
 
 	if !dbt.StartedAt.IsZero() {
-		t.StartedAt = ref.New(dbt.StartedAt.Format(time.RFC3339))
+		t.StartedAt = new(dbt.StartedAt.Format(time.RFC3339))
 	}
 	if !dbt.CompletedAt.IsZero() {
-		t.CompletedAt = ref.New(dbt.CompletedAt.Format(time.RFC3339))
+		t.CompletedAt = new(dbt.CompletedAt.Format(time.RFC3339))
 	}
 	if dbt.Note != "" {
 		t.Note = &dbt.Note
@@ -144,11 +142,11 @@ func convertDBAIP(dba *db.AIP) *types.AIP {
 	}
 
 	if dba.Edges.Location != nil {
-		aip.LocationUUID = ref.New(dba.Edges.Location.UUID)
+		aip.LocationUUID = new(dba.Edges.Location.UUID)
 	}
 
 	if dba.DeletionReportKey != "" {
-		aip.DeletionReportKey = ref.New(dba.DeletionReportKey)
+		aip.DeletionReportKey = new(dba.DeletionReportKey)
 	}
 
 	return aip

--- a/internal/storage/persistence/ent/client/deletion_request_test.go
+++ b/internal/storage/persistence/ent/client/deletion_request_test.go
@@ -189,7 +189,7 @@ func TestListDeletionRequests(t *testing.T) {
 		{
 			name: "Lists Deletion Requests by AIP UUID",
 			filter: &persistence.DeletionRequestFilter{
-				AIPUUID: ref.New(aipID),
+				AIPUUID: new(aipID),
 			},
 			want: []*types.DeletionRequest{
 				{
@@ -221,7 +221,7 @@ func TestListDeletionRequests(t *testing.T) {
 		{
 			name: "Returns no results for non-matching filter",
 			filter: &persistence.DeletionRequestFilter{
-				AIPUUID: ref.New(uuid.New()),
+				AIPUUID: new(uuid.New()),
 			},
 			want: []*types.DeletionRequest{},
 		},

--- a/internal/storage/service_test.go
+++ b/internal/storage/service_test.go
@@ -67,7 +67,7 @@ func setUpService(t *testing.T, attrs *setUpAttrs) storage.Service {
 	td := tfs.NewDir(t, "enduro-service-test")
 
 	params := setUpAttrs{
-		logger: ref.New(logr.Discard()),
+		logger: new(logr.Discard()),
 		config: &storage.Config{
 			TaskQueue: "global",
 			Internal: storage.LocationConfig{
@@ -525,14 +525,14 @@ func TestServiceList(t *testing.T) {
 		storedLocations := goastorage.LocationCollection{
 			{
 				Name:        "perma-aips-1",
-				Description: ref.New("One"),
+				Description: new("One"),
 				Source:      "minio",
 				Purpose:     "aip_store",
 				UUID:        uuid.New(),
 			},
 			{
 				Name:        "perma-aips-2",
-				Description: ref.New("Two"),
+				Description: new("Two"),
 				Source:      "minio",
 				Purpose:     "aip_store",
 				UUID:        uuid.New(),
@@ -561,7 +561,7 @@ func TestServiceListAips(t *testing.T) {
 		svc := setUpService(t, attrs)
 
 		payload := &goastorage.ListAipsPayload{
-			Limit: ref.New(20),
+			Limit: new(20),
 		}
 		aips := &goastorage.AIPs{
 			Items: goastorage.AIPCollection{
@@ -1085,7 +1085,7 @@ func TestListAipWorkflows(t *testing.T) {
 			name: "Filter AIP workflows by status",
 			payload: &goastorage.ListAipWorkflowsPayload{
 				UUID:   aipID.String(),
-				Status: ref.New(enums.WorkflowStatusInProgress.String()),
+				Status: new(enums.WorkflowStatusInProgress.String()),
 			},
 			mock: func(ctx context.Context, s *fake.MockStorage) {
 				s.EXPECT().
@@ -1101,7 +1101,7 @@ func TestListAipWorkflows(t *testing.T) {
 			name: "Filter AIP workflows by type",
 			payload: &goastorage.ListAipWorkflowsPayload{
 				UUID: aipID.String(),
-				Type: ref.New(enums.WorkflowTypeMoveAip.String()),
+				Type: new(enums.WorkflowTypeMoveAip.String()),
 			},
 			mock: func(ctx context.Context, s *fake.MockStorage) {
 				s.EXPECT().
@@ -1124,7 +1124,7 @@ func TestListAipWorkflows(t *testing.T) {
 			name: "Fails on invalid workflow status",
 			payload: &goastorage.ListAipWorkflowsPayload{
 				UUID:   aipID.String(),
-				Status: ref.New("bad status"),
+				Status: new("bad status"),
 			},
 			wantErr: "status: invalid value",
 		},
@@ -1132,7 +1132,7 @@ func TestListAipWorkflows(t *testing.T) {
 			name: "Fails on invalid workflow type",
 			payload: &goastorage.ListAipWorkflowsPayload{
 				UUID: aipID.String(),
-				Type: ref.New("bad type"),
+				Type: new("bad type"),
 			},
 			wantErr: "type: invalid value",
 		},

--- a/internal/storage/workflows/delete_test.go
+++ b/internal/storage/workflows/delete_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.artefactual.dev/tools/ref"
 	temporalsdk_activity "go.temporal.io/sdk/activity"
 	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
 	"go.uber.org/mock/gomock"
@@ -57,7 +56,7 @@ func NewStorageDeleteWorkflowTestSuite(
 	s.req = req
 	s.aip = &goastorage.AIP{
 		UUID:         s.req.AIPID,
-		LocationUUID: ref.New(uuid.New()),
+		LocationUUID: new(uuid.New()),
 		Status:       enums.AIPStatusStored.String(),
 	}
 	s.reviewTask = &datatypes.Task{ID: 1}

--- a/internal/timerange/timerange_test.go
+++ b/internal/timerange/timerange_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"go.artefactual.dev/tools/ref"
 	"gotest.tools/v3/assert"
 
 	"github.com/artefactual-sdps/enduro/internal/timerange"
@@ -115,8 +114,8 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "Parses valid start and end times",
-			start: ref.New("2024-09-17T00:00:00Z"),
-			end:   ref.New("2024-09-18T00:00:00Z"),
+			start: new("2024-09-17T00:00:00Z"),
+			end:   new("2024-09-18T00:00:00Z"),
 			want: &timerange.Range{
 				Start: time.Date(2024, 9, 17, 0, 0, 0, 0, time.UTC),
 				End:   time.Date(2024, 9, 18, 0, 0, 0, 0, time.UTC),
@@ -125,7 +124,7 @@ func TestParse(t *testing.T) {
 		{
 			name:  "Uses arbitrary past time when start is nil",
 			start: nil,
-			end:   ref.New("2024-09-18T00:00:00Z"),
+			end:   new("2024-09-18T00:00:00Z"),
 			want: &timerange.Range{
 				Start: time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC),
 				End:   time.Date(2024, 9, 18, 0, 0, 0, 0, time.UTC),
@@ -133,7 +132,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "Uses current time when end is nil",
-			start: ref.New("2024-09-17T00:00:00Z"),
+			start: new("2024-09-17T00:00:00Z"),
 			end:   nil,
 			want: &timerange.Range{
 				Start: time.Date(2024, 9, 17, 0, 0, 0, 0, time.UTC),
@@ -142,22 +141,22 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:    "Errors when start time is invalid",
-			start:   ref.New("invalid"),
-			end:     ref.New("2024-09-18T00:00:00Z"),
+			start:   new("invalid"),
+			end:     new("2024-09-18T00:00:00Z"),
 			want:    nil,
 			wantErr: "time range: cannot parse start time",
 		},
 		{
 			name:    "Errors when end time is invalid",
-			start:   ref.New("2024-09-17T00:00:00Z"),
-			end:     ref.New("invalid"),
+			start:   new("2024-09-17T00:00:00Z"),
+			end:     new("invalid"),
 			want:    nil,
 			wantErr: "time range: cannot parse end time",
 		},
 		{
 			name:    "Errors when end time is before start time",
-			start:   ref.New("2024-09-18T00:00:00Z"),
-			end:     ref.New("2024-09-17T00:00:00Z"),
+			start:   new("2024-09-18T00:00:00Z"),
+			end:     new("2024-09-17T00:00:00Z"),
 			want:    nil,
 			wantErr: "time range: end cannot be before start",
 		},

--- a/internal/workflow/activities/bundle.go
+++ b/internal/workflow/activities/bundle.go
@@ -11,6 +11,7 @@ import (
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/otiai10/copy"
+	gofsutils "go.artefactual.dev/tools/fsutil"
 	temporal_tools "go.artefactual.dev/tools/temporal"
 
 	"github.com/artefactual-sdps/enduro/internal/bagit"
@@ -87,7 +88,7 @@ func (a *BundleActivity) Execute(ctx context.Context, params *BundleActivityPara
 		)
 	}
 
-	if err = fsutil.SetFileModes(res.FullPath, ModeDir, ModeFile); err != nil {
+	if err = gofsutils.SetFileModes(res.FullPath, ModeDir, ModeFile); err != nil {
 		return nil, temporal_tools.NewNonRetryableError(
 			fmt.Errorf("bundle: set permissions: %v", err),
 		)

--- a/internal/workflow/activities/clear_ingested_sips.go
+++ b/internal/workflow/activities/clear_ingested_sips.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"go.artefactual.dev/tools/ref"
 	"go.artefactual.dev/tools/temporal"
 	goa "goa.design/goa/v3/pkg"
 
@@ -61,9 +60,9 @@ func (a *ClearIngestedSIPsActivity) Execute(
 	var aipIDs []string
 	for {
 		result, err := a.ingestsvc.ListSips(ctx, &goaingest.ListSipsPayload{
-			BatchUUID: ref.New(params.BatchUUID.String()),
-			Limit:     ref.New(1000),
-			Offset:    ref.New(sipCount),
+			BatchUUID: new(params.BatchUUID.String()),
+			Limit:     new(1000),
+			Offset:    new(sipCount),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("list SIPs: %v", err)
@@ -134,7 +133,7 @@ func (a *ClearIngestedSIPsActivity) deleteAIP(ctx context.Context, batchUUID uui
 	err := a.storageClient.AipDeletionAuto(ctx, &goastorage.AipDeletionAutoPayload{
 		UUID:       aipID,
 		Reason:     fmt.Sprintf("Batch %s canceled", batchUUID),
-		SkipReport: ref.New(true),
+		SkipReport: new(true),
 	})
 	if err != nil {
 		if isAIPNotStoredError(err) {

--- a/internal/workflow/activities/clear_ingested_sips_test.go
+++ b/internal/workflow/activities/clear_ingested_sips_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/uuid"
 	"go.artefactual.dev/tools/mockutil"
-	"go.artefactual.dev/tools/ref"
 	temporalsdk_activity "go.temporal.io/sdk/activity"
 	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
 	"go.uber.org/mock/gomock"
@@ -37,9 +36,9 @@ func TestClearIngestedSIPsActivity(t *testing.T) {
 
 	listPayload := func(offset int) *goaingest.ListSipsPayload {
 		return &goaingest.ListSipsPayload{
-			BatchUUID: ref.New(batchUUID.String()),
-			Limit:     ref.New(1000),
-			Offset:    ref.New(offset),
+			BatchUUID: new(batchUUID.String()),
+			Limit:     new(1000),
+			Offset:    new(offset),
 		}
 	}
 
@@ -47,7 +46,7 @@ func TestClearIngestedSIPsActivity(t *testing.T) {
 		return &goastorage.AipDeletionAutoPayload{
 			UUID:       aipID,
 			Reason:     fmt.Sprintf("Batch %s canceled", batchUUID),
-			SkipReport: ref.New(true),
+			SkipReport: new(true),
 		}
 	}
 
@@ -68,7 +67,7 @@ func TestClearIngestedSIPsActivity(t *testing.T) {
 							{
 								UUID:    sipUUID1,
 								Status:  enums.SIPStatusIngested.String(),
-								AipUUID: ref.New(aipID1),
+								AipUUID: new(aipID1),
 							},
 							{
 								UUID:   sipUUID2,
@@ -86,7 +85,7 @@ func TestClearIngestedSIPsActivity(t *testing.T) {
 							{
 								UUID:    sipUUID3,
 								Status:  enums.SIPStatusCanceled.String(),
-								AipUUID: ref.New(aipID2),
+								AipUUID: new(aipID2),
 							},
 						},
 						Page: &goaingest.EnduroPage{Total: 3},
@@ -119,7 +118,7 @@ func TestClearIngestedSIPsActivity(t *testing.T) {
 							{
 								UUID:    sipUUID1,
 								Status:  enums.SIPStatusCanceled.String(),
-								AipUUID: ref.New(aipID1),
+								AipUUID: new(aipID1),
 							},
 						},
 						Page: &goaingest.EnduroPage{Total: 1},
@@ -144,12 +143,12 @@ func TestClearIngestedSIPsActivity(t *testing.T) {
 							{
 								UUID:    sipUUID2,
 								Status:  enums.SIPStatusIngested.String(),
-								AipUUID: ref.New(aipID1),
+								AipUUID: new(aipID1),
 							},
 							{
 								UUID:    sipUUID3,
 								Status:  enums.SIPStatusCanceled.String(),
-								AipUUID: ref.New(aipID2),
+								AipUUID: new(aipID2),
 							},
 						},
 						Page: &goaingest.EnduroPage{Total: 3},
@@ -176,22 +175,22 @@ func TestClearIngestedSIPsActivity(t *testing.T) {
 							{
 								UUID:    sipUUID1,
 								Status:  enums.SIPStatusCanceled.String(),
-								AipUUID: ref.New(aipID1),
+								AipUUID: new(aipID1),
 							},
 							{
 								UUID:    sipUUID2,
 								Status:  enums.SIPStatusCanceled.String(),
-								AipUUID: ref.New(aipID2),
+								AipUUID: new(aipID2),
 							},
 							{
 								UUID:    sipUUID3,
 								Status:  enums.SIPStatusCanceled.String(),
-								AipUUID: ref.New(aipID3),
+								AipUUID: new(aipID3),
 							},
 							{
 								UUID:    sipUUID4,
 								Status:  enums.SIPStatusCanceled.String(),
-								AipUUID: ref.New(aipID4),
+								AipUUID: new(aipID4),
 							},
 						},
 						Page: &goaingest.EnduroPage{Total: 4},

--- a/internal/workflow/activities/poll_sip_statuses.go
+++ b/internal/workflow/activities/poll_sip_statuses.go
@@ -100,7 +100,7 @@ func (a *PollSIPStatusesActivity) checkSIPStatuses(
 	// Query all SIPs for this batch. Limit to the maximum page size for now,
 	// we may switch to a stats-based or aggregated query approach in the future.
 	result, err := a.ingestsvc.ListSips(ctx, &goaingest.ListSipsPayload{
-		BatchUUID: ref.New(batchUUID.String()),
+		BatchUUID: new(batchUUID.String()),
 		Limit:     ref.New(entfilter.MaxPageSize),
 	})
 	if err != nil {

--- a/internal/workflow/activities/poll_sip_statuses_test.go
+++ b/internal/workflow/activities/poll_sip_statuses_test.go
@@ -30,7 +30,7 @@ func TestPollSIPStatusesActivity(t *testing.T) {
 	aip2UUID := uuid.New()
 
 	payload := &goaingest.ListSipsPayload{
-		BatchUUID: ref.New(batchUUID.String()),
+		BatchUUID: new(batchUUID.String()),
 		Limit:     ref.New(entfilter.MaxPageSize),
 	}
 
@@ -71,12 +71,12 @@ func TestPollSIPStatusesActivity(t *testing.T) {
 						{
 							UUID:    sip1UUID,
 							Status:  enums.SIPStatusIngested.String(),
-							AipUUID: ref.New(aip1UUID.String()),
+							AipUUID: new(aip1UUID.String()),
 						},
 						{
 							UUID:    sip2UUID,
 							Status:  enums.SIPStatusIngested.String(),
-							AipUUID: ref.New(aip2UUID.String()),
+							AipUUID: new(aip2UUID.String()),
 						},
 					}}, nil)
 			},
@@ -223,7 +223,7 @@ func TestPollSIPStatusesActivity(t *testing.T) {
 						{
 							UUID:    sip1UUID,
 							Status:  enums.SIPStatusIngested.String(),
-							AipUUID: ref.New("invalid-uuid"),
+							AipUUID: new("invalid-uuid"),
 						},
 						{UUID: sip2UUID, Status: enums.SIPStatusIngested.String()},
 					}}, nil)

--- a/internal/workflow/activities/storage_test.go
+++ b/internal/workflow/activities/storage_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/uuid"
 	"go.artefactual.dev/tools/mockutil"
-	"go.artefactual.dev/tools/ref"
 	"go.artefactual.dev/tools/temporal"
 	temporalsdk_activity "go.temporal.io/sdk/activity"
 	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
@@ -52,7 +51,7 @@ func TestCreateAIPActivity(t *testing.T) {
 						UUID:         aipID.String(),
 						ObjectKey:    objectKey.String(),
 						Status:       "stored",
-						LocationUUID: ref.New(locationID),
+						LocationUUID: new(locationID),
 					},
 				).Return(
 					&goastorage.AIP{
@@ -60,7 +59,7 @@ func TestCreateAIPActivity(t *testing.T) {
 						UUID:         aipID,
 						ObjectKey:    objectKey,
 						Status:       "stored",
-						LocationUUID: ref.New(locationID),
+						LocationUUID: new(locationID),
 						CreatedAt:    "2024-05-03 16:02:25",
 					},
 					nil,
@@ -87,7 +86,7 @@ func TestCreateAIPActivity(t *testing.T) {
 						UUID:         "12345",
 						ObjectKey:    objectKey.String(),
 						Status:       "stored",
-						LocationUUID: ref.New(locationID),
+						LocationUUID: new(locationID),
 					},
 				).Return(
 					nil, goastorage.MakeNotValid(errors.New("invalid aip_id")),
@@ -112,7 +111,7 @@ func TestCreateAIPActivity(t *testing.T) {
 						UUID:         aipID.String(),
 						ObjectKey:    objectKey.String(),
 						Status:       "stored",
-						LocationUUID: ref.New(locationID),
+						LocationUUID: new(locationID),
 					},
 				).Return(
 					nil, goastorage.Unauthorized("Unauthorized"),

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -659,7 +659,8 @@ func (w *ProcessingWorkflow) transferA3m(
 		// Set SIP to pending status.
 		{
 			ctx := withLocalActivityOpts(sessCtx)
-			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setStatusLocalActivity, w.ingestsvc, state.sip.uuid, enums.SIPStatusPending).Get(ctx, nil)
+			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setStatusLocalActivity, w.ingestsvc, state.sip.uuid, enums.SIPStatusPending).
+				Get(ctx, nil)
 			if err != nil {
 				return sessCtx, err
 			}
@@ -668,7 +669,8 @@ func (w *ProcessingWorkflow) transferA3m(
 		// Set workflow to pending status.
 		{
 			ctx := withLocalActivityOpts(sessCtx)
-			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setWorkflowStatusLocalActivity, w.ingestsvc, state.workflowID, enums.WorkflowStatusPending).Get(ctx, nil)
+			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setWorkflowStatusLocalActivity, w.ingestsvc, state.workflowID, enums.WorkflowStatusPending).
+				Get(ctx, nil)
 			if err != nil {
 				return sessCtx, err
 			}
@@ -696,7 +698,8 @@ func (w *ProcessingWorkflow) transferA3m(
 		// Set SIP to in progress status.
 		{
 			ctx := withLocalActivityOpts(sessCtx)
-			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setStatusLocalActivity, w.ingestsvc, state.sip.uuid, enums.SIPStatusProcessing).Get(ctx, nil)
+			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setStatusLocalActivity, w.ingestsvc, state.sip.uuid, enums.SIPStatusProcessing).
+				Get(ctx, nil)
 			if err != nil {
 				return sessCtx, err
 			}
@@ -705,7 +708,8 @@ func (w *ProcessingWorkflow) transferA3m(
 		// Set workflow to in progress status.
 		{
 			ctx := withLocalActivityOpts(sessCtx)
-			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setWorkflowStatusLocalActivity, w.ingestsvc, state.workflowID, enums.WorkflowStatusInProgress).Get(ctx, nil)
+			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, setWorkflowStatusLocalActivity, w.ingestsvc, state.workflowID, enums.WorkflowStatusInProgress).
+				Get(ctx, nil)
 			if err != nil {
 				return sessCtx, err
 			}
@@ -797,7 +801,8 @@ func (w *ProcessingWorkflow) transferA3m(
 				ID:     reviewTaskID,
 				Status: enums.TaskStatusDone,
 				Note:   ref.New("Reviewed and rejected"),
-			}).Get(ctx, nil)
+			}).
+				Get(ctx, nil)
 			if err != nil {
 				return sessCtx, err
 			}
@@ -808,7 +813,8 @@ func (w *ProcessingWorkflow) transferA3m(
 			activityOpts := withActivityOptsForRequest(sessCtx)
 			err := temporalsdk_workflow.ExecuteActivity(activityOpts, activities.RejectSIPActivityName, &activities.RejectSIPActivityParams{
 				AIPID: state.aip.id,
-			}).Get(activityOpts, nil)
+			}).
+				Get(activityOpts, nil)
 			if err != nil {
 				return sessCtx, err
 			}

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -20,7 +20,6 @@ import (
 	"github.com/artefactual-sdps/temporal-activities/removepaths"
 	"github.com/artefactual-sdps/temporal-activities/xmlvalidate"
 	"github.com/google/uuid"
-	"go.artefactual.dev/tools/ref"
 	temporal_tools "go.artefactual.dev/tools/temporal"
 	temporalapi_enums "go.temporal.io/api/enums/v1"
 	temporalsdk_temporal "go.temporal.io/sdk/temporal"
@@ -637,7 +636,7 @@ func (w *ProcessingWorkflow) transferA3m(
 		err := temporalsdk_workflow.ExecuteLocalActivity(ctx, completeTaskLocalActivity, w.ingestsvc, &completeTaskLocalActivityParams{
 			ID:     uploadTaskID,
 			Status: enums.TaskStatusDone,
-			Note:   ref.New("Moved to review bucket"),
+			Note:   new("Moved to review bucket"),
 		}).
 			Get(ctx, nil)
 		if err != nil {
@@ -723,7 +722,7 @@ func (w *ProcessingWorkflow) transferA3m(
 			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, completeTaskLocalActivity, w.ingestsvc, &completeTaskLocalActivityParams{
 				ID:     reviewTaskID,
 				Status: enums.TaskStatusDone,
-				Note:   ref.New("Reviewed and accepted"),
+				Note:   new("Reviewed and accepted"),
 			}).
 				Get(ctx, nil)
 			if err != nil {
@@ -782,7 +781,7 @@ func (w *ProcessingWorkflow) transferA3m(
 			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, completeTaskLocalActivity, w.ingestsvc, &completeTaskLocalActivityParams{
 				ID:     moveTaskID,
 				Status: enums.TaskStatusDone,
-				Note:   ref.New(fmt.Sprintf("Moved to location %s", *reviewResult.LocationID)),
+				Note:   new(fmt.Sprintf("Moved to location %s", *reviewResult.LocationID)),
 			}).
 				Get(ctx, nil)
 			if err != nil {
@@ -800,7 +799,7 @@ func (w *ProcessingWorkflow) transferA3m(
 			err := temporalsdk_workflow.ExecuteLocalActivity(ctx, completeTaskLocalActivity, w.ingestsvc, &completeTaskLocalActivityParams{
 				ID:     reviewTaskID,
 				Status: enums.TaskStatusDone,
-				Note:   ref.New("Reviewed and rejected"),
+				Note:   new("Reviewed and rejected"),
 			}).
 				Get(ctx, nil)
 			if err != nil {
@@ -1145,7 +1144,7 @@ func (w *ProcessingWorkflow) completeTask(
 		&completeTaskLocalActivityParams{
 			ID:     task.ID,
 			Status: task.Status,
-			Note:   ref.New(task.Note),
+			Note:   new(task.Note),
 		},
 	).Get(ctx, nil)
 	if err != nil {


### PR DESCRIPTION
Looks like we won't need `ref.New` anymore!

I've enabled the [`modernize`](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize) linter.