### PR TITLE
Pass BatchID to preprocessing child workflow

### DIFF
--- a/internal/childwf/preprocessing.go
+++ b/internal/childwf/preprocessing.go
@@ -8,6 +8,10 @@ type PreprocessingParams struct {
 
 	// SIPID is the identifier of the SIP being processed.
 	SIPID uuid.UUID
+
+	// BatchID is the identifier of the batch being processed. If the SIP is not
+	// part of a batch, this will equal uuid.Nil.
+	BatchID uuid.UUID
 }
 
 type PreprocessingResult struct {

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -1035,7 +1035,11 @@ func (w *ProcessingWorkflow) preprocessing(ctx temporalsdk_workflow.Context, sta
 	err = temporalsdk_workflow.ExecuteChildWorkflow(
 		preCtx,
 		cfg.WorkflowName,
-		childwf.PreprocessingParams{RelativePath: relPath, SIPID: state.sip.uuid},
+		childwf.PreprocessingParams{
+			RelativePath: relPath,
+			SIPID:        state.sip.uuid,
+			BatchID:      state.req.BatchUUID,
+		},
 	).Get(preCtx, &ppResult)
 	if err != nil {
 		return err


### PR DESCRIPTION
The CVA preprocessing child workflow should upload a metadata file only if the SIP is part of a batch, as the metadata is used to create a CSV for a batch of SIPs. Pass the BatchID (if there is one) to preprocessing so it knows whether to upload the metadata file or not.