### PR TITLE
Remove sql.NullTime from domain types

### DIFF
--- a/internal/a3m/a3m.go
+++ b/internal/a3m/a3m.go
@@ -2,7 +2,6 @@ package a3m
 
 import (
 	context "context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"time"
@@ -196,13 +195,10 @@ func saveTasks(
 			return err
 		}
 		tasks[i] = &datatypes.Task{
-			UUID:   taskUUID,
-			Name:   job.Name,
-			Status: a3mJobToTaskStatus[job.Status],
-			StartedAt: sql.NullTime{
-				Time:  job.StartTime.AsTime(),
-				Valid: true,
-			},
+			UUID:         taskUUID,
+			Name:         job.Name,
+			Status:       a3mJobToTaskStatus[job.Status],
+			StartedAt:    job.StartTime.AsTime(),
 			WorkflowUUID: wUUID,
 		}
 	}

--- a/internal/a3m/a3m_test.go
+++ b/internal/a3m/a3m_test.go
@@ -1,7 +1,6 @@
 package a3m_test
 
 import (
-	"database/sql"
 	"testing"
 	"time"
 
@@ -69,12 +68,9 @@ func TestCreateAIPActivity(t *testing.T) {
 		mockutil.Context(),
 		[]*datatypes.Task{
 			{
-				UUID:   taskUUID,
-				Status: enums.TaskStatusDone,
-				StartedAt: sql.NullTime{
-					Time:  time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
-					Valid: true,
-				},
+				UUID:      taskUUID,
+				Status:    enums.TaskStatusDone,
+				StartedAt: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 			},
 		},
 	).Return(nil)

--- a/internal/am/job_tracker.go
+++ b/internal/am/job_tracker.go
@@ -2,8 +2,8 @@ package am
 
 import (
 	context "context"
-	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
@@ -215,9 +215,9 @@ func ConvertJobToTask(job amclient.Job) (*datatypes.Task, error) {
 }
 
 // jobTimeRange calculates the overall start and end times for a job.
-func jobTimeRange(job amclient.Job) (sql.NullTime, sql.NullTime) {
+func jobTimeRange(job amclient.Job) (time.Time, time.Time) {
 	if len(job.Tasks) == 0 {
-		return sql.NullTime{}, sql.NullTime{}
+		return time.Time{}, time.Time{}
 	}
 	st := job.Tasks[0].StartedAt.Time
 	ct := job.Tasks[0].CompletedAt.Time
@@ -234,8 +234,5 @@ func jobTimeRange(job amclient.Job) (sql.NullTime, sql.NullTime) {
 	}
 
 	// Emit NULLs if we see the zero value.
-	start := sql.NullTime{Time: st, Valid: !st.IsZero()}
-	end := sql.NullTime{Time: ct, Valid: !ct.IsZero()}
-
-	return start, end
+	return st, ct
 }

--- a/internal/am/job_tracker_test.go
+++ b/internal/am/job_tracker_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"go.artefactual.dev/amclient"
@@ -109,8 +108,8 @@ func TestJobTracker(t *testing.T) {
 							UUID:         taskUUID,
 							Name:         "Extract zipped bag transfer",
 							Status:       enums.TaskStatusDone,
-							StartedAt:    sql.NullTime{Time: startedAt, Valid: true},
-							CompletedAt:  sql.NullTime{Time: completedAt, Valid: true},
+							StartedAt:    startedAt,
+							CompletedAt:  completedAt,
 							WorkflowUUID: wUUID,
 						},
 					}).Return(nil)
@@ -215,17 +214,11 @@ func TestConvertJobToTask(t *testing.T) {
 				},
 			},
 			want: &datatypes.Task{
-				UUID:   taskUUID,
-				Name:   "Move to processing directory",
-				Status: enums.TaskStatusDone,
-				StartedAt: sql.NullTime{
-					Time:  time.Date(2024, time.January, 18, 1, 27, 49, 0, time.UTC),
-					Valid: true,
-				},
-				CompletedAt: sql.NullTime{
-					Time:  time.Date(2026, time.January, 18, 1, 27, 49, 0, time.UTC),
-					Valid: true,
-				},
+				UUID:        taskUUID,
+				Name:        "Move to processing directory",
+				Status:      enums.TaskStatusDone,
+				StartedAt:   time.Date(2024, time.January, 18, 1, 27, 49, 0, time.UTC),
+				CompletedAt: time.Date(2026, time.January, 18, 1, 27, 49, 0, time.UTC),
 			},
 		},
 		{
@@ -255,14 +248,10 @@ func TestConvertJobToTask(t *testing.T) {
 				},
 			},
 			want: &datatypes.Task{
-				UUID:   taskUUID,
-				Name:   "Verify SIP compliance",
-				Status: enums.TaskStatusInProgress,
-				StartedAt: sql.NullTime{
-					Time:  time.Date(2024, time.January, 18, 1, 27, 49, 0, time.UTC),
-					Valid: true,
-				},
-				CompletedAt: sql.NullTime{},
+				UUID:      taskUUID,
+				Name:      "Verify SIP compliance",
+				Status:    enums.TaskStatusInProgress,
+				StartedAt: time.Date(2024, time.January, 18, 1, 27, 49, 0, time.UTC),
 			},
 		},
 		{

--- a/internal/datatypes/sip.go
+++ b/internal/datatypes/sip.go
@@ -1,7 +1,6 @@
 package datatypes
 
 import (
-	"database/sql"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,11 +21,11 @@ type SIP struct {
 	// It defaults to CURRENT_TIMESTAMP(6) so populated as soon as possible.
 	CreatedAt time.Time
 
-	// Nullable, populated as soon as processing starts.
-	StartedAt sql.NullTime
+	// Zero until processing starts.
+	StartedAt time.Time
 
-	// Nullable, populated as soon as ingest completes.
-	CompletedAt sql.NullTime
+	// Zero until ingest completes.
+	CompletedAt time.Time
 
 	// Set if there is a failure in workflow, it can be empty.
 	FailedAs enums.SIPFailedAs
@@ -52,8 +51,8 @@ func (s *SIP) Goa() *goaingest.SIP {
 		Name:        db.FormatOptionalString(s.Name),
 		Status:      s.Status.String(),
 		CreatedAt:   db.FormatTime(s.CreatedAt),
-		StartedAt:   db.FormatOptionalTime(s.StartedAt),
-		CompletedAt: db.FormatOptionalTime(s.CompletedAt),
+		StartedAt:   db.FormatOptionalZeroTime(s.StartedAt),
+		CompletedAt: db.FormatOptionalZeroTime(s.CompletedAt),
 	}
 	if s.AIPID.Valid {
 		col.AipUUID = new(s.AIPID.UUID.String())

--- a/internal/datatypes/sip_test.go
+++ b/internal/datatypes/sip_test.go
@@ -1,0 +1,99 @@
+package datatypes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gotest.tools/v3/assert"
+
+	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	"github.com/artefactual-sdps/enduro/internal/enums"
+)
+
+func TestSIPGoa(t *testing.T) {
+	t.Parallel()
+
+	sipUUID := uuid.New()
+	aipUUID := uuid.New()
+	uploaderUUID := uuid.New()
+	batchUUID := uuid.New()
+	createdAt := time.Date(2025, 6, 23, 14, 57, 12, 0, time.UTC)
+	startedAt := time.Date(2025, 6, 23, 15, 0, 0, 0, time.UTC)
+	completedAt := time.Date(2025, 6, 23, 15, 5, 0, 0, time.UTC)
+
+	type test struct {
+		name string
+		sip  *SIP
+		want *goaingest.SIP
+	}
+
+	for _, tt := range []test{
+		{
+			name: "Converts nil SIP to nil Goa SIP",
+		},
+		{
+			name: "Converts SIP with zero optional times",
+			sip: &SIP{
+				UUID:      sipUUID,
+				Name:      "transfer-1",
+				Status:    enums.SIPStatusQueued,
+				CreatedAt: createdAt,
+			},
+			want: &goaingest.SIP{
+				UUID:      sipUUID,
+				Name:      new("transfer-1"),
+				Status:    enums.SIPStatusQueued.String(),
+				CreatedAt: "2025-06-23T14:57:12Z",
+			},
+		},
+		{
+			name: "Converts SIP with all optional fields",
+			sip: &SIP{
+				UUID:        sipUUID,
+				Name:        "transfer-1",
+				AIPID:       uuid.NullUUID{Valid: true, UUID: aipUUID},
+				Status:      enums.SIPStatusIngested,
+				CreatedAt:   createdAt,
+				StartedAt:   startedAt,
+				CompletedAt: completedAt,
+				FailedAs:    enums.SIPFailedAsPIP,
+				FailedKey:   "failed/pip.7z",
+				Uploader: &User{
+					UUID:  uploaderUUID,
+					Email: "nobody@example.com",
+					Name:  "Test User",
+				},
+				Batch: &Batch{
+					UUID:       batchUUID,
+					Identifier: "batch-1",
+					Status:     enums.BatchStatusPending,
+				},
+			},
+			want: &goaingest.SIP{
+				UUID:            sipUUID,
+				Name:            new("transfer-1"),
+				Status:          enums.SIPStatusIngested.String(),
+				AipUUID:         new(aipUUID.String()),
+				CreatedAt:       "2025-06-23T14:57:12Z",
+				StartedAt:       new("2025-06-23T15:00:00Z"),
+				CompletedAt:     new("2025-06-23T15:05:00Z"),
+				FailedAs:        new(enums.SIPFailedAsPIP.String()),
+				FailedKey:       new("failed/pip.7z"),
+				UploaderUUID:    new(uploaderUUID),
+				UploaderEmail:   new("nobody@example.com"),
+				UploaderName:    new("Test User"),
+				BatchUUID:       new(batchUUID),
+				BatchIdentifier: new("batch-1"),
+				BatchStatus:     new(enums.BatchStatusPending.String()),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.sip.Goa()
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}

--- a/internal/datatypes/task.go
+++ b/internal/datatypes/task.go
@@ -1,8 +1,8 @@
 package datatypes
 
 import (
-	"database/sql"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -15,8 +15,8 @@ type Task struct {
 	UUID         uuid.UUID
 	Name         string
 	Status       enums.TaskStatus
-	StartedAt    sql.NullTime
-	CompletedAt  sql.NullTime
+	StartedAt    time.Time
+	CompletedAt  time.Time
 	Note         string
 	WorkflowUUID uuid.UUID
 }

--- a/internal/datatypes/workflow.go
+++ b/internal/datatypes/workflow.go
@@ -1,7 +1,7 @@
 package datatypes
 
 import (
-	"database/sql"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -19,8 +19,8 @@ type Workflow struct {
 	TemporalID  string
 	Type        enums.WorkflowType
 	Status      enums.WorkflowStatus
-	StartedAt   sql.NullTime
-	CompletedAt sql.NullTime
+	StartedAt   time.Time
+	CompletedAt time.Time
 	SIPUUID     uuid.UUID
 
 	// Tasks contains the workflow's tasks, or nil if they were not loaded.

--- a/internal/db/convert.go
+++ b/internal/db/convert.go
@@ -23,6 +23,16 @@ func FormatOptionalTime(nt sql.NullTime) *string {
 	return res
 }
 
+// FormatOptionalZeroTime returns nil when t has the zero value.
+func FormatOptionalZeroTime(t time.Time) *string {
+	if t.IsZero() {
+		return nil
+	}
+
+	f := FormatTime(t)
+	return &f
+}
+
 // FormatTime returns an empty string when t has the zero value.
 func FormatTime(t time.Time) string {
 	var ret string

--- a/internal/db/convert_test.go
+++ b/internal/db/convert_test.go
@@ -44,3 +44,21 @@ func TestFormatOptionalTime(t *testing.T) {
 		assert.Equal(t, *got, "2024-03-06T11:57:17Z")
 	})
 }
+
+func TestFormatOptionalZeroTime(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Returns nil pointer for zero time", func(t *testing.T) {
+		t.Parallel()
+
+		got := db.FormatOptionalZeroTime(time.Time{})
+		assert.Assert(t, got == nil)
+	})
+
+	t.Run("Returns an RFC3339 time string", func(t *testing.T) {
+		t.Parallel()
+
+		got := db.FormatOptionalZeroTime(time.Date(2024, 3, 6, 11, 57, 17, 115, time.UTC))
+		assert.Equal(t, *got, "2024-03-06T11:57:17Z")
+	})
+}

--- a/internal/ingest/convert.go
+++ b/internal/ingest/convert.go
@@ -45,8 +45,8 @@ func sipIngestAuditEvent(s *datatypes.SIP) *auditlog.Event {
 // workflowToGoa returns the API representation of a workflow.
 func workflowToGoa(w *datatypes.Workflow) *goaingest.SIPWorkflow {
 	var startedAt string
-	if w.StartedAt.Valid {
-		startedAt = w.StartedAt.Time.Format(time.RFC3339)
+	if !w.StartedAt.IsZero() {
+		startedAt = w.StartedAt.Format(time.RFC3339)
 	}
 
 	res := &goaingest.SIPWorkflow{
@@ -55,7 +55,7 @@ func workflowToGoa(w *datatypes.Workflow) *goaingest.SIPWorkflow {
 		Type:        w.Type.String(),
 		Status:      w.Status.String(),
 		StartedAt:   startedAt,
-		CompletedAt: db.FormatOptionalTime(w.CompletedAt),
+		CompletedAt: db.FormatOptionalZeroTime(w.CompletedAt),
 		SipUUID:     w.SIPUUID,
 	}
 
@@ -71,6 +71,11 @@ func workflowToGoa(w *datatypes.Workflow) *goaingest.SIPWorkflow {
 
 // taskToGoa returns the API representation of a task.
 func taskToGoa(task *datatypes.Task) *goaingest.SIPTask {
+	var startedAt string
+	if !task.StartedAt.IsZero() {
+		startedAt = task.StartedAt.Format(time.RFC3339)
+	}
+
 	return &goaingest.SIPTask{
 		UUID:   task.UUID,
 		Name:   task.Name,
@@ -78,9 +83,9 @@ func taskToGoa(task *datatypes.Task) *goaingest.SIPTask {
 
 		// TODO: Make Goa StartedAt a pointer to a string to avoid having to
 		// convert a null time to an empty (zero value) string.
-		StartedAt: ref.DerefZero(db.FormatOptionalTime(task.StartedAt)),
+		StartedAt: startedAt,
 
-		CompletedAt:  db.FormatOptionalTime(task.CompletedAt),
+		CompletedAt:  db.FormatOptionalZeroTime(task.CompletedAt),
 		Note:         &task.Note,
 		WorkflowUUID: task.WorkflowUUID,
 	}

--- a/internal/ingest/goa_test.go
+++ b/internal/ingest/goa_test.go
@@ -2,7 +2,6 @@ package ingest_test
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"testing"
@@ -338,20 +337,14 @@ var (
 	sipUUID3 = uuid.New()
 	testSIPs = []*datatypes.SIP{
 		{
-			ID:        1,
-			UUID:      sipUUID1,
-			Name:      "Test SIP 1",
-			AIPID:     nullUUID("e2ace0da-8697-453d-9ea1-4c9b62309e54"),
-			Status:    enums.SIPStatusIngested,
-			CreatedAt: time.Date(2024, 9, 25, 9, 31, 10, 0, time.UTC),
-			StartedAt: sql.NullTime{
-				Time:  time.Date(2024, 9, 25, 9, 31, 11, 0, time.UTC),
-				Valid: true,
-			},
-			CompletedAt: sql.NullTime{
-				Time:  time.Date(2024, 9, 25, 9, 31, 12, 0, time.UTC),
-				Valid: true,
-			},
+			ID:          1,
+			UUID:        sipUUID1,
+			Name:        "Test SIP 1",
+			AIPID:       nullUUID("e2ace0da-8697-453d-9ea1-4c9b62309e54"),
+			Status:      enums.SIPStatusIngested,
+			CreatedAt:   time.Date(2024, 9, 25, 9, 31, 10, 0, time.UTC),
+			StartedAt:   time.Date(2024, 9, 25, 9, 31, 11, 0, time.UTC),
+			CompletedAt: time.Date(2024, 9, 25, 9, 31, 12, 0, time.UTC),
 			Uploader: &datatypes.User{
 				UUID:  uuid.MustParse("0b075937-458c-43d9-b46c-222a072d62a9"),
 				Email: "uploader@example.com",
@@ -359,37 +352,25 @@ var (
 			},
 		},
 		{
-			ID:        2,
-			UUID:      sipUUID2,
-			Name:      "Test SIP 2",
-			AIPID:     nullUUID("ffdb12f4-1735-4022-b746-a9bf4a32109b"),
-			Status:    enums.SIPStatusProcessing,
-			CreatedAt: time.Date(2024, 10, 1, 17, 13, 26, 0, time.UTC),
-			StartedAt: sql.NullTime{
-				Time:  time.Date(2024, 10, 1, 17, 13, 27, 0, time.UTC),
-				Valid: true,
-			},
-			CompletedAt: sql.NullTime{
-				Time:  time.Date(2024, 10, 1, 17, 13, 28, 0, time.UTC),
-				Valid: true,
-			},
+			ID:          2,
+			UUID:        sipUUID2,
+			Name:        "Test SIP 2",
+			AIPID:       nullUUID("ffdb12f4-1735-4022-b746-a9bf4a32109b"),
+			Status:      enums.SIPStatusProcessing,
+			CreatedAt:   time.Date(2024, 10, 1, 17, 13, 26, 0, time.UTC),
+			StartedAt:   time.Date(2024, 10, 1, 17, 13, 27, 0, time.UTC),
+			CompletedAt: time.Date(2024, 10, 1, 17, 13, 28, 0, time.UTC),
 		},
 		{
-			ID:        3,
-			UUID:      sipUUID3,
-			Name:      "Test SIP 3",
-			Status:    enums.SIPStatusError,
-			CreatedAt: time.Date(2024, 10, 1, 17, 13, 26, 0, time.UTC),
-			StartedAt: sql.NullTime{
-				Time:  time.Date(2024, 10, 1, 17, 13, 27, 0, time.UTC),
-				Valid: true,
-			},
-			CompletedAt: sql.NullTime{
-				Time:  time.Date(2024, 10, 1, 17, 13, 28, 0, time.UTC),
-				Valid: true,
-			},
-			FailedAs:  enums.SIPFailedAsSIP,
-			FailedKey: "failed-key",
+			ID:          3,
+			UUID:        sipUUID3,
+			Name:        "Test SIP 3",
+			Status:      enums.SIPStatusError,
+			CreatedAt:   time.Date(2024, 10, 1, 17, 13, 26, 0, time.UTC),
+			StartedAt:   time.Date(2024, 10, 1, 17, 13, 27, 0, time.UTC),
+			CompletedAt: time.Date(2024, 10, 1, 17, 13, 28, 0, time.UTC),
+			FailedAs:    enums.SIPFailedAsSIP,
+			FailedKey:   "failed-key",
 		},
 	}
 )

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -162,10 +162,7 @@ func (svc *ingestImpl) SetStatusInProgress(ctx context.Context, id uuid.UUID, st
 	sip, err := svc.perSvc.UpdateSIP(ctx, id, func(s *datatypes.SIP) (*datatypes.SIP, error) {
 		s.Status = enums.SIPStatusProcessing
 		if !startedAt.IsZero() {
-			s.StartedAt = sql.NullTime{
-				Time:  startedAt,
-				Valid: true,
-			}
+			s.StartedAt = startedAt
 		}
 		return s, nil
 	})

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -409,7 +409,7 @@ func TestSetStatusInProgress(t *testing.T) {
 					updated, err := upd(&datatypes.SIP{})
 					assert.NilError(t, err)
 					assert.Equal(t, updated.Status, enums.SIPStatusProcessing)
-					assert.DeepEqual(t, updated.StartedAt, sql.NullTime{Time: startedAt, Valid: true})
+					assert.DeepEqual(t, updated.StartedAt, startedAt)
 					return nil
 				},
 			),
@@ -417,7 +417,7 @@ func TestSetStatusInProgress(t *testing.T) {
 		Return(&datatypes.SIP{
 			UUID:      sipUUID,
 			Status:    enums.SIPStatusProcessing,
-			StartedAt: sql.NullTime{Time: startedAt, Valid: true},
+			StartedAt: startedAt,
 		}, nil)
 
 	assert.NilError(t, ingestsvc.SetStatusInProgress(t.Context(), sipUUID, startedAt))

--- a/internal/ingest/task.go
+++ b/internal/ingest/task.go
@@ -2,7 +2,6 @@ package ingest
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"time"
 
@@ -61,10 +60,7 @@ func (svc *ingestImpl) CompleteTask(
 		id,
 		func(task *datatypes.Task) (*datatypes.Task, error) {
 			task.Status = status
-			task.CompletedAt = sql.NullTime{
-				Time:  completedAt,
-				Valid: true,
-			}
+			task.CompletedAt = completedAt
 			if note != nil {
 				task.Note = *note
 			}

--- a/internal/ingest/task_test.go
+++ b/internal/ingest/task_test.go
@@ -2,7 +2,6 @@ package ingest_test
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"testing"
@@ -62,17 +61,11 @@ func TestCreateTask(t *testing.T) {
 		{
 			name: "Creates a task with optional values",
 			task: datatypes.Task{
-				UUID:   taskUUID,
-				Name:   "PT2",
-				Status: enums.TaskStatusInProgress,
-				StartedAt: sql.NullTime{
-					Time:  time.Date(2024, 3, 27, 11, 32, 41, 0, time.UTC),
-					Valid: true,
-				},
-				CompletedAt: sql.NullTime{
-					Time:  time.Date(2024, 3, 27, 11, 32, 43, 0, time.UTC),
-					Valid: true,
-				},
+				UUID:         taskUUID,
+				Name:         "PT2",
+				Status:       enums.TaskStatusInProgress,
+				StartedAt:    time.Date(2024, 3, 27, 11, 32, 41, 0, time.UTC),
+				CompletedAt:  time.Date(2024, 3, 27, 11, 32, 43, 0, time.UTC),
 				Note:         "PT2 Note",
 				WorkflowUUID: wUUID,
 			},
@@ -88,18 +81,12 @@ func TestCreateTask(t *testing.T) {
 				return svc
 			},
 			want: datatypes.Task{
-				ID:     2,
-				UUID:   taskUUID,
-				Name:   "PT2",
-				Status: enums.TaskStatusInProgress,
-				StartedAt: sql.NullTime{
-					Time:  time.Date(2024, 3, 27, 11, 32, 41, 0, time.UTC),
-					Valid: true,
-				},
-				CompletedAt: sql.NullTime{
-					Time:  time.Date(2024, 3, 27, 11, 32, 43, 0, time.UTC),
-					Valid: true,
-				},
+				ID:           2,
+				UUID:         taskUUID,
+				Name:         "PT2",
+				Status:       enums.TaskStatusInProgress,
+				StartedAt:    time.Date(2024, 3, 27, 11, 32, 41, 0, time.UTC),
+				CompletedAt:  time.Date(2024, 3, 27, 11, 32, 43, 0, time.UTC),
 				Note:         "PT2 Note",
 				WorkflowUUID: wUUID,
 			},
@@ -269,13 +256,10 @@ func TestCompleteTask(t *testing.T) {
 				return svc
 			},
 			want: datatypes.Task{
-				ID:     1,
-				Status: enums.TaskStatusDone,
-				CompletedAt: sql.NullTime{
-					Time:  completedAt,
-					Valid: true,
-				},
-				Note: "Reviewed and accepted",
+				ID:          1,
+				Status:      enums.TaskStatusDone,
+				CompletedAt: completedAt,
+				Note:        "Reviewed and accepted",
 			},
 		},
 		{
@@ -314,12 +298,9 @@ func TestCompleteTask(t *testing.T) {
 				return svc
 			},
 			want: datatypes.Task{
-				ID:     1,
-				Status: enums.TaskStatusDone,
-				CompletedAt: sql.NullTime{
-					Time:  completedAt,
-					Valid: true,
-				},
+				ID:          1,
+				Status:      enums.TaskStatusDone,
+				CompletedAt: completedAt,
 			},
 		},
 		{

--- a/internal/ingest/workflow.go
+++ b/internal/ingest/workflow.go
@@ -2,7 +2,6 @@ package ingest
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"time"
 
@@ -59,10 +58,7 @@ func (svc *ingestImpl) CompleteWorkflow(
 ) error {
 	w, err := svc.perSvc.UpdateWorkflow(ctx, ID, func(w *datatypes.Workflow) (*datatypes.Workflow, error) {
 		w.Status = status
-		w.CompletedAt = sql.NullTime{
-			Time:  completedAt,
-			Valid: !completedAt.IsZero(),
-		}
+		w.CompletedAt = completedAt
 		return w, nil
 	})
 	if err != nil {

--- a/internal/ingest/workflow_test.go
+++ b/internal/ingest/workflow_test.go
@@ -2,7 +2,6 @@ package ingest_test
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -22,14 +21,8 @@ func TestCreateWorkflow(t *testing.T) {
 
 	sipUUID := uuid.New()
 	temporalID := "processing-workflow-720db1d4-825c-4911-9a20-61c212cf23ff"
-	startedAt := sql.NullTime{
-		Time:  time.Date(2024, 6, 3, 8, 51, 35, 0, time.UTC),
-		Valid: true,
-	}
-	completedAt := sql.NullTime{
-		Time:  time.Date(2024, 6, 3, 8, 52, 18, 0, time.UTC),
-		Valid: true,
-	}
+	startedAt := time.Date(2024, 6, 3, 8, 51, 35, 0, time.UTC)
+	completedAt := time.Date(2024, 6, 3, 8, 52, 18, 0, time.UTC)
 
 	type test struct {
 		name    string
@@ -51,11 +44,8 @@ func TestCreateWorkflow(t *testing.T) {
 				TemporalID: temporalID,
 				Type:       enums.WorkflowTypeCreateAip,
 				Status:     enums.WorkflowStatusUnspecified,
-				StartedAt: sql.NullTime{
-					Time:  time.Date(2024, 6, 3, 9, 4, 23, 0, time.UTC),
-					Valid: true,
-				},
-				SIPUUID: sipUUID,
+				StartedAt:  time.Date(2024, 6, 3, 9, 4, 23, 0, time.UTC),
+				SIPUUID:    sipUUID,
 			},
 			mock: func(svc *persistence_fake.MockService, w datatypes.Workflow) *persistence_fake.MockService {
 				svc.EXPECT().
@@ -63,10 +53,7 @@ func TestCreateWorkflow(t *testing.T) {
 					DoAndReturn(
 						func(ctx context.Context, w *datatypes.Workflow) error {
 							w.ID = 11
-							w.StartedAt = sql.NullTime{
-								Time:  time.Date(2024, 6, 3, 9, 4, 23, 0, time.UTC),
-								Valid: true,
-							}
+							w.StartedAt = time.Date(2024, 6, 3, 9, 4, 23, 0, time.UTC)
 							return nil
 						},
 					)
@@ -277,7 +264,7 @@ func TestCompleteWorkflow(t *testing.T) {
 									return err
 								}
 								assert.Equal(t, updated.Status, enums.WorkflowStatusDone)
-								assert.DeepEqual(t, updated.CompletedAt, sql.NullTime{Time: completedAt, Valid: true})
+								assert.DeepEqual(t, updated.CompletedAt, completedAt)
 								return nil
 							},
 						),
@@ -314,7 +301,7 @@ func TestCompleteWorkflow(t *testing.T) {
 									return err
 								}
 								assert.Equal(t, updated.Status, enums.WorkflowStatusError)
-								assert.DeepEqual(t, updated.CompletedAt, sql.NullTime{Time: completedAt, Valid: true})
+								assert.DeepEqual(t, updated.CompletedAt, completedAt)
 								return nil
 							},
 						),

--- a/internal/persistence/ent/client/convert.go
+++ b/internal/persistence/ent/client/convert.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"database/sql"
 	"time"
 
 	"github.com/google/uuid"
@@ -21,8 +20,8 @@ func convertSIP(sip *db.SIP) *datatypes.SIP {
 		Name:        sip.Name,
 		Status:      sip.Status,
 		CreatedAt:   sip.CreatedAt,
-		StartedAt:   nullTime(sip.StartedAt),
-		CompletedAt: nullTime(sip.CompletedAt),
+		StartedAt:   normalizeTime(sip.StartedAt),
+		CompletedAt: normalizeTime(sip.CompletedAt),
 		FailedAs:    sip.FailedAs,
 		FailedKey:   sip.FailedKey,
 	}
@@ -59,8 +58,8 @@ func convertTask(task *db.Task) *datatypes.Task {
 		UUID:         task.UUID,
 		Name:         task.Name,
 		Status:       enums.TaskStatus(status),
-		StartedAt:    nullTime(task.StartedAt),
-		CompletedAt:  nullTime(task.CompletedAt),
+		StartedAt:    normalizeTime(task.StartedAt),
+		CompletedAt:  normalizeTime(task.CompletedAt),
 		Note:         task.Note,
 		WorkflowUUID: wUUID,
 	}
@@ -111,8 +110,8 @@ func convertWorkflow(dbw *db.Workflow) *datatypes.Workflow {
 		TemporalID:  dbw.TemporalID,
 		Type:        dbw.Type,
 		Status:      enums.WorkflowStatus(uint(dbw.Status)), // #nosec G115 -- constrained value.
-		StartedAt:   nullTime(dbw.StartedAt),
-		CompletedAt: nullTime(dbw.CompletedAt),
+		StartedAt:   normalizeTime(dbw.StartedAt),
+		CompletedAt: normalizeTime(dbw.CompletedAt),
 	}
 
 	if dbw.Edges.Sip != nil {
@@ -134,9 +133,9 @@ func convertWorkflow(dbw *db.Workflow) *datatypes.Workflow {
 	return w
 }
 
-func nullTime(t time.Time) sql.NullTime {
+func normalizeTime(t time.Time) time.Time {
 	if t.IsZero() {
-		return sql.NullTime{}
+		return time.Time{}
 	}
-	return sql.NullTime{Time: t.UTC(), Valid: true}
+	return t
 }

--- a/internal/persistence/ent/client/sip.go
+++ b/internal/persistence/ent/client/sip.go
@@ -46,11 +46,11 @@ func (c *client) CreateSIP(ctx context.Context, s *datatypes.SIP) error {
 	if s.AIPID.Valid {
 		q.SetAipID(s.AIPID.UUID)
 	}
-	if s.StartedAt.Valid {
-		q.SetStartedAt(s.StartedAt.Time)
+	if !s.StartedAt.IsZero() {
+		q.SetStartedAt(s.StartedAt)
 	}
-	if s.CompletedAt.Valid {
-		q.SetCompletedAt(s.CompletedAt.Time)
+	if !s.CompletedAt.IsZero() {
+		q.SetCompletedAt(s.CompletedAt)
 	}
 
 	// If Uploader is set, find or create the user and link it to the SIP.
@@ -149,11 +149,11 @@ func (c *client) UpdateSIP(
 	if up.AIPID.Valid {
 		q.SetAipID(up.AIPID.UUID)
 	}
-	if up.StartedAt.Valid {
-		q.SetStartedAt(up.StartedAt.Time)
+	if !up.StartedAt.IsZero() {
+		q.SetStartedAt(up.StartedAt)
 	}
-	if up.CompletedAt.Valid {
-		q.SetCompletedAt(up.CompletedAt.Time)
+	if !up.CompletedAt.IsZero() {
+		q.SetCompletedAt(up.CompletedAt)
 	}
 	if up.FailedAs.IsValid() {
 		q.SetFailedAs(up.FailedAs)

--- a/internal/persistence/ent/client/sip_test.go
+++ b/internal/persistence/ent/client/sip_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -25,8 +24,8 @@ func TestCreateSIP(t *testing.T) {
 
 	sipUUID := uuid.New()
 	aipID := uuid.NullUUID{UUID: uuid.New(), Valid: true}
-	started := sql.NullTime{Time: time.Now(), Valid: true}
-	completed := sql.NullTime{Time: started.Time.Add(time.Second), Valid: true}
+	started := time.Now()
+	completed := started.Add(time.Second)
 	uploaderID := uuid.New()
 	uploaderID2 := uuid.New()
 	batchUUID := uuid.New()
@@ -223,17 +222,11 @@ func TestUpdateSIP(t *testing.T) {
 	uploaderID := uuid.New()
 	batchUUID := uuid.New()
 
-	started := sql.NullTime{Time: time.Now(), Valid: true}
-	started2 := sql.NullTime{
-		Time: func() time.Time {
-			t, _ := time.Parse(time.RFC3339, "1980-01-01T09:30:00Z")
-			return t
-		}(),
-		Valid: true,
-	}
+	started := time.Now()
+	started2 := time.Date(1980, 1, 1, 9, 30, 0, 0, time.UTC)
 
-	completed := sql.NullTime{Time: started.Time.Add(time.Second), Valid: true}
-	completed2 := sql.NullTime{Time: started2.Time.Add(time.Second), Valid: true}
+	completed := started.Add(time.Second)
+	completed2 := started2.Add(time.Second)
 
 	type params struct {
 		sipUUID uuid.UUID
@@ -279,7 +272,7 @@ func TestUpdateSIP(t *testing.T) {
 					s.Name = "Updated SIP"
 					s.AIPID = aipID2
 					s.Status = enums.SIPStatusIngested
-					s.CreatedAt = started2.Time // No-op, can't update CreatedAt.
+					s.CreatedAt = started2 // No-op, can't update CreatedAt.
 					s.StartedAt = started2
 					s.CompletedAt = completed2
 					s.FailedAs = enums.SIPFailedAsSIP
@@ -511,8 +504,8 @@ func TestReadSIP(t *testing.T) {
 				Status:      enums.SIPStatusError,
 				AIPID:       uuid.NullUUID{UUID: uuid.New(), Valid: true},
 				CreatedAt:   time.Now(),
-				StartedAt:   sql.NullTime{Time: time.Now().Add(time.Second), Valid: true},
-				CompletedAt: sql.NullTime{Time: time.Now().Add(time.Minute), Valid: true},
+				StartedAt:   time.Now().Add(time.Second),
+				CompletedAt: time.Now().Add(time.Minute),
 				FailedAs:    enums.SIPFailedAsPIP,
 				FailedKey:   "failed-key",
 				Uploader: &datatypes.User{
@@ -560,8 +553,8 @@ func TestReadSIP(t *testing.T) {
 					SetStatus(tt.want.Status).
 					SetAipID(tt.want.AIPID.UUID).
 					SetCreatedAt(tt.want.CreatedAt).
-					SetStartedAt(tt.want.StartedAt.Time).
-					SetCompletedAt(tt.want.CompletedAt.Time).
+					SetStartedAt(tt.want.StartedAt).
+					SetCompletedAt(tt.want.CompletedAt).
 					SetFailedAs(tt.want.FailedAs).
 					SetFailedKey(tt.want.FailedKey).
 					SetUploader(user).
@@ -600,23 +593,11 @@ func TestListSIPs(t *testing.T) {
 	batchID := uuid.New()
 	batchID2 := uuid.New()
 
-	started := sql.NullTime{
-		Time: func() time.Time {
-			t, _ := time.Parse(time.RFC3339, "2024-09-25T09:31:11Z")
-			return t
-		}(),
-		Valid: true,
-	}
-	started2 := sql.NullTime{
-		Time: func() time.Time {
-			t, _ := time.Parse(time.RFC3339, "2024-09-25T10:03:42Z")
-			return t
-		}(),
-		Valid: true,
-	}
+	started := time.Date(2024, 9, 25, 9, 31, 11, 0, time.UTC)
+	started2 := time.Date(2024, 9, 25, 10, 3, 42, 0, time.UTC)
 
-	completed := sql.NullTime{Time: started.Time.Add(time.Second), Valid: true}
-	completed2 := sql.NullTime{Time: started2.Time.Add(time.Second), Valid: true}
+	completed := started.Add(time.Second)
+	completed2 := started2.Add(time.Second)
 
 	type results struct {
 		data []*datatypes.SIP
@@ -1188,8 +1169,8 @@ func TestListSIPs(t *testing.T) {
 						SetName(sip.Name).
 						SetStatus(sip.Status).
 						SetCreatedAt(time.Now()).
-						SetStartedAt(sip.StartedAt.Time).
-						SetCompletedAt(sip.CompletedAt.Time)
+						SetStartedAt(sip.StartedAt).
+						SetCompletedAt(sip.CompletedAt)
 
 					if sip.AIPID.Valid {
 						q.SetAipID(sip.AIPID.UUID)

--- a/internal/persistence/ent/client/task.go
+++ b/internal/persistence/ent/client/task.go
@@ -57,13 +57,13 @@ func (c *client) CreateTasks(ctx context.Context, tasks []*datatypes.Task) error
 			}
 
 			var startedAt *time.Time
-			if task.StartedAt.Valid {
-				startedAt = &task.StartedAt.Time
+			if !task.StartedAt.IsZero() {
+				startedAt = &task.StartedAt
 			}
 
 			var completedAt *time.Time
-			if task.CompletedAt.Valid {
-				completedAt = &task.CompletedAt.Time
+			if !task.CompletedAt.IsZero() {
+				completedAt = &task.CompletedAt
 			}
 
 			wID, ok := workflowIDs[task.WorkflowUUID]
@@ -153,11 +153,11 @@ func (c *client) UpdateTask(
 		SetNote(up.Note)
 
 	// Set nullable column values.
-	if up.StartedAt.Valid {
-		q.SetStartedAt(up.StartedAt.Time)
+	if !up.StartedAt.IsZero() {
+		q.SetStartedAt(up.StartedAt)
 	}
-	if up.CompletedAt.Valid {
-		q.SetCompletedAt(up.CompletedAt.Time)
+	if !up.CompletedAt.IsZero() {
+		q.SetCompletedAt(up.CompletedAt)
 	}
 
 	task, err = q.Save(ctx)

--- a/internal/persistence/ent/client/task_test.go
+++ b/internal/persistence/ent/client/task_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -37,8 +36,8 @@ func TestCreateTask(t *testing.T) {
 	t.Parallel()
 
 	taskUUID := uuid.New()
-	started := sql.NullTime{Time: time.Now(), Valid: true}
-	completed := sql.NullTime{Time: started.Time.Add(time.Second), Valid: true}
+	started := time.Now()
+	completed := started.Add(time.Second)
 
 	tests := []struct {
 		name    string
@@ -133,8 +132,8 @@ func TestCreateTask(t *testing.T) {
 func TestCreateTasks(t *testing.T) {
 	t.Parallel()
 
-	started := sql.NullTime{Time: time.Now(), Valid: true}
-	completed := sql.NullTime{Time: started.Time.Add(time.Second), Valid: true}
+	started := time.Now()
+	completed := started.Add(time.Second)
 
 	tests := []struct {
 		name    string
@@ -280,17 +279,11 @@ func TestUpdateTask(t *testing.T) {
 	taskID := uuid.MustParse("c5f7c35a-d5a6-4e00-b4da-b036ce5b40bc")
 	taskID2 := uuid.MustParse("c04d0191-d7ce-46dd-beff-92d6830082ff")
 
-	started := sql.NullTime{
-		Time:  time.Date(2024, 3, 31, 10, 11, 12, 0, time.UTC),
-		Valid: true,
-	}
-	started2 := sql.NullTime{
-		Time:  time.Date(2024, 4, 1, 17, 5, 49, 0, time.UTC),
-		Valid: true,
-	}
+	started := time.Date(2024, 3, 31, 10, 11, 12, 0, time.UTC)
+	started2 := time.Date(2024, 4, 1, 17, 5, 49, 0, time.UTC)
 
-	completed := sql.NullTime{Time: started.Time.Add(time.Second), Valid: true}
-	completed2 := sql.NullTime{Time: started2.Time.Add(time.Second), Valid: true}
+	completed := started.Add(time.Second)
+	completed2 := started2.Add(time.Second)
 
 	type params struct {
 		task    *datatypes.Task

--- a/internal/persistence/ent/client/workflow.go
+++ b/internal/persistence/ent/client/workflow.go
@@ -31,12 +31,12 @@ func (c *client) CreateWorkflow(ctx context.Context, w *datatypes.Workflow) erro
 
 	// Handle nullable fields.
 	var startedAt *time.Time
-	if w.StartedAt.Valid {
-		startedAt = &w.StartedAt.Time
+	if !w.StartedAt.IsZero() {
+		startedAt = &w.StartedAt
 	}
 	var completedAt *time.Time
-	if w.CompletedAt.Valid {
-		completedAt = &w.CompletedAt.Time
+	if !w.CompletedAt.IsZero() {
+		completedAt = &w.CompletedAt
 	}
 
 	tx, err := c.ent.BeginTx(ctx, nil)
@@ -104,13 +104,13 @@ func (c *client) UpdateWorkflow(
 	if up.Status.IsValid() {
 		q.SetStatus(int8(up.Status)) // #nosec G115 -- constrained value.
 	}
-	if up.StartedAt.Valid {
-		q.SetStartedAt(up.StartedAt.Time.UTC())
+	if !up.StartedAt.IsZero() {
+		q.SetStartedAt(up.StartedAt)
 	} else {
 		q.ClearStartedAt()
 	}
-	if up.CompletedAt.Valid {
-		q.SetCompletedAt(up.CompletedAt.Time.UTC())
+	if !up.CompletedAt.IsZero() {
+		q.SetCompletedAt(up.CompletedAt)
 	} else {
 		q.ClearCompletedAt()
 	}

--- a/internal/persistence/ent/client/workflow_test.go
+++ b/internal/persistence/ent/client/workflow_test.go
@@ -1,7 +1,6 @@
 package client_test
 
 import (
-	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -21,8 +20,8 @@ func TestCreateWorkflow(t *testing.T) {
 
 	workflowUUID := uuid.New()
 	temporalID := "processing-workflow-720db1d4-825c-4911-9a20-61c212cf23ff"
-	started := sql.NullTime{Time: time.Now(), Valid: true}
-	completed := sql.NullTime{Time: started.Time.Add(time.Second), Valid: true}
+	started := time.Now()
+	completed := started.Add(time.Second)
 
 	tests := []struct {
 		name    string
@@ -124,8 +123,8 @@ func TestUpdateWorkflow(t *testing.T) {
 	t.Parallel()
 
 	workflowUUID := uuid.New()
-	started := sql.NullTime{Time: time.Now(), Valid: true}
-	completed := sql.NullTime{Time: started.Time.Add(time.Second), Valid: true}
+	started := time.Now()
+	completed := started.Add(time.Second)
 
 	type params struct {
 		workflow *datatypes.Workflow
@@ -206,7 +205,7 @@ func TestUpdateWorkflow(t *testing.T) {
 					SetTemporalID(tt.args.workflow.TemporalID).
 					SetType(tt.args.workflow.Type).
 					SetStatus(int8(tt.args.workflow.Status)). // #nosec G115 -- constrained value.
-					SetStartedAt(tt.args.workflow.StartedAt.Time).
+					SetStartedAt(tt.args.workflow.StartedAt).
 					SetSipID(sip.ID).
 					Save(ctx)
 				assert.NilError(t, err)
@@ -229,7 +228,7 @@ func TestReadWorkflow(t *testing.T) {
 	t.Parallel()
 
 	workflowUUID := uuid.New()
-	started := sql.NullTime{Time: time.Now(), Valid: true}
+	started := time.Now()
 
 	for _, tt := range []struct {
 		name    string
@@ -267,7 +266,7 @@ func TestReadWorkflow(t *testing.T) {
 					SetTemporalID(tt.want.TemporalID).
 					SetType(tt.want.Type).
 					SetStatus(int8(tt.want.Status)). // #nosec G115 -- constrained value.
-					SetStartedAt(tt.want.StartedAt.Time).
+					SetStartedAt(tt.want.StartedAt).
 					SetSipID(sip.ID).
 					Save(ctx)
 				assert.NilError(t, err)
@@ -291,8 +290,8 @@ func TestListWorkflowsBySIP(t *testing.T) {
 
 	workflowUUID1 := uuid.New()
 	workflowUUID2 := uuid.New()
-	started := sql.NullTime{Time: time.Date(2024, 9, 25, 9, 31, 11, 0, time.UTC), Valid: true}
-	started2 := sql.NullTime{Time: time.Date(2024, 9, 25, 10, 3, 42, 0, time.UTC), Valid: true}
+	started := time.Date(2024, 9, 25, 9, 31, 11, 0, time.UTC)
+	started2 := time.Date(2024, 9, 25, 10, 3, 42, 0, time.UTC)
 
 	for _, tt := range []struct {
 		name      string
@@ -359,7 +358,7 @@ func TestListWorkflowsBySIP(t *testing.T) {
 					SetTemporalID(wf.TemporalID).
 					SetType(wf.Type).
 					SetStatus(int8(wf.Status)). // #nosec G115 -- constrained value.
-					SetStartedAt(wf.StartedAt.Time).
+					SetStartedAt(wf.StartedAt).
 					SetSipID(sip.ID).
 					Save(ctx)
 				assert.NilError(t, err)

--- a/internal/workflow/local_activities.go
+++ b/internal/workflow/local_activities.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"io"
 	"time"
@@ -73,7 +72,7 @@ func updateSIPLocalActivity(
 			}
 
 			if !params.CompletedAt.IsZero() {
-				s.CompletedAt = sql.NullTime{Valid: true, Time: params.CompletedAt}
+				s.CompletedAt = params.CompletedAt
 			}
 
 			return s, nil
@@ -142,10 +141,10 @@ func createWorkflowLocalActivity(
 		SIPUUID:    params.SIPUUID,
 	}
 	if !params.StartedAt.IsZero() {
-		w.StartedAt = sql.NullTime{Time: params.StartedAt, Valid: true}
+		w.StartedAt = params.StartedAt
 	}
 	if !params.CompletedAt.IsZero() {
-		w.CompletedAt = sql.NullTime{Time: params.CompletedAt, Valid: true}
+		w.CompletedAt = params.CompletedAt
 	}
 
 	if err := ingestsvc.CreateWorkflow(ctx, &w); err != nil {
@@ -205,10 +204,7 @@ func createTaskLocalActivity(
 	}
 	task.UUID = uid
 
-	task.StartedAt = sql.NullTime{
-		Time:  time.Now().UTC(),
-		Valid: true,
-	}
+	task.StartedAt = time.Now()
 
 	if err := params.Ingestsvc.CreateTask(ctx, params.Task); err != nil {
 		return 0, err

--- a/internal/workflow/local_activities_test.go
+++ b/internal/workflow/local_activities_test.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -54,8 +53,8 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 					TemporalID:  "workflow-id",
 					Type:        enums.WorkflowTypeCreateAip,
 					Status:      enums.WorkflowStatusDone,
-					StartedAt:   sql.NullTime{Time: startedAt, Valid: true},
-					CompletedAt: sql.NullTime{Time: completedAt, Valid: true},
+					StartedAt:   startedAt,
+					CompletedAt: completedAt,
 					SIPUUID:     sipUUID,
 				}).DoAndReturn(func(ctx context.Context, w *datatypes.Workflow) error {
 					w.ID = 1
@@ -136,6 +135,72 @@ func TestCreateWorkflowLocalActivity(t *testing.T) {
 	}
 }
 
+func TestCreateTaskLocalActivity(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		name      string
+		mockCalls func(context.Context, *ingest_fake.MockService, *datatypes.Task, time.Time)
+		wantID    int
+		wantErr   string
+	}
+	for _, tt := range []test{
+		{
+			name: "Creates a task",
+			mockCalls: func(ctx context.Context, svc *ingest_fake.MockService, task *datatypes.Task, before time.Time) {
+				svc.EXPECT().
+					CreateTask(ctx, task).
+					DoAndReturn(func(context.Context, *datatypes.Task) error {
+						assert.Assert(t, task.UUID != uuid.Nil)
+						assert.Assert(t, !task.StartedAt.IsZero())
+						assert.Assert(t, !task.StartedAt.Before(before))
+						task.ID = 7
+						return nil
+					})
+			},
+			wantID: 7,
+		},
+		{
+			name: "Fails if there is a persistence error",
+			mockCalls: func(ctx context.Context, svc *ingest_fake.MockService, task *datatypes.Task, before time.Time) {
+				svc.EXPECT().
+					CreateTask(ctx, task).
+					DoAndReturn(func(context.Context, *datatypes.Task) error {
+						assert.Assert(t, task.UUID != uuid.Nil)
+						assert.Assert(t, !task.StartedAt.IsZero())
+						assert.Assert(t, !task.StartedAt.Before(before))
+						return errors.New("persistence error")
+					})
+			},
+			wantErr: "persistence error",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			before := time.Now()
+			svc := ingest_fake.NewMockService(gomock.NewController(t))
+			task := &datatypes.Task{Name: "bundle"}
+			if tt.mockCalls != nil {
+				tt.mockCalls(ctx, svc, task, before)
+			}
+
+			got, err := createTaskLocalActivity(ctx, &createTaskLocalActivityParams{
+				Ingestsvc: svc,
+				RNG:       rand.New(rand.NewSource(1)), // #nosec: G404
+				Task:      task,
+			})
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.wantID)
+		})
+	}
+}
+
 func TestUpdateSIPLocalActivity(t *testing.T) {
 	t.Parallel()
 
@@ -174,7 +239,7 @@ func TestUpdateSIPLocalActivity(t *testing.T) {
 								assert.NilError(t, err)
 								assert.DeepEqual(t, s.Name, name)
 								assert.DeepEqual(t, s.Status, enums.SIPStatusIngested)
-								assert.DeepEqual(t, s.CompletedAt, sql.NullTime{Valid: true, Time: completedAt})
+								assert.DeepEqual(t, s.CompletedAt, completedAt)
 								assert.DeepEqual(t, s.AIPID, uuid.NullUUID{Valid: true, UUID: aipUUID})
 								assert.DeepEqual(t, s.FailedAs, enums.SIPFailedAsSIP)
 								assert.DeepEqual(t, s.FailedKey, failedKey)

--- a/internal/workflow/localact/save_preprocessing_tasks.go
+++ b/internal/workflow/localact/save_preprocessing_tasks.go
@@ -2,10 +2,8 @@ package localact
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/google/uuid"
 
@@ -74,16 +72,8 @@ func preprocTaskToTask(t childwf.Task) datatypes.Task {
 	return datatypes.Task{
 		Name:        t.Name,
 		Status:      status,
-		StartedAt:   timeToNullTime(t.StartedAt),
-		CompletedAt: timeToNullTime(t.CompletedAt),
+		StartedAt:   t.StartedAt,
+		CompletedAt: t.CompletedAt,
 		Note:        t.Message,
 	}
-}
-
-func timeToNullTime(t time.Time) sql.NullTime {
-	var r sql.NullTime
-	if !t.IsZero() {
-		r = sql.NullTime{Time: t, Valid: true}
-	}
-	return r
 }

--- a/internal/workflow/localact/save_preprocessing_tasks_test.go
+++ b/internal/workflow/localact/save_preprocessing_tasks_test.go
@@ -1,7 +1,6 @@
 package localact_test
 
 import (
-	"database/sql"
 	"errors"
 	"math/rand"
 	"testing"
@@ -58,8 +57,8 @@ func TestSavePreprocessingTasksActivity(t *testing.T) {
 							UUID:         taskUUID,
 							Name:         "Validate SIP structure",
 							Status:       enums.TaskStatusDone,
-							StartedAt:    sql.NullTime{Time: startedAt, Valid: true},
-							CompletedAt:  sql.NullTime{Time: completedAt, Valid: true},
+							StartedAt:    startedAt,
+							CompletedAt:  completedAt,
 							Note:         "SIP structure matches validation criteria",
 							WorkflowUUID: wUUID,
 						},
@@ -90,8 +89,8 @@ func TestSavePreprocessingTasksActivity(t *testing.T) {
 						{
 							UUID:         taskUUID,
 							Status:       enums.TaskStatusDone,
-							StartedAt:    sql.NullTime{Time: startedAt, Valid: true},
-							CompletedAt:  sql.NullTime{Time: completedAt, Valid: true},
+							StartedAt:    startedAt,
+							CompletedAt:  completedAt,
 							Note:         "SIP structure matches validation criteria",
 							WorkflowUUID: wUUID,
 						},


### PR DESCRIPTION
`sql.NullTime` was leaking a persistence concern into the ingest domain model. `datatypes.SIP`, `datatypes.Workflow`, and `datatypes.Task` were using a SQL-specific nullable wrapper to represent optional timestamps, even though those types are not database rows and should not need to know how SQL encodes `NULL`.

This change moves null handling back to the edges:

- Domain types now use plain `time.Time`
- The zero value of `time.Time` represents "timestamp not set"
- Persistence adapters translate zero time <-> SQL `NULL`
- Goa/API conversion translates zero time into omitted optional fields

The important distinction is that "unset" is still preserved, but it is now represented in the domain with Go's own zero value instead of a database wrapper type.

#### Why zero `time.Time` instead of `*time.Time`?

The domain only needs a simple "set or not set" representation and `time.Time{}` already provides that without adding pointer semantics.

#### Why keep nullable handling in the adapters?

Because NULL is a database/API representation detail, not a domain concept. The domain can use zero `time.Time` to mean "unset", and the adapters are the right place to translate that to and from SQL NULL or omitted wire fields.