### PR TITLE
Bump ambox from 1.0.9 to 1.0.12

### DIFF
--- a/hack/kube/overlays/dev-am/ambox.yaml
+++ b/hack/kube/overlays/dev-am/ambox.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: ambox
-          image: docker.io/artefactual/ambox:1.0.9
+          image: docker.io/artefactual/ambox:1.0.12
           ports:
             - name: am-dashboard
               containerPort: 64080


### PR DESCRIPTION
I know your target is v1.18.0, and ambox doesn't provide that yet since it currently follows qa/1.x. However, since you're limited to the QA branch anyway, you might want to try the latest available version. It includes [some cool changes](https://github.com/sevein/ambox/releases) that recently landed upstream in the Archivematica project.