### PR TITLE
Fetch tags separately in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      with:
-        fetch-tags: true
+    - name: Fetch tags
+      run: git fetch --tags origin
     - name: Install Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:


### PR DESCRIPTION
Fetching them as before caused:

```
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules --depth=1 origin +4650d6bcf3c60b34a383f38b6a6d1274d9618f22:refs/tags/v0.25.0
  Error: fatal: Cannot fetch both 4650d6bcf3c60b34a383f38b6a6d1274d9618f22 and refs/tags/v0.25.0 to refs/tags/v0.25.0
  The process '/usr/bin/git' failed with exit code 128
  Waiting 14 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules --depth=1 origin +4650d6bcf3c60b34a383f38b6a6d1274d9618f22:refs/tags/v0.25.0
  Error: fatal: Cannot fetch both 4650d6bcf3c60b34a383f38b6a6d1274d9618f22 and refs/tags/v0.25.0 to refs/tags/v0.25.0
  The process '/usr/bin/git' failed with exit code 128
  Waiting 13 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules --depth=1 origin +4650d6bcf3c60b34a383f38b6a6d1274d9618f22:refs/tags/v0.25.0
  Error: fatal: Cannot fetch both 4650d6bcf3c60b34a383f38b6a6d1274d9618f22 and refs/tags/v0.25.0 to refs/tags/v0.25.0
  Error: The process '/usr/bin/git' failed with exit code 128
```


https://github.com/artefactual-sdps/enduro/actions/runs/22970909409/job/66687353992