### PR TITLE
Fetch release tags with explicit forced refspec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Fetch tags
-      run: git fetch --tags origin
+      run: git fetch --force origin refs/tags/*:refs/tags/*
     - name: Install Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:


### PR DESCRIPTION
Sorry for the noise. #1547 was not enough:

```
Run git fetch --tags origin
From https://github.com/artefactual-sdps/enduro
 * [new branch]        dependabot/github_actions/all-actions-f99467c83d -> origin/dependabot/github_actions/all-actions-f99467c83d
 * [new branch]        dev/add-iac-kubernetes-scan -> origin/dev/add-iac-kubernetes-scan
 * [new branch]        dev/add-user-manual   -> origin/dev/add-user-manual
 * [new branch]        dev/bucket-upload-filter -> origin/dev/bucket-upload-filter
 * [new branch]        dev/bucket-upload-filter-v2 -> origin/dev/bucket-upload-filter-v2
 * [new branch]        dev/ci-tweaks         -> origin/dev/ci-tweaks
 * [new branch]        dev/fix-dependencytrack-url -> origin/dev/fix-dependencytrack-url
 * [new branch]        dev/issue-1100-grafana-loki -> origin/dev/issue-1100-grafana-loki
 * [new branch]        dev/issue-1174-list-aip-workflows -> origin/dev/issue-1174-list-aip-workflows
 * [new branch]        dev/issue-1396-dashboard-customization -> origin/dev/issue-1396-dashboard-customization
 * [new branch]        dev/issue-1405-concurrent-a3m-sessions -> origin/dev/issue-1405-concurrent-a3m-sessions
 * [new branch]        dev/issue-886-preprocessing-id -> origin/dev/issue-886-preprocessing-id
 * [new branch]        dev/minio-dir-uploads -> origin/dev/minio-dir-uploads
 * [new branch]        dev/minio-sfa-roles   -> origin/dev/minio-sfa-roles
 * [new branch]        dev/save-multiple-preservation-tasks -> origin/dev/save-multiple-preservation-tasks
 * [new branch]        dev/save-multiple-preservation-tasks-take-two -> origin/dev/save-multiple-preservation-tasks-take-two
 * [new branch]        dev/use-dependencytrack-upload-action -> origin/dev/use-dependencytrack-upload-action
 * [new branch]        env/sfa-dev           -> origin/env/sfa-dev
 * [new branch]        main                  -> origin/main
 * [new tag]           v0.1.0                -> v0.1.0
 * [new tag]           v0.10.0               -> v0.10.0
 * [new tag]           v0.11.0               -> v0.11.0
 * [new tag]           v0.12.0               -> v0.12.0
 * [new tag]           v0.13.0               -> v0.13.0
 * [new tag]           v0.14.0               -> v0.14.0
 * [new tag]           v0.15.0               -> v0.15.0
 * [new tag]           v0.16.0               -> v0.16.0
 * [new tag]           v0.17.0               -> v0.17.0
 * [new tag]           v0.18.0               -> v0.18.0
 * [new tag]           v0.19.0               -> v0.19.0
 * [new tag]           v0.2.0                -> v0.2.0
 * [new tag]           v0.20.0               -> v0.20.0
 * [new tag]           v0.21.0               -> v0.21.0
 * [new tag]           v0.22.0               -> v0.22.0
 * [new tag]           v0.23.0               -> v0.23.0
 * [new tag]           v0.24.0               -> v0.24.0
 ! [rejected]          v0.25.0               -> v0.25.0  (would clobber existing tag)
 * [new tag]           v0.3.0                -> v0.3.0
 * [new tag]           v0.4.0                -> v0.4.0
 * [new tag]           v0.5.0                -> v0.5.0
 * [new tag]           v0.6.0                -> v0.6.0
 * [new tag]           v0.7.0                -> v0.7.0
 * [new tag]           v0.8.0                -> v0.8.0
 * [new tag]           v0.9.0                -> v0.9.0
Error: Process completed with exit code 1.
```

This should avoid fetching branches and force tag fetching. Ref: https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt-refspec