### PR TITLE
Fix GitHub release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - name: Fetch tags
-      run: git fetch --force origin refs/tags/*:refs/tags/*
+      with:
+        fetch-depth: 0
     - name: Install Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
@@ -21,11 +21,11 @@ jobs:
       with:
         node-version: 22
     - name: Generate release notes
-      run: ./hack/generate_release_notes.sh
+      run: ./hack/generate_release_notes.sh "${{ runner.temp }}/enduro-release-notes.md"
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
       with:
         version: latest
-        args: release --release-notes .release-notes.md
+        args: release --release-notes ${{ runner.temp }}/enduro-release-notes.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/hack/generate_release_notes.sh
+++ b/hack/generate_release_notes.sh
@@ -2,6 +2,7 @@
 
 set -eu
 
+OUTPUT_PATH=${1}
 CURRENT_TAG=${GITHUB_REF_NAME}
 
 LATEST_HEADING=$(
@@ -48,7 +49,7 @@ CHANGELOG_ANCHOR=$(
 		sed 's/[^a-z0-9 -]//g; s/ /-/g'
 )
 
-cat > ".release-notes.md" << EOF
+cat > "${OUTPUT_PATH}" << EOF
 - Functional changelog: [CHANGELOG.md](https://github.com/artefactual-sdps/enduro/blob/main/CHANGELOG.md#${CHANGELOG_ANCHOR})
 - Full changelog: https://github.com/artefactual-sdps/enduro/compare/${PREVIOUS_TAG}...${CURRENT_TAG}
 EOF


### PR DESCRIPTION
Fetch full git history in the release workflow so the workflow can resolve the current and previous tags correctly. Write generated release notes to the runner's temporary directory instead of the repository so GoReleaser does not fail on a dirty checkout.