### PR TITLE
Remove nightly gosec Github action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,13 +21,3 @@ jobs:
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Execute govulncheck
         run: govulncheck ./...
-  gosec:
-    name: GoSec security scan
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: Scan code
-        uses: securego/gosec@b7b2c7b668f3f2bef8a8ae04d72f0eb60492322c # master
-        with:
-          args: ./...


### PR DESCRIPTION
We are running gosec as part of the golangci-lint suite on pull request and when pushing to main so a nightly check is no longer necessary.