### PR TITLE
Fix User Manual link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ enables users to run failure-oblivious and durable preservation workflows.
 
 ## User documentation resources
 
-- [User manual](https://enduro.readthedocs.io/user-manual/)
+- [User manual]([https://enduro.readthedocs.io/user-manual/](https://enduro.readthedocs.io/user-manual/overview/)
 
 ## Development documentation resources
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ enables users to run failure-oblivious and durable preservation workflows.
 
 ## User documentation resources
 
-- [User manual]([https://enduro.readthedocs.io/user-manual/](https://enduro.readthedocs.io/user-manual/overview/)
+- [User manual](https://enduro.readthedocs.io/user-manual/overview/)
 
 ## Development documentation resources
 


### PR DESCRIPTION
User documentation linked to a page that no longer exists. I have updated that to point to the "Overview and first steps" link instead.