### PR TITLE
Count SIP preservation files

### DIFF
--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -269,6 +269,10 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: bagvalidate.Name},
 		)
 		w.RegisterActivityWithOptions(
+			activities.NewCountSIPFilesActivity().Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.CountSIPFilesActivityName},
+		)
+		w.RegisterActivityWithOptions(
 			activities.NewBundleActivity().Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.BundleActivityName},
 		)

--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -276,6 +276,10 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: bagvalidate.Name},
 		)
 		w.RegisterActivityWithOptions(
+			activities.NewCountSIPFilesActivity().Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.CountSIPFilesActivityName},
+		)
+		w.RegisterActivityWithOptions(
 			activities.NewBundleActivity().Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.BundleActivityName},
 		)

--- a/internal/workflow/activities/count_sip_files.go
+++ b/internal/workflow/activities/count_sip_files.go
@@ -1,0 +1,75 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.artefactual.dev/tools/fsutil"
+
+	"github.com/artefactual-sdps/enduro/internal/enums"
+)
+
+const CountSIPFilesActivityName = "count-files-activity"
+
+type (
+	CountSIPFilesActivity struct{}
+
+	CountSIPFilesActivityParams struct {
+		// Path is the Bag filepath.
+		Path string
+
+		// SIPType is the SIP type (e.g. BagIt) which may be used to determine
+		// where the preservation files are located in the SIP.
+		SIPType enums.SIPType
+	}
+
+	CountSIPFilesActivityResult struct {
+		// Count is the number of preservation files in the Bag.
+		Count int
+	}
+)
+
+func NewCountSIPFilesActivity() *CountSIPFilesActivity {
+	return &CountSIPFilesActivity{}
+}
+
+// Execute counts the number of preservation files in the SIP at params.Path.
+//
+// If the SIP is a BagIt Bag, Execute counts the files in the "data" directory.
+// If the SIP type is unknown, Execute counts all the files in the SIP.
+func (a *CountSIPFilesActivity) Execute(
+	ctx context.Context,
+	params *CountSIPFilesActivityParams,
+) (*CountSIPFilesActivityResult, error) {
+	path := params.Path
+	if params.SIPType == enums.SIPTypeBagIt {
+		// For BagIt Bags only count the files in the "data" directory.
+		path = filepath.Join(params.Path, "data")
+	}
+
+	found, err := fsutil.Exists(path)
+	if err != nil {
+		return nil, fmt.Errorf("count SIP files: %v", err)
+	}
+	if !found {
+		return nil, fmt.Errorf("count SIP files: directory not found: %s", path)
+	}
+
+	var count int
+	err = filepath.WalkDir(path, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("count SIP files: walk dir: %v", err)
+	}
+
+	return &CountSIPFilesActivityResult{Count: count}, nil
+}

--- a/internal/workflow/activities/count_sip_files_test.go
+++ b/internal/workflow/activities/count_sip_files_test.go
@@ -1,0 +1,65 @@
+package activities_test
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/enums"
+	"github.com/artefactual-sdps/enduro/internal/workflow/activities"
+)
+
+func TestCountSIPFilesActivity(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		name    string
+		params  *activities.CountSIPFilesActivityParams
+		want    *activities.CountSIPFilesActivityResult
+		wantErr string
+	}
+	for _, tc := range []test{
+		{
+			name: "count files in BagIt Bag",
+			params: &activities.CountSIPFilesActivityParams{
+				Path:    "../../testdata/bag/small_bag",
+				SIPType: enums.SIPTypeBagIt,
+			},
+			want: &activities.CountSIPFilesActivityResult{
+				Count: 1,
+			},
+		},
+		{
+			name: "count files in a standard transfer",
+			params: &activities.CountSIPFilesActivityParams{
+				Path:    "../../testdata/standard_transfer/small",
+				SIPType: enums.SIPTypeUnknown,
+			},
+			want: &activities.CountSIPFilesActivityResult{
+				Count: 1,
+			},
+		},
+		{
+			name: "missing data directory",
+			params: &activities.CountSIPFilesActivityParams{
+				Path:    "../../testdata/missing",
+				SIPType: enums.SIPTypeBagIt,
+			},
+			wantErr: "count SIP files: directory not found: ../../testdata/missing/data",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			activity := activities.NewCountSIPFilesActivity()
+			got, err := activity.Execute(context.Background(), tc.params)
+			if tc.wantErr != "" {
+				assert.Error(t, err, tc.wantErr)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Equal(t, tc.want.Count, got.Count)
+		})
+	}
+}

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -479,6 +479,12 @@ func (w *ProcessingWorkflow) SessionHandler(
 		}
 	}
 
+	// Count the files in the SIP and store the result in the workflow state for
+	// later use.
+	if err := w.CountSIPFiles(sessCtx, state); err != nil {
+		return fmt.Errorf("count SIP files: %v", err)
+	}
+
 	// Do preservation.
 	{
 		var err error
@@ -1138,10 +1144,10 @@ func (w *ProcessingWorkflow) createTask(
 }
 
 func (w *ProcessingWorkflow) completeTask(
-	ctx temporalsdk_workflow.Context,
+	sessCtx temporalsdk_workflow.Context,
 	task datatypes.Task,
 ) error {
-	ctx = withLocalActivityOpts(ctx)
+	ctx := withLocalActivityOpts(sessCtx)
 	err := temporalsdk_workflow.ExecuteLocalActivity(
 		ctx,
 		completeTaskLocalActivity,
@@ -1425,4 +1431,60 @@ func (w *ProcessingWorkflow) waitForBatch(
 	}
 
 	return sessCtx, nil
+}
+
+func (w *ProcessingWorkflow) CountSIPFiles(
+	sessCtx temporalsdk_workflow.Context,
+	state *workflowState,
+) error {
+	var result activities.CountSIPFilesActivityResult
+
+	id, err := w.createTask(
+		sessCtx,
+		&datatypes.Task{
+			Name:         "Count SIP Files",
+			Status:       enums.TaskStatusInProgress,
+			WorkflowUUID: state.workflowUUID,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("create count SIP files task: %v", err)
+	}
+
+	// Set the default (successful) task completion values.
+	task := datatypes.Task{ID: id, Status: enums.TaskStatusDone}
+
+	opts := withActivityOptsForLocalAction(sessCtx)
+	err = temporalsdk_workflow.ExecuteActivity(
+		opts,
+		activities.CountSIPFilesActivityName,
+		&activities.CountSIPFilesActivityParams{
+			Path:    state.sip.path,
+			SIPType: state.sip.sipType,
+		},
+	).Get(opts, &result)
+	if err != nil {
+		task.SystemError(
+			"Counting SIP files has failed.",
+			"An error has occurred while attempting to count the files in the SIP. Please try again, or ask a system administrator to investigate.",
+		)
+		state.status = enums.WorkflowStatusError
+	}
+
+	// Update the count SIP files task.
+	task.Note = fmt.Sprintf("SIP contains %d files", result.Count)
+	if e := w.completeTask(sessCtx, task); e != nil {
+		return errors.Join(
+			err,
+			fmt.Errorf("complete Count SIP Files task: %v", e),
+		)
+	}
+
+	if err != nil {
+		return fmt.Errorf("count SIP files: %v", err)
+	}
+
+	state.sip.fileCount = result.Count
+
+	return nil
 }

--- a/internal/workflow/processing_expectations_test.go
+++ b/internal/workflow/processing_expectations_test.go
@@ -22,27 +22,29 @@ import (
 )
 
 const (
-	tempPath         = "/tmp/enduro123456"
-	extractPath      = "/tmp/enduro123456/extract"
-	transferPath     = "/home/a3m/.local/share/a3m/share/enduro2985726865"
-	prepSharedPath   = "/home/enduro/preprocessing/"
-	prepDownloadPath = "/home/enduro/preprocessing/enduro123456"
-	prepExtractPath  = "/home/enduro/preprocessing/enduro123456/extract"
-	failedSIPKey     = "Failed_SIP_name-e2ace0da-8697-453d-9ea1-4c9b62309e54.zip"
-	failedPIPKey     = "Failed_PIP_name-e2ace0da-8697-453d-9ea1-4c9b62309e54.zip"
-	sipID            = 1
-	workflowID       = 1
-	copySIPTaskID    = 100
-	valBagTaskID     = 101
-	valPREMISTaskID  = 102
-	batchWaitTaskID  = 103
-	uploadTaskID     = 104
-	reviewAIPTaskID  = 105
-	moveAIPTaskID    = 106
-	deleteSIPTaskID  = 107
-	sipName          = "name.zip"
-	key              = "transfer.zip"
-	watcherName      = "watcher"
+	tempPath            = "/tmp/enduro123456"
+	extractPath         = "/tmp/enduro123456/extract"
+	transferPath        = "/home/a3m/.local/share/a3m/share/enduro2985726865"
+	prepSharedPath      = "/home/enduro/preprocessing/"
+	prepDownloadPath    = "/home/enduro/preprocessing/enduro123456"
+	prepExtractPath     = "/home/enduro/preprocessing/enduro123456/extract"
+	failedSIPKey        = "Failed_SIP_name-e2ace0da-8697-453d-9ea1-4c9b62309e54.zip"
+	failedPIPKey        = "Failed_PIP_name-e2ace0da-8697-453d-9ea1-4c9b62309e54.zip"
+	sipID               = 1
+	workflowID          = 1
+	copySIPTaskID       = 100
+	valPREMISTaskID     = 101
+	batchWaitTaskID     = 102
+	uploadTaskID        = 103
+	reviewAIPTaskID     = 104
+	moveAIPTaskID       = 105
+	deleteSIPTaskID     = 106
+	valBagTaskID        = 107
+	CountSIPFilesTaskID = 108
+	sipName             = "name.zip"
+	key                 = "transfer.zip"
+	watcherName         = "watcher"
+	fileCount           = 5
 )
 
 var (
@@ -341,6 +343,16 @@ var expectations = map[string]expectationFunc{
 			&bagvalidate.Params{Path: params.extractPath},
 		).Return(&bagvalidate.Result{Valid: true}, nil)
 	},
+	"countSIPFiles": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			activities.CountSIPFilesActivityName,
+			sessionCtx,
+			&activities.CountSIPFilesActivityParams{
+				Path:    params.extractPath,
+				SIPType: params.sipType,
+			},
+		).Return(&activities.CountSIPFilesActivityResult{Count: fileCount}, nil)
+	},
 	"validatePREMIS": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
 		s.env.OnActivity(
 			xmlvalidate.Name,
@@ -494,4 +506,17 @@ func cleanupExpectations(s *ProcessingWorkflowTestSuite, params expectationParam
 	}
 	expectations["updateSIPIngested"](s, params)
 	expectations["completeWorkflow"](s, params)
+}
+
+func CountSIPFilesExpectations(s *ProcessingWorkflowTestSuite, params expectationParams) {
+	params.updateTaskParams(CountSIPFilesTaskID, enums.TaskStatusInProgress, "Count SIP Files", "")
+	expectations["createTask"](s, params)
+	expectations["countSIPFiles"](s, params)
+	params.updateTaskParams(
+		CountSIPFilesTaskID,
+		enums.TaskStatusDone,
+		"",
+		fmt.Sprintf("SIP contains %d files", fileCount),
+	)
+	expectations["completeTask"](s, params)
 }

--- a/internal/workflow/processing_setup_test.go
+++ b/internal/workflow/processing_setup_test.go
@@ -111,6 +111,10 @@ func (s *ProcessingWorkflowTestSuite) SetupWorkflowTest(cfg config.Configuration
 		temporalsdk_activity.RegisterOptions{Name: bagvalidate.Name},
 	)
 	s.env.RegisterActivityWithOptions(
+		activities.NewCountSIPFilesActivity().Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.CountSIPFilesActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
 		activities.NewClassifySIPActivity().Execute,
 		temporalsdk_activity.RegisterOptions{Name: activities.ClassifySIPActivityName},
 	)

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -63,6 +63,7 @@ func (s *ProcessingWorkflowTestSuite) TestConfirmation() {
 	downloadExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
+	CountSIPFilesExpectations(s, params)
 	reviewA3mExpectations(s, params)
 	params.updateTaskParams(reviewAIPTaskID, enums.TaskStatusDone, "", "Reviewed and accepted")
 	expectations["completeTask"](s, params)
@@ -118,6 +119,7 @@ func (s *ProcessingWorkflowTestSuite) TestRejection() {
 	downloadExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
+	CountSIPFilesExpectations(s, params)
 	reviewA3mExpectations(s, params)
 	params.updateTaskParams(reviewAIPTaskID, enums.TaskStatusDone, "", "Reviewed and rejected")
 	expectations["completeTask"](s, params)
@@ -156,6 +158,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 	downloadExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
+	CountSIPFilesExpectations(s, params)
 	autoApproveA3mExpectations(s, params)
 	params.retentionPeriod = -1 * time.Second
 	cleanupExpectations(s, params)
@@ -191,6 +194,7 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
 	expectations["createBag"](s, params)
+	CountSIPFilesExpectations(s, params)
 	params.updateTaskParams(valPREMISTaskID, enums.TaskStatusInProgress, "Validate PREMIS", "")
 	expectations["createTask"](s, params)
 	params.premisXMLPath = filepath.Join(extractPath, "data", "metadata", "premis.xml")
@@ -369,6 +373,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	expectations["validateBag"](s, params)
 	params.updateTaskParams(valBagTaskID, enums.TaskStatusDone, "", "Bag successfully validated")
 	expectations["completeTask"](s, params)
+	CountSIPFilesExpectations(s, params)
 	autoApproveA3mExpectations(s, params)
 
 	s.env.OnWorkflow(
@@ -481,6 +486,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPA3m() {
 	expectations["validateBag"](s, params)
 	params.updateTaskParams(valBagTaskID, enums.TaskStatusDone, "", "Bag successfully validated")
 	expectations["completeTask"](s, params)
+	CountSIPFilesExpectations(s, params)
 	expectations["bundle"](s, params)
 	params.updateTaskParams(valPREMISTaskID, enums.TaskStatusInProgress, "Validate PREMIS", "")
 	expectations["createTask"](s, params)
@@ -540,6 +546,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPAM() {
 	downloadExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
+	CountSIPFilesExpectations(s, params)
 	expectations["createBag"](s, params)
 	expectations["zipArchive"](s, params)
 
@@ -597,6 +604,7 @@ func (s *ProcessingWorkflowTestSuite) TestInternalUpload() {
 	expectations["completeTask"](s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
+	CountSIPFilesExpectations(s, params)
 	autoApproveA3mExpectations(s, params)
 
 	expectations["removePaths"](s, params)
@@ -734,6 +742,7 @@ func (s *ProcessingWorkflowTestSuite) TestSIPSourceUpload() {
 	expectations["getSIPExtension"](s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
+	CountSIPFilesExpectations(s, params)
 	autoApproveA3mExpectations(s, params)
 
 	expectations["removePaths"](s, params)
@@ -782,6 +791,7 @@ func (s *ProcessingWorkflowTestSuite) TestSIPDeletionError() {
 	downloadExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
+	CountSIPFilesExpectations(s, params)
 	autoApproveA3mExpectations(s, params)
 	expectations["removePaths"](s, params)
 	params.updateTaskParams(
@@ -836,6 +846,7 @@ func (s *ProcessingWorkflowTestSuite) TestBatchSignalDoNotContinue() {
 	downloadExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
+	CountSIPFilesExpectations(s, params)
 	expectations["bundle"](s, params)
 
 	// Batch signal handler and expectations.

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -102,6 +102,10 @@ type sipInfo struct {
 
 	// failed_key is the object key of the failed SIP/PIP in the internal bucket.
 	failed_key string
+
+	// fileCount is the number of preservation files in the SIP. It is populated
+	// by the CountSIPFilesActivity after preprocessing.
+	fileCount int
 }
 
 // aipInfo represents the AIP.


### PR DESCRIPTION
Two clients have requested reports from Enduro that include a count of the preservation files in the ingested SIP.  Counting the SIPs in a BagIt bag is easy to standardize because the BagIt standard requires all preservation files to be put in the "data" directory, or one of its sub-directories.

The only time we don't have a bagged SIP in Enduro is when a3m is used as the preservation engine, which is not a configuration of Enduro that is supported at this time.