### PR TITLE
Pass SIP name to preprocessing workflow

### DIFF
--- a/internal/childwf/preprocessing.go
+++ b/internal/childwf/preprocessing.go
@@ -12,6 +12,9 @@ type PreprocessingParams struct {
 	// BatchID is the identifier of the batch being processed. If the SIP is not
 	// part of a batch, this will equal uuid.Nil.
 	BatchID uuid.UUID
+
+	// SIPName is the original filename of the SIP being processed.
+	SIPName string
 }
 
 type PreprocessingResult struct {

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -1039,6 +1039,7 @@ func (w *ProcessingWorkflow) preprocessing(ctx temporalsdk_workflow.Context, sta
 			RelativePath: relPath,
 			SIPID:        state.sip.uuid,
 			BatchID:      state.req.BatchUUID,
+			SIPName:      state.sip.name,
 		},
 	).Get(preCtx, &ppResult)
 	if err != nil {

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -324,6 +324,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 		&childwf.PreprocessingParams{
 			RelativePath: strings.TrimPrefix(prepDownloadPath+"/"+key, prepSharedPath),
 			SIPID:        sipUUID,
+			SIPName:      sipName,
 		},
 	).Return(
 		&childwf.PreprocessingResult{
@@ -426,6 +427,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 		&childwf.PreprocessingParams{
 			RelativePath: strings.TrimPrefix(prepDownloadPath+"/"+key, prepSharedPath),
 			SIPID:        sipUUID,
+			SIPName:      sipName,
 		},
 	).Return(
 		&childwf.PreprocessingResult{


### PR DESCRIPTION
Pass the original SIP file name (AKA "key") to the preprocessing child workflow. I need the original SIP name for a client preprocessing workflow but the name is modified during download to avoid name collisions.