### PR TITLE
Set Tilt dashboard target based on DASHBOARD_DEV

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -16,6 +16,7 @@ if PRES_SYS not in ("a3m", "am"):
 
 true = ("true", "1", "yes", "t", "y")
 LOCAL_A3M = os.environ.get("LOCAL_A3M", "").lower() in true
+DASHBOARD_DEV = os.environ.get("DASHBOARD_DEV", "").lower() in true
 
 # Docker images
 custom_build(
@@ -42,9 +43,7 @@ else:
 docker_build(
   "enduro-dashboard:dev",
   context="dashboard",
-  # Comment the following line to serve the app with Nginx instead of the Vite
-  # dev server
-  target="builder",
+  target="builder" if DASHBOARD_DEV else "",
   live_update=[
     fall_back_on("dashboard/vite.config.js"),
     sync("dashboard/", "/app/"),

--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -197,6 +197,7 @@ located in the root of the project. Example:
 TRIGGER_MODE_AUTO=true
 ENDURO_PRES_SYSTEM=a3m
 LOCAL_A3M=true
+DASHBOARD_DEV=true
 CHILD_WORKFLOW_PATHS='../preprocessing-acme:../acme-enduro-workflows'
 MOUNT_PREPROCESSING_VOLUME=true
 ```
@@ -216,6 +217,13 @@ but it has seen little adoption and is largely unmaintained. Check the
 
 Build and use a local version of a3m. Requires to have the `a3m` repository
 cloned as a sibling of this repository folder.
+
+### DASHBOARD_DEV
+
+If `DASHBOARD_DEV` is truthy (`t`, `true`, `y`, `yes`, `1`), Tilt builds the
+dashboard image with the `builder` target and serves the dashboard with the
+Vite development server, including hot reload. Otherwise, Tilt uses the default
+image target and serves the dashboard with Nginx.
 
 ### CHILD_WORKFLOW_PATHS
 


### PR DESCRIPTION
Set the Tilt dashboard image target to `builder` only when `DASHBOARD_DEV` is truthy, and to the default target otherwise. This makes the choice explicit through `.tilt.env` instead of requiring manual edits to the Tiltfile.