### PR TITLE
Add `file_count` column to the SIP table

### DIFF
--- a/internal/datatypes/sip.go
+++ b/internal/datatypes/sip.go
@@ -38,6 +38,9 @@ type SIP struct {
 
 	// Batch is the batch this SIP belongs to.
 	Batch *Batch
+
+	// FileCount is the number of files in the SIP.
+	FileCount int32
 }
 
 // Goa returns the API representation of the SIP.

--- a/internal/db/migrations/20260417140248_add_sip_file_count_column.up.sql
+++ b/internal/db/migrations/20260417140248_add_sip_file_count_column.up.sql
@@ -1,0 +1,2 @@
+-- Modify "sip" table
+ALTER TABLE `sip` ADD COLUMN `file_count` int NULL;

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:+w0cFlo2J6po1A+Xh2d1s3AOIbBR68sVVU6MdKrVrX0=
+h1:SCNNo6ElQOyVdaaaPahyx3vTXaqfIPmBtHTqGdL0bGE=
 1570659451_init.up.sql h1:zyiKKl39RqMxuEhop5jeeiPTxPiSSq00Tn6u06gyNmk=
 1710442322_nullable_aip_id.up.sql h1:vL4eG5YELXr3k4ymhHuRD/R7KpNt3/DNRhH26t83x3A=
 20250207193001_rename_package_table.up.sql h1:d2RjfIturPoFYMMtFocrMvvjEXEqDXDdxQRttcknX/0=
@@ -18,3 +18,4 @@ h1:+w0cFlo2J6po1A+Xh2d1s3AOIbBR68sVVU6MdKrVrX0=
 20251114163946_add_batch_table.up.sql h1:cvMYRBO1l4OfFdrNWmc9H2GK0oP4S4OU78Tk/JTyWqs=
 20251121205505_add_batch_failed_status.up.sql h1:jfxlOIIF7+9jpPsCcm0GZ4KNt2+tcm8AaWmO+DWqaOU=
 20251124204400_add_sip_statuses.up.sql h1:EmniCLIzTUvVmmWfX7rQ75ZmO33v+hv3OlCP6ToRLPo=
+20260417140248_add_sip_file_count_column.up.sql h1:KZSZObToIAAAIy60Xo3MHMLun9uAY1SMyISD0s/Rmk8=

--- a/internal/persistence/ent/client/convert.go
+++ b/internal/persistence/ent/client/convert.go
@@ -24,6 +24,7 @@ func convertSIP(sip *db.SIP) *datatypes.SIP {
 		CompletedAt: normalizeTime(sip.CompletedAt),
 		FailedAs:    sip.FailedAs,
 		FailedKey:   sip.FailedKey,
+		FileCount:   sip.FileCount,
 	}
 
 	// Convert optional fields.

--- a/internal/persistence/ent/client/sip.go
+++ b/internal/persistence/ent/client/sip.go
@@ -52,6 +52,9 @@ func (c *client) CreateSIP(ctx context.Context, s *datatypes.SIP) error {
 	if !s.CompletedAt.IsZero() {
 		q.SetCompletedAt(s.CompletedAt)
 	}
+	if s.FileCount > 0 {
+		q.SetFileCount(s.FileCount)
+	}
 
 	// If Uploader is set, find or create the user and link it to the SIP.
 	if s.Uploader != nil {
@@ -138,9 +141,10 @@ func (c *client) UpdateSIP(
 	}
 
 	// Save the updated SIP data to the database.
-	q := tx.SIP.UpdateOneID(dbID).SetName(up.Name)
+	q := tx.SIP.UpdateOneID(dbID).
+		SetName(up.Name)
 
-	// Validate columns.
+	// Set status if the value is valid.
 	if up.Status.IsValid() {
 		q.SetStatus(up.Status)
 	}
@@ -160,6 +164,9 @@ func (c *client) UpdateSIP(
 	}
 	if up.FailedKey != "" {
 		q.SetFailedKey(up.FailedKey)
+	}
+	if up.FileCount > 0 {
+		q.SetFileCount(up.FileCount)
 	}
 
 	// Save changes.

--- a/internal/persistence/ent/client/sip_test.go
+++ b/internal/persistence/ent/client/sip_test.go
@@ -45,6 +45,7 @@ func TestCreateSIP(t *testing.T) {
 				Status:      enums.SIPStatusProcessing,
 				StartedAt:   started,
 				CompletedAt: completed,
+				FileCount:   8,
 			},
 			want: &datatypes.SIP{
 				ID:          1,
@@ -55,6 +56,7 @@ func TestCreateSIP(t *testing.T) {
 				CreatedAt:   time.Now(),
 				StartedAt:   started,
 				CompletedAt: completed,
+				FileCount:   8,
 			},
 		},
 		{
@@ -265,6 +267,7 @@ func TestUpdateSIP(t *testing.T) {
 						SIPSCount:  5,
 						CreatedAt:  time.Now(),
 					},
+					FileCount: 0,
 				},
 				updater: func(s *datatypes.SIP) (*datatypes.SIP, error) {
 					s.ID = 100        // No-op, can't update ID.
@@ -278,6 +281,7 @@ func TestUpdateSIP(t *testing.T) {
 					s.FailedAs = enums.SIPFailedAsSIP
 					s.FailedKey = "failed-key"
 					s.Uploader = &datatypes.User{UUID: uuid.New()} // No-op, can't update Uploader.
+					s.FileCount = 8
 					return s, nil
 				},
 			},
@@ -308,6 +312,7 @@ func TestUpdateSIP(t *testing.T) {
 					SIPSCount:  5,
 					CreatedAt:  time.Now(),
 				},
+				FileCount: 8,
 			},
 		},
 		{
@@ -320,6 +325,7 @@ func TestUpdateSIP(t *testing.T) {
 					AIPID:     aipID,
 					Status:    enums.SIPStatusProcessing,
 					StartedAt: started,
+					FileCount: 0,
 				},
 				updater: func(s *datatypes.SIP) (*datatypes.SIP, error) {
 					// Immutable.
@@ -328,6 +334,7 @@ func TestUpdateSIP(t *testing.T) {
 					// Mutable.
 					s.Status = enums.SIPStatusIngested
 					s.CompletedAt = completed
+					s.FileCount = 8
 
 					return s, nil
 				},
@@ -341,6 +348,7 @@ func TestUpdateSIP(t *testing.T) {
 				CreatedAt:   time.Now(),
 				StartedAt:   started,
 				CompletedAt: completed,
+				FileCount:   8,
 			},
 		},
 		{
@@ -524,6 +532,7 @@ func TestReadSIP(t *testing.T) {
 					SIPSCount:  5,
 					CreatedAt:  time.Now(),
 				},
+				FileCount: 8,
 			},
 		},
 		{
@@ -559,6 +568,7 @@ func TestReadSIP(t *testing.T) {
 					SetFailedKey(tt.want.FailedKey).
 					SetUploader(user).
 					SetBatchID(tt.want.Batch.ID).
+					SetFileCount(8).
 					Save(ctx)
 				assert.NilError(t, err)
 			}
@@ -620,6 +630,7 @@ func TestListSIPs(t *testing.T) {
 					Status:      enums.SIPStatusIngested,
 					StartedAt:   started,
 					CompletedAt: completed,
+					FileCount:   3,
 				},
 				{
 					UUID:        sipUUID2,
@@ -636,6 +647,7 @@ func TestListSIPs(t *testing.T) {
 						OIDCIss:   "https://example.com/oidc",
 						OIDCSub:   "1234567890",
 					},
+					FileCount: 6,
 				},
 				{
 					UUID:        sipUUID3,
@@ -645,6 +657,7 @@ func TestListSIPs(t *testing.T) {
 					CompletedAt: completed2,
 					FailedAs:    enums.SIPFailedAsPIP,
 					FailedKey:   "failed-key",
+					FileCount:   9,
 				},
 			},
 			want: results{
@@ -658,6 +671,7 @@ func TestListSIPs(t *testing.T) {
 						CreatedAt:   time.Now(),
 						StartedAt:   started,
 						CompletedAt: completed,
+						FileCount:   3,
 					},
 					{
 						ID:          2,
@@ -676,6 +690,7 @@ func TestListSIPs(t *testing.T) {
 							OIDCIss:   "https://example.com/oidc",
 							OIDCSub:   "1234567890",
 						},
+						FileCount: 6,
 					},
 					{
 						ID:          3,
@@ -687,6 +702,7 @@ func TestListSIPs(t *testing.T) {
 						CompletedAt: completed2,
 						FailedAs:    enums.SIPFailedAsPIP,
 						FailedKey:   "failed-key",
+						FileCount:   9,
 					},
 				},
 				page: &persistence.Page{
@@ -705,6 +721,7 @@ func TestListSIPs(t *testing.T) {
 					Status:      enums.SIPStatusIngested,
 					StartedAt:   started,
 					CompletedAt: completed,
+					FileCount:   3,
 				},
 				{
 					UUID:        sipUUID2,
@@ -713,6 +730,7 @@ func TestListSIPs(t *testing.T) {
 					Status:      enums.SIPStatusProcessing,
 					StartedAt:   started2,
 					CompletedAt: completed2,
+					FileCount:   6,
 				},
 			},
 			sipFilter: &persistence.SIPFilter{
@@ -729,6 +747,7 @@ func TestListSIPs(t *testing.T) {
 						CreatedAt:   time.Now(),
 						StartedAt:   started,
 						CompletedAt: completed,
+						FileCount:   3,
 					},
 				},
 				page: &persistence.Page{
@@ -763,6 +782,7 @@ func TestListSIPs(t *testing.T) {
 						OIDCIss:   "https://example.com/oidc",
 						OIDCSub:   "1234567890",
 					},
+					FileCount: 6,
 				},
 			},
 			sipFilter: &persistence.SIPFilter{
@@ -787,6 +807,7 @@ func TestListSIPs(t *testing.T) {
 							OIDCIss:   "https://example.com/oidc",
 							OIDCSub:   "1234567890",
 						},
+						FileCount: 6,
 					},
 				},
 				page: &persistence.Page{
@@ -806,6 +827,7 @@ func TestListSIPs(t *testing.T) {
 					Status:      enums.SIPStatusIngested,
 					StartedAt:   started,
 					CompletedAt: completed,
+					FileCount:   3,
 				},
 				{
 					UUID:        sipUUID2,
@@ -814,6 +836,7 @@ func TestListSIPs(t *testing.T) {
 					Status:      enums.SIPStatusProcessing,
 					StartedAt:   started2,
 					CompletedAt: completed2,
+					FileCount:   6,
 				},
 			},
 			sipFilter: &persistence.SIPFilter{
@@ -830,6 +853,7 @@ func TestListSIPs(t *testing.T) {
 						CreatedAt:   time.Now(),
 						StartedAt:   started2,
 						CompletedAt: completed2,
+						FileCount:   6,
 					},
 				},
 				page: &persistence.Page{
@@ -848,6 +872,7 @@ func TestListSIPs(t *testing.T) {
 					Status:      enums.SIPStatusIngested,
 					StartedAt:   started,
 					CompletedAt: completed,
+					FileCount:   3,
 				},
 				{
 					UUID:        sipUUID2,
@@ -856,6 +881,7 @@ func TestListSIPs(t *testing.T) {
 					Status:      enums.SIPStatusProcessing,
 					StartedAt:   started2,
 					CompletedAt: completed2,
+					FileCount:   6,
 				},
 			},
 			sipFilter: &persistence.SIPFilter{
@@ -872,6 +898,7 @@ func TestListSIPs(t *testing.T) {
 						CreatedAt:   time.Now(),
 						StartedAt:   started2,
 						CompletedAt: completed2,
+						FileCount:   6,
 					},
 				},
 				page: &persistence.Page{
@@ -890,6 +917,7 @@ func TestListSIPs(t *testing.T) {
 					Status:      enums.SIPStatusIngested,
 					StartedAt:   started,
 					CompletedAt: completed,
+					FileCount:   3,
 				},
 				{
 					UUID:        sipUUID2,
@@ -898,6 +926,7 @@ func TestListSIPs(t *testing.T) {
 					Status:      enums.SIPStatusProcessing,
 					StartedAt:   started2,
 					CompletedAt: completed2,
+					FileCount:   6,
 				},
 			},
 			sipFilter: &persistence.SIPFilter{
@@ -914,6 +943,7 @@ func TestListSIPs(t *testing.T) {
 						CreatedAt:   time.Now(),
 						StartedAt:   started2,
 						CompletedAt: completed2,
+						FileCount:   6,
 					},
 				},
 				page: &persistence.Page{
@@ -932,6 +962,7 @@ func TestListSIPs(t *testing.T) {
 					Status:      enums.SIPStatusIngested,
 					StartedAt:   started,
 					CompletedAt: completed,
+					FileCount:   3,
 				},
 				{
 					UUID:        sipUUID2,
@@ -940,6 +971,7 @@ func TestListSIPs(t *testing.T) {
 					Status:      enums.SIPStatusProcessing,
 					StartedAt:   started2,
 					CompletedAt: completed2,
+					FileCount:   6,
 				},
 			},
 			sipFilter: &persistence.SIPFilter{
@@ -965,6 +997,7 @@ func TestListSIPs(t *testing.T) {
 						CreatedAt:   time.Now(),
 						StartedAt:   started,
 						CompletedAt: completed,
+						FileCount:   3,
 					},
 					{
 						ID:          2,
@@ -975,6 +1008,7 @@ func TestListSIPs(t *testing.T) {
 						CreatedAt:   time.Now(),
 						StartedAt:   started2,
 						CompletedAt: completed2,
+						FileCount:   6,
 					},
 				},
 				page: &persistence.Page{
@@ -1170,7 +1204,8 @@ func TestListSIPs(t *testing.T) {
 						SetStatus(sip.Status).
 						SetCreatedAt(time.Now()).
 						SetStartedAt(sip.StartedAt).
-						SetCompletedAt(sip.CompletedAt)
+						SetCompletedAt(sip.CompletedAt).
+						SetFileCount(sip.FileCount)
 
 					if sip.AIPID.Valid {
 						q.SetAipID(sip.AIPID.UUID)

--- a/internal/persistence/ent/db/migrate/schema.go
+++ b/internal/persistence/ent/db/migrate/schema.go
@@ -77,6 +77,7 @@ var (
 		{Name: "completed_at", Type: field.TypeTime, Nullable: true},
 		{Name: "failed_as", Type: field.TypeEnum, Nullable: true, Enums: []string{"SIP", "PIP"}},
 		{Name: "failed_key", Type: field.TypeString, Nullable: true, Size: 1024},
+		{Name: "file_count", Type: field.TypeInt32, Nullable: true},
 		{Name: "batch_id", Type: field.TypeInt, Nullable: true},
 		{Name: "uploader_id", Type: field.TypeInt, Nullable: true},
 	}
@@ -88,13 +89,13 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "sip_batch_sips",
-				Columns:    []*schema.Column{SipColumns[10]},
+				Columns:    []*schema.Column{SipColumns[11]},
 				RefColumns: []*schema.Column{BatchColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "sip_user_uploaded_sips",
-				Columns:    []*schema.Column{SipColumns[11]},
+				Columns:    []*schema.Column{SipColumns[12]},
 				RefColumns: []*schema.Column{UserColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -131,12 +132,12 @@ var (
 			{
 				Name:    "sip_uploader_id_idx",
 				Unique:  false,
-				Columns: []*schema.Column{SipColumns[11]},
+				Columns: []*schema.Column{SipColumns[12]},
 			},
 			{
 				Name:    "sip_batch_id_idx",
 				Unique:  false,
-				Columns: []*schema.Column{SipColumns[10]},
+				Columns: []*schema.Column{SipColumns[11]},
 			},
 		},
 	}

--- a/internal/persistence/ent/db/mutation.go
+++ b/internal/persistence/ent/db/mutation.go
@@ -991,6 +991,8 @@ type SIPMutation struct {
 	completed_at     *time.Time
 	failed_as        *enums.SIPFailedAs
 	failed_key       *string
+	file_count       *int32
+	addfile_count    *int32
 	clearedFields    map[string]struct{}
 	workflows        map[int]struct{}
 	removedworkflows map[int]struct{}
@@ -1589,6 +1591,76 @@ func (m *SIPMutation) ResetBatchID() {
 	delete(m.clearedFields, sip.FieldBatchID)
 }
 
+// SetFileCount sets the "file_count" field.
+func (m *SIPMutation) SetFileCount(i int32) {
+	m.file_count = &i
+	m.addfile_count = nil
+}
+
+// FileCount returns the value of the "file_count" field in the mutation.
+func (m *SIPMutation) FileCount() (r int32, exists bool) {
+	v := m.file_count
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldFileCount returns the old "file_count" field's value of the SIP entity.
+// If the SIP object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SIPMutation) OldFileCount(ctx context.Context) (v int32, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldFileCount is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldFileCount requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldFileCount: %w", err)
+	}
+	return oldValue.FileCount, nil
+}
+
+// AddFileCount adds i to the "file_count" field.
+func (m *SIPMutation) AddFileCount(i int32) {
+	if m.addfile_count != nil {
+		*m.addfile_count += i
+	} else {
+		m.addfile_count = &i
+	}
+}
+
+// AddedFileCount returns the value that was added to the "file_count" field in this mutation.
+func (m *SIPMutation) AddedFileCount() (r int32, exists bool) {
+	v := m.addfile_count
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearFileCount clears the value of the "file_count" field.
+func (m *SIPMutation) ClearFileCount() {
+	m.file_count = nil
+	m.addfile_count = nil
+	m.clearedFields[sip.FieldFileCount] = struct{}{}
+}
+
+// FileCountCleared returns if the "file_count" field was cleared in this mutation.
+func (m *SIPMutation) FileCountCleared() bool {
+	_, ok := m.clearedFields[sip.FieldFileCount]
+	return ok
+}
+
+// ResetFileCount resets all changes to the "file_count" field.
+func (m *SIPMutation) ResetFileCount() {
+	m.file_count = nil
+	m.addfile_count = nil
+	delete(m.clearedFields, sip.FieldFileCount)
+}
+
 // AddWorkflowIDs adds the "workflows" edge to the Workflow entity by ids.
 func (m *SIPMutation) AddWorkflowIDs(ids ...int) {
 	if m.workflows == nil {
@@ -1731,7 +1803,7 @@ func (m *SIPMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SIPMutation) Fields() []string {
-	fields := make([]string, 0, 11)
+	fields := make([]string, 0, 12)
 	if m.uuid != nil {
 		fields = append(fields, sip.FieldUUID)
 	}
@@ -1765,6 +1837,9 @@ func (m *SIPMutation) Fields() []string {
 	if m.batch != nil {
 		fields = append(fields, sip.FieldBatchID)
 	}
+	if m.file_count != nil {
+		fields = append(fields, sip.FieldFileCount)
+	}
 	return fields
 }
 
@@ -1795,6 +1870,8 @@ func (m *SIPMutation) Field(name string) (ent.Value, bool) {
 		return m.UploaderID()
 	case sip.FieldBatchID:
 		return m.BatchID()
+	case sip.FieldFileCount:
+		return m.FileCount()
 	}
 	return nil, false
 }
@@ -1826,6 +1903,8 @@ func (m *SIPMutation) OldField(ctx context.Context, name string) (ent.Value, err
 		return m.OldUploaderID(ctx)
 	case sip.FieldBatchID:
 		return m.OldBatchID(ctx)
+	case sip.FieldFileCount:
+		return m.OldFileCount(ctx)
 	}
 	return nil, fmt.Errorf("unknown SIP field %s", name)
 }
@@ -1912,6 +1991,13 @@ func (m *SIPMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetBatchID(v)
 		return nil
+	case sip.FieldFileCount:
+		v, ok := value.(int32)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetFileCount(v)
+		return nil
 	}
 	return fmt.Errorf("unknown SIP field %s", name)
 }
@@ -1920,6 +2006,9 @@ func (m *SIPMutation) SetField(name string, value ent.Value) error {
 // this mutation.
 func (m *SIPMutation) AddedFields() []string {
 	var fields []string
+	if m.addfile_count != nil {
+		fields = append(fields, sip.FieldFileCount)
+	}
 	return fields
 }
 
@@ -1928,6 +2017,8 @@ func (m *SIPMutation) AddedFields() []string {
 // was not set, or was not defined in the schema.
 func (m *SIPMutation) AddedField(name string) (ent.Value, bool) {
 	switch name {
+	case sip.FieldFileCount:
+		return m.AddedFileCount()
 	}
 	return nil, false
 }
@@ -1937,6 +2028,13 @@ func (m *SIPMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *SIPMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case sip.FieldFileCount:
+		v, ok := value.(int32)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddFileCount(v)
+		return nil
 	}
 	return fmt.Errorf("unknown SIP numeric field %s", name)
 }
@@ -1965,6 +2063,9 @@ func (m *SIPMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(sip.FieldBatchID) {
 		fields = append(fields, sip.FieldBatchID)
+	}
+	if m.FieldCleared(sip.FieldFileCount) {
+		fields = append(fields, sip.FieldFileCount)
 	}
 	return fields
 }
@@ -2000,6 +2101,9 @@ func (m *SIPMutation) ClearField(name string) error {
 		return nil
 	case sip.FieldBatchID:
 		m.ClearBatchID()
+		return nil
+	case sip.FieldFileCount:
+		m.ClearFileCount()
 		return nil
 	}
 	return fmt.Errorf("unknown SIP nullable field %s", name)
@@ -2041,6 +2145,9 @@ func (m *SIPMutation) ResetField(name string) error {
 		return nil
 	case sip.FieldBatchID:
 		m.ResetBatchID()
+		return nil
+	case sip.FieldFileCount:
+		m.ResetFileCount()
 		return nil
 	}
 	return fmt.Errorf("unknown SIP field %s", name)

--- a/internal/persistence/ent/db/runtime.go
+++ b/internal/persistence/ent/db/runtime.go
@@ -45,6 +45,10 @@ func init() {
 	sipDescBatchID := sipFields[10].Descriptor()
 	// sip.BatchIDValidator is a validator for the "batch_id" field. It is called by the builders before save.
 	sip.BatchIDValidator = sipDescBatchID.Validators[0].(func(int) error)
+	// sipDescFileCount is the schema descriptor for file_count field.
+	sipDescFileCount := sipFields[11].Descriptor()
+	// sip.FileCountValidator is a validator for the "file_count" field. It is called by the builders before save.
+	sip.FileCountValidator = sipDescFileCount.Validators[0].(func(int32) error)
 	taskFields := schema.Task{}.Fields()
 	_ = taskFields
 	// taskDescWorkflowID is the schema descriptor for workflow_id field.

--- a/internal/persistence/ent/db/sip.go
+++ b/internal/persistence/ent/db/sip.go
@@ -43,6 +43,8 @@ type SIP struct {
 	UploaderID int `json:"uploader_id,omitempty"`
 	// BatchID holds the value of the "batch_id" field.
 	BatchID int `json:"batch_id,omitempty"`
+	// FileCount holds the value of the "file_count" field.
+	FileCount int32 `json:"file_count,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the SIPQuery when eager-loading is set.
 	Edges        SIPEdges `json:"edges"`
@@ -98,7 +100,7 @@ func (*SIP) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case sip.FieldID, sip.FieldUploaderID, sip.FieldBatchID:
+		case sip.FieldID, sip.FieldUploaderID, sip.FieldBatchID, sip.FieldFileCount:
 			values[i] = new(sql.NullInt64)
 		case sip.FieldName, sip.FieldStatus, sip.FieldFailedAs, sip.FieldFailedKey:
 			values[i] = new(sql.NullString)
@@ -193,6 +195,12 @@ func (_m *SIP) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.BatchID = int(value.Int64)
 			}
+		case sip.FieldFileCount:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field file_count", values[i])
+			} else if value.Valid {
+				_m.FileCount = int32(value.Int64)
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -276,6 +284,9 @@ func (_m *SIP) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("batch_id=")
 	builder.WriteString(fmt.Sprintf("%v", _m.BatchID))
+	builder.WriteString(", ")
+	builder.WriteString("file_count=")
+	builder.WriteString(fmt.Sprintf("%v", _m.FileCount))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/internal/persistence/ent/db/sip/sip.go
+++ b/internal/persistence/ent/db/sip/sip.go
@@ -38,6 +38,8 @@ const (
 	FieldUploaderID = "uploader_id"
 	// FieldBatchID holds the string denoting the batch_id field in the database.
 	FieldBatchID = "batch_id"
+	// FieldFileCount holds the string denoting the file_count field in the database.
+	FieldFileCount = "file_count"
 	// EdgeWorkflows holds the string denoting the workflows edge name in mutations.
 	EdgeWorkflows = "workflows"
 	// EdgeUploader holds the string denoting the uploader edge name in mutations.
@@ -83,6 +85,7 @@ var Columns = []string{
 	FieldFailedKey,
 	FieldUploaderID,
 	FieldBatchID,
+	FieldFileCount,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -102,6 +105,8 @@ var (
 	UploaderIDValidator func(int) error
 	// BatchIDValidator is a validator for the "batch_id" field. It is called by the builders before save.
 	BatchIDValidator func(int) error
+	// FileCountValidator is a validator for the "file_count" field. It is called by the builders before save.
+	FileCountValidator func(int32) error
 )
 
 // StatusValidator is a validator for the "status" field enum values. It is called by the builders before save.
@@ -185,6 +190,11 @@ func ByUploaderID(opts ...sql.OrderTermOption) OrderOption {
 // ByBatchID orders the results by the batch_id field.
 func ByBatchID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldBatchID, opts...).ToFunc()
+}
+
+// ByFileCount orders the results by the file_count field.
+func ByFileCount(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFileCount, opts...).ToFunc()
 }
 
 // ByWorkflowsCount orders the results by workflows count.

--- a/internal/persistence/ent/db/sip/where.go
+++ b/internal/persistence/ent/db/sip/where.go
@@ -102,6 +102,11 @@ func BatchID(v int) predicate.SIP {
 	return predicate.SIP(sql.FieldEQ(FieldBatchID, v))
 }
 
+// FileCount applies equality check predicate on the "file_count" field. It's identical to FileCountEQ.
+func FileCount(v int32) predicate.SIP {
+	return predicate.SIP(sql.FieldEQ(FieldFileCount, v))
+}
+
 // UUIDEQ applies the EQ predicate on the "uuid" field.
 func UUIDEQ(v uuid.UUID) predicate.SIP {
 	return predicate.SIP(sql.FieldEQ(FieldUUID, v))
@@ -600,6 +605,56 @@ func BatchIDIsNil() predicate.SIP {
 // BatchIDNotNil applies the NotNil predicate on the "batch_id" field.
 func BatchIDNotNil() predicate.SIP {
 	return predicate.SIP(sql.FieldNotNull(FieldBatchID))
+}
+
+// FileCountEQ applies the EQ predicate on the "file_count" field.
+func FileCountEQ(v int32) predicate.SIP {
+	return predicate.SIP(sql.FieldEQ(FieldFileCount, v))
+}
+
+// FileCountNEQ applies the NEQ predicate on the "file_count" field.
+func FileCountNEQ(v int32) predicate.SIP {
+	return predicate.SIP(sql.FieldNEQ(FieldFileCount, v))
+}
+
+// FileCountIn applies the In predicate on the "file_count" field.
+func FileCountIn(vs ...int32) predicate.SIP {
+	return predicate.SIP(sql.FieldIn(FieldFileCount, vs...))
+}
+
+// FileCountNotIn applies the NotIn predicate on the "file_count" field.
+func FileCountNotIn(vs ...int32) predicate.SIP {
+	return predicate.SIP(sql.FieldNotIn(FieldFileCount, vs...))
+}
+
+// FileCountGT applies the GT predicate on the "file_count" field.
+func FileCountGT(v int32) predicate.SIP {
+	return predicate.SIP(sql.FieldGT(FieldFileCount, v))
+}
+
+// FileCountGTE applies the GTE predicate on the "file_count" field.
+func FileCountGTE(v int32) predicate.SIP {
+	return predicate.SIP(sql.FieldGTE(FieldFileCount, v))
+}
+
+// FileCountLT applies the LT predicate on the "file_count" field.
+func FileCountLT(v int32) predicate.SIP {
+	return predicate.SIP(sql.FieldLT(FieldFileCount, v))
+}
+
+// FileCountLTE applies the LTE predicate on the "file_count" field.
+func FileCountLTE(v int32) predicate.SIP {
+	return predicate.SIP(sql.FieldLTE(FieldFileCount, v))
+}
+
+// FileCountIsNil applies the IsNil predicate on the "file_count" field.
+func FileCountIsNil() predicate.SIP {
+	return predicate.SIP(sql.FieldIsNull(FieldFileCount))
+}
+
+// FileCountNotNil applies the NotNil predicate on the "file_count" field.
+func FileCountNotNil() predicate.SIP {
+	return predicate.SIP(sql.FieldNotNull(FieldFileCount))
 }
 
 // HasWorkflows applies the HasEdge predicate on the "workflows" edge.

--- a/internal/persistence/ent/db/sip_create.go
+++ b/internal/persistence/ent/db/sip_create.go
@@ -157,6 +157,20 @@ func (_c *SIPCreate) SetNillableBatchID(v *int) *SIPCreate {
 	return _c
 }
 
+// SetFileCount sets the "file_count" field.
+func (_c *SIPCreate) SetFileCount(v int32) *SIPCreate {
+	_c.mutation.SetFileCount(v)
+	return _c
+}
+
+// SetNillableFileCount sets the "file_count" field if the given value is not nil.
+func (_c *SIPCreate) SetNillableFileCount(v *int32) *SIPCreate {
+	if v != nil {
+		_c.SetFileCount(*v)
+	}
+	return _c
+}
+
 // AddWorkflowIDs adds the "workflows" edge to the Workflow entity by IDs.
 func (_c *SIPCreate) AddWorkflowIDs(ids ...int) *SIPCreate {
 	_c.mutation.AddWorkflowIDs(ids...)
@@ -257,6 +271,11 @@ func (_c *SIPCreate) check() error {
 			return &ValidationError{Name: "batch_id", err: fmt.Errorf(`db: validator failed for field "SIP.batch_id": %w`, err)}
 		}
 	}
+	if v, ok := _c.mutation.FileCount(); ok {
+		if err := sip.FileCountValidator(v); err != nil {
+			return &ValidationError{Name: "file_count", err: fmt.Errorf(`db: validator failed for field "SIP.file_count": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -319,6 +338,10 @@ func (_c *SIPCreate) createSpec() (*SIP, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.FailedKey(); ok {
 		_spec.SetField(sip.FieldFailedKey, field.TypeString, value)
 		_node.FailedKey = value
+	}
+	if value, ok := _c.mutation.FileCount(); ok {
+		_spec.SetField(sip.FieldFileCount, field.TypeInt32, value)
+		_node.FileCount = value
 	}
 	if nodes := _c.mutation.WorkflowsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -572,6 +595,30 @@ func (u *SIPUpsert) ClearBatchID() *SIPUpsert {
 	return u
 }
 
+// SetFileCount sets the "file_count" field.
+func (u *SIPUpsert) SetFileCount(v int32) *SIPUpsert {
+	u.Set(sip.FieldFileCount, v)
+	return u
+}
+
+// UpdateFileCount sets the "file_count" field to the value that was provided on create.
+func (u *SIPUpsert) UpdateFileCount() *SIPUpsert {
+	u.SetExcluded(sip.FieldFileCount)
+	return u
+}
+
+// AddFileCount adds v to the "file_count" field.
+func (u *SIPUpsert) AddFileCount(v int32) *SIPUpsert {
+	u.Add(sip.FieldFileCount, v)
+	return u
+}
+
+// ClearFileCount clears the value of the "file_count" field.
+func (u *SIPUpsert) ClearFileCount() *SIPUpsert {
+	u.SetNull(sip.FieldFileCount)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -792,6 +839,34 @@ func (u *SIPUpsertOne) UpdateBatchID() *SIPUpsertOne {
 func (u *SIPUpsertOne) ClearBatchID() *SIPUpsertOne {
 	return u.Update(func(s *SIPUpsert) {
 		s.ClearBatchID()
+	})
+}
+
+// SetFileCount sets the "file_count" field.
+func (u *SIPUpsertOne) SetFileCount(v int32) *SIPUpsertOne {
+	return u.Update(func(s *SIPUpsert) {
+		s.SetFileCount(v)
+	})
+}
+
+// AddFileCount adds v to the "file_count" field.
+func (u *SIPUpsertOne) AddFileCount(v int32) *SIPUpsertOne {
+	return u.Update(func(s *SIPUpsert) {
+		s.AddFileCount(v)
+	})
+}
+
+// UpdateFileCount sets the "file_count" field to the value that was provided on create.
+func (u *SIPUpsertOne) UpdateFileCount() *SIPUpsertOne {
+	return u.Update(func(s *SIPUpsert) {
+		s.UpdateFileCount()
+	})
+}
+
+// ClearFileCount clears the value of the "file_count" field.
+func (u *SIPUpsertOne) ClearFileCount() *SIPUpsertOne {
+	return u.Update(func(s *SIPUpsert) {
+		s.ClearFileCount()
 	})
 }
 
@@ -1181,6 +1256,34 @@ func (u *SIPUpsertBulk) UpdateBatchID() *SIPUpsertBulk {
 func (u *SIPUpsertBulk) ClearBatchID() *SIPUpsertBulk {
 	return u.Update(func(s *SIPUpsert) {
 		s.ClearBatchID()
+	})
+}
+
+// SetFileCount sets the "file_count" field.
+func (u *SIPUpsertBulk) SetFileCount(v int32) *SIPUpsertBulk {
+	return u.Update(func(s *SIPUpsert) {
+		s.SetFileCount(v)
+	})
+}
+
+// AddFileCount adds v to the "file_count" field.
+func (u *SIPUpsertBulk) AddFileCount(v int32) *SIPUpsertBulk {
+	return u.Update(func(s *SIPUpsert) {
+		s.AddFileCount(v)
+	})
+}
+
+// UpdateFileCount sets the "file_count" field to the value that was provided on create.
+func (u *SIPUpsertBulk) UpdateFileCount() *SIPUpsertBulk {
+	return u.Update(func(s *SIPUpsert) {
+		s.UpdateFileCount()
+	})
+}
+
+// ClearFileCount clears the value of the "file_count" field.
+func (u *SIPUpsertBulk) ClearFileCount() *SIPUpsertBulk {
+	return u.Update(func(s *SIPUpsert) {
+		s.ClearFileCount()
 	})
 }
 

--- a/internal/persistence/ent/db/sip_update.go
+++ b/internal/persistence/ent/db/sip_update.go
@@ -201,6 +201,33 @@ func (_u *SIPUpdate) ClearBatchID() *SIPUpdate {
 	return _u
 }
 
+// SetFileCount sets the "file_count" field.
+func (_u *SIPUpdate) SetFileCount(v int32) *SIPUpdate {
+	_u.mutation.ResetFileCount()
+	_u.mutation.SetFileCount(v)
+	return _u
+}
+
+// SetNillableFileCount sets the "file_count" field if the given value is not nil.
+func (_u *SIPUpdate) SetNillableFileCount(v *int32) *SIPUpdate {
+	if v != nil {
+		_u.SetFileCount(*v)
+	}
+	return _u
+}
+
+// AddFileCount adds value to the "file_count" field.
+func (_u *SIPUpdate) AddFileCount(v int32) *SIPUpdate {
+	_u.mutation.AddFileCount(v)
+	return _u
+}
+
+// ClearFileCount clears the value of the "file_count" field.
+func (_u *SIPUpdate) ClearFileCount() *SIPUpdate {
+	_u.mutation.ClearFileCount()
+	return _u
+}
+
 // AddWorkflowIDs adds the "workflows" edge to the Workflow entity by IDs.
 func (_u *SIPUpdate) AddWorkflowIDs(ids ...int) *SIPUpdate {
 	_u.mutation.AddWorkflowIDs(ids...)
@@ -313,6 +340,11 @@ func (_u *SIPUpdate) check() error {
 			return &ValidationError{Name: "batch_id", err: fmt.Errorf(`db: validator failed for field "SIP.batch_id": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.FileCount(); ok {
+		if err := sip.FileCountValidator(v); err != nil {
+			return &ValidationError{Name: "file_count", err: fmt.Errorf(`db: validator failed for field "SIP.file_count": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -363,6 +395,15 @@ func (_u *SIPUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if _u.mutation.FailedKeyCleared() {
 		_spec.ClearField(sip.FieldFailedKey, field.TypeString)
+	}
+	if value, ok := _u.mutation.FileCount(); ok {
+		_spec.SetField(sip.FieldFileCount, field.TypeInt32, value)
+	}
+	if value, ok := _u.mutation.AddedFileCount(); ok {
+		_spec.AddField(sip.FieldFileCount, field.TypeInt32, value)
+	}
+	if _u.mutation.FileCountCleared() {
+		_spec.ClearField(sip.FieldFileCount, field.TypeInt32)
 	}
 	if _u.mutation.WorkflowsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -655,6 +696,33 @@ func (_u *SIPUpdateOne) ClearBatchID() *SIPUpdateOne {
 	return _u
 }
 
+// SetFileCount sets the "file_count" field.
+func (_u *SIPUpdateOne) SetFileCount(v int32) *SIPUpdateOne {
+	_u.mutation.ResetFileCount()
+	_u.mutation.SetFileCount(v)
+	return _u
+}
+
+// SetNillableFileCount sets the "file_count" field if the given value is not nil.
+func (_u *SIPUpdateOne) SetNillableFileCount(v *int32) *SIPUpdateOne {
+	if v != nil {
+		_u.SetFileCount(*v)
+	}
+	return _u
+}
+
+// AddFileCount adds value to the "file_count" field.
+func (_u *SIPUpdateOne) AddFileCount(v int32) *SIPUpdateOne {
+	_u.mutation.AddFileCount(v)
+	return _u
+}
+
+// ClearFileCount clears the value of the "file_count" field.
+func (_u *SIPUpdateOne) ClearFileCount() *SIPUpdateOne {
+	_u.mutation.ClearFileCount()
+	return _u
+}
+
 // AddWorkflowIDs adds the "workflows" edge to the Workflow entity by IDs.
 func (_u *SIPUpdateOne) AddWorkflowIDs(ids ...int) *SIPUpdateOne {
 	_u.mutation.AddWorkflowIDs(ids...)
@@ -780,6 +848,11 @@ func (_u *SIPUpdateOne) check() error {
 			return &ValidationError{Name: "batch_id", err: fmt.Errorf(`db: validator failed for field "SIP.batch_id": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.FileCount(); ok {
+		if err := sip.FileCountValidator(v); err != nil {
+			return &ValidationError{Name: "file_count", err: fmt.Errorf(`db: validator failed for field "SIP.file_count": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -847,6 +920,15 @@ func (_u *SIPUpdateOne) sqlSave(ctx context.Context) (_node *SIP, err error) {
 	}
 	if _u.mutation.FailedKeyCleared() {
 		_spec.ClearField(sip.FieldFailedKey, field.TypeString)
+	}
+	if value, ok := _u.mutation.FileCount(); ok {
+		_spec.SetField(sip.FieldFileCount, field.TypeInt32, value)
+	}
+	if value, ok := _u.mutation.AddedFileCount(); ok {
+		_spec.AddField(sip.FieldFileCount, field.TypeInt32, value)
+	}
+	if _u.mutation.FileCountCleared() {
+		_spec.ClearField(sip.FieldFileCount, field.TypeInt32)
 	}
 	if _u.mutation.WorkflowsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/persistence/ent/schema/sip.go
+++ b/internal/persistence/ent/schema/sip.go
@@ -61,6 +61,9 @@ func (SIP) Fields() []ent.Field {
 		field.Int("batch_id").
 			Optional().
 			Positive(),
+		field.Int32("file_count").
+			Optional().
+			NonNegative(),
 	}
 }
 


### PR DESCRIPTION
Refs #1595.

- Add a `sip.file_count` column to the db schema
- Add a database migration to add the `sip.file_count` column
- Add a `FileCount` field to `datatypes.SIP`
- Add the "file count" field to SIP create, update, and read methods