### PR TITLE
Persist SIP file count

### DIFF
--- a/internal/workflow/activities/count_sip_files.go
+++ b/internal/workflow/activities/count_sip_files.go
@@ -27,7 +27,7 @@ type (
 
 	CountSIPFilesActivityResult struct {
 		// Count is the number of preservation files in the Bag.
-		Count int
+		Count int32
 	}
 )
 
@@ -57,7 +57,7 @@ func (a *CountSIPFilesActivity) Execute(
 		return nil, fmt.Errorf("count SIP files: directory not found: %s", path)
 	}
 
-	var count int
+	var count int32
 	err = filepath.WalkDir(path, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/internal/workflow/local_activities.go
+++ b/internal/workflow/local_activities.go
@@ -37,6 +37,7 @@ type updateSIPLocalActivityParams struct {
 	Status      enums.SIPStatus
 	FailedAs    enums.SIPFailedAs
 	FailedKey   string
+	FileCount   int32
 }
 
 type updateSIPLocalActivityResult struct{}
@@ -50,17 +51,26 @@ func updateSIPLocalActivity(
 		ctx,
 		params.UUID,
 		func(s *datatypes.SIP) (*datatypes.SIP, error) {
-			s.Name = params.Name
-			s.Status = params.Status
-			s.FailedAs = params.FailedAs
-			s.FailedKey = params.FailedKey
-
-			if !params.Status.IsValid() {
-				return nil, fmt.Errorf("invalid status: %s", params.Status)
+			if params.Name != "" {
+				s.Name = params.Name
 			}
 
-			if params.FailedAs != "" && !params.FailedAs.IsValid() {
-				return nil, fmt.Errorf("invalid failed as: %s", params.FailedAs)
+			if params.Status != "" {
+				if !params.Status.IsValid() {
+					return nil, fmt.Errorf("invalid status: %s", params.Status)
+				}
+				s.Status = params.Status
+			}
+
+			if params.FailedAs != "" {
+				if !params.FailedAs.IsValid() {
+					return nil, fmt.Errorf("invalid failed as: %s", params.FailedAs)
+				}
+				s.FailedAs = params.FailedAs
+			}
+
+			if params.FailedKey != "" {
+				s.FailedKey = params.FailedKey
 			}
 
 			if params.AIPUUID != "" {
@@ -73,6 +83,10 @@ func updateSIPLocalActivity(
 
 			if !params.CompletedAt.IsZero() {
 				s.CompletedAt = params.CompletedAt
+			}
+
+			if params.FileCount > 0 {
+				s.FileCount = params.FileCount
 			}
 
 			return s, nil

--- a/internal/workflow/local_activities_test.go
+++ b/internal/workflow/local_activities_test.go
@@ -209,6 +209,7 @@ func TestUpdateSIPLocalActivity(t *testing.T) {
 	name := "Test SIP"
 	completedAt := time.Now()
 	failedKey := "failed-key"
+	filecount := int32(42)
 
 	for _, tt := range []struct {
 		name      string
@@ -226,6 +227,7 @@ func TestUpdateSIPLocalActivity(t *testing.T) {
 				AIPUUID:     aipUUID.String(),
 				FailedAs:    enums.SIPFailedAsSIP,
 				FailedKey:   failedKey,
+				FileCount:   filecount,
 			},
 			mockCalls: func(ctx context.Context, svc *ingest_fake.MockService) {
 				svc.EXPECT().
@@ -240,6 +242,7 @@ func TestUpdateSIPLocalActivity(t *testing.T) {
 								assert.DeepEqual(t, s.Name, name)
 								assert.DeepEqual(t, s.Status, enums.SIPStatusIngested)
 								assert.DeepEqual(t, s.CompletedAt, completedAt)
+								assert.DeepEqual(t, s.FileCount, filecount)
 								assert.DeepEqual(t, s.AIPID, uuid.NullUUID{Valid: true, UUID: aipUUID})
 								assert.DeepEqual(t, s.FailedAs, enums.SIPFailedAsSIP)
 								assert.DeepEqual(t, s.FailedKey, failedKey)
@@ -255,7 +258,7 @@ func TestUpdateSIPLocalActivity(t *testing.T) {
 			params: &updateSIPLocalActivityParams{
 				UUID:        sipUUID,
 				Name:        name,
-				Status:      "",
+				Status:      "invalid",
 				CompletedAt: completedAt,
 				AIPUUID:     aipUUID.String(),
 			},

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -481,8 +481,25 @@ func (w *ProcessingWorkflow) SessionHandler(
 
 	// Count the files in the SIP and store the result in the workflow state for
 	// later use.
-	if err := w.CountSIPFiles(sessCtx, state); err != nil {
+	if err := w.countSIPFIles(sessCtx, state); err != nil {
 		return fmt.Errorf("count SIP files: %v", err)
+	}
+
+	// Persist the SIP file count.
+	{
+		opts := withLocalActivityOpts(sessCtx)
+		err := temporalsdk_workflow.ExecuteLocalActivity(
+			opts,
+			updateSIPLocalActivity,
+			w.ingestsvc,
+			&updateSIPLocalActivityParams{
+				UUID:      state.sip.uuid,
+				FileCount: state.sip.fileCount,
+			},
+		).Get(opts, nil)
+		if err != nil {
+			return fmt.Errorf("update SIP file count: %v", err)
+		}
 	}
 
 	// Do preservation.
@@ -1433,7 +1450,7 @@ func (w *ProcessingWorkflow) waitForBatch(
 	return sessCtx, nil
 }
 
-func (w *ProcessingWorkflow) CountSIPFiles(
+func (w *ProcessingWorkflow) countSIPFIles(
 	sessCtx temporalsdk_workflow.Context,
 	state *workflowState,
 ) error {

--- a/internal/workflow/processing_expectations_test.go
+++ b/internal/workflow/processing_expectations_test.go
@@ -353,6 +353,17 @@ var expectations = map[string]expectationFunc{
 			},
 		).Return(&activities.CountSIPFilesActivityResult{Count: fileCount}, nil)
 	},
+	"saveFileCount": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			updateSIPLocalActivity,
+			ctx,
+			s.workflow.ingestsvc,
+			&updateSIPLocalActivityParams{
+				UUID:      sipUUID,
+				FileCount: fileCount,
+			},
+		).Return(nil, nil)
+	},
 	"validatePREMIS": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
 		s.env.OnActivity(
 			xmlvalidate.Name,

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -64,6 +64,7 @@ func (s *ProcessingWorkflowTestSuite) TestConfirmation() {
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
 	CountSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
 	reviewA3mExpectations(s, params)
 	params.updateTaskParams(reviewAIPTaskID, enums.TaskStatusDone, "", "Reviewed and accepted")
 	expectations["completeTask"](s, params)
@@ -120,6 +121,7 @@ func (s *ProcessingWorkflowTestSuite) TestRejection() {
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
 	CountSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
 	reviewA3mExpectations(s, params)
 	params.updateTaskParams(reviewAIPTaskID, enums.TaskStatusDone, "", "Reviewed and rejected")
 	expectations["completeTask"](s, params)
@@ -159,6 +161,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
 	CountSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
 	autoApproveA3mExpectations(s, params)
 	params.retentionPeriod = -1 * time.Second
 	cleanupExpectations(s, params)
@@ -195,6 +198,7 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 	expectations["classifySIP"](s, params)
 	expectations["createBag"](s, params)
 	CountSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
 	params.updateTaskParams(valPREMISTaskID, enums.TaskStatusInProgress, "Validate PREMIS", "")
 	expectations["createTask"](s, params)
 	params.premisXMLPath = filepath.Join(extractPath, "data", "metadata", "premis.xml")
@@ -374,6 +378,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	params.updateTaskParams(valBagTaskID, enums.TaskStatusDone, "", "Bag successfully validated")
 	expectations["completeTask"](s, params)
 	CountSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
 	autoApproveA3mExpectations(s, params)
 
 	s.env.OnWorkflow(
@@ -487,6 +492,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPA3m() {
 	params.updateTaskParams(valBagTaskID, enums.TaskStatusDone, "", "Bag successfully validated")
 	expectations["completeTask"](s, params)
 	CountSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
 	expectations["bundle"](s, params)
 	params.updateTaskParams(valPREMISTaskID, enums.TaskStatusInProgress, "Validate PREMIS", "")
 	expectations["createTask"](s, params)
@@ -547,6 +553,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPAM() {
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
 	CountSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
 	expectations["createBag"](s, params)
 	expectations["zipArchive"](s, params)
 
@@ -605,6 +612,7 @@ func (s *ProcessingWorkflowTestSuite) TestInternalUpload() {
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
 	CountSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
 	autoApproveA3mExpectations(s, params)
 
 	expectations["removePaths"](s, params)
@@ -743,6 +751,7 @@ func (s *ProcessingWorkflowTestSuite) TestSIPSourceUpload() {
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
 	CountSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
 	autoApproveA3mExpectations(s, params)
 
 	expectations["removePaths"](s, params)
@@ -792,6 +801,7 @@ func (s *ProcessingWorkflowTestSuite) TestSIPDeletionError() {
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
 	CountSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
 	autoApproveA3mExpectations(s, params)
 	expectations["removePaths"](s, params)
 	params.updateTaskParams(
@@ -847,6 +857,7 @@ func (s *ProcessingWorkflowTestSuite) TestBatchSignalDoNotContinue() {
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
 	CountSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
 	expectations["bundle"](s, params)
 
 	// Batch signal handler and expectations.

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -105,7 +105,7 @@ type sipInfo struct {
 
 	// fileCount is the number of preservation files in the SIP. It is populated
 	// by the CountSIPFilesActivity after preprocessing.
-	fileCount int
+	fileCount int32
 }
 
 // aipInfo represents the AIP.


### PR DESCRIPTION
Refs #1595.

- Change all file count variables to int32 to avoid conversion issues
- Add `FileCount` to `updateSIPLocalActivity()` parameters
- Make all `updateSIPLocalActivity()` parameters optional, except for the SIP UUID
- Call `updateSIPLocalActivity()` to persist the file count

I've kept the call to persist the file count separate from the `countSIPfiles()` function to make it easier to use a file count passed from preprocessing in the future.