### PR TITLE
Allow Enduro pods to load config from a K8s secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build
 /covreport
 /dist
+/enduro.local.toml
 /.tilt.env
 *.secret

--- a/Tiltfile
+++ b/Tiltfile
@@ -22,6 +22,22 @@ true = ("true", "1", "yes", "t", "y")
 LOCAL_A3M = os.environ.get("LOCAL_A3M", "").lower() in true
 DASHBOARD_DEV = os.environ.get("DASHBOARD_DEV", "").lower() in true
 
+def add_enduro_config_secret(yaml):
+  config_path = "enduro.toml"
+  if os.path.exists("enduro.local.toml"):
+    config_path = "enduro.local.toml"
+
+  config = str(read_file(config_path))
+  secret_yaml = encode_yaml({
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": {"name": "enduro-config", "namespace": "enduro-sdps"},
+    "type": "Opaque",
+    "stringData": {"enduro.toml": config},
+  })
+
+  return [yaml, secret_yaml]
+
 # Docker images
 custom_build(
   ref="enduro:dev",
@@ -69,6 +85,7 @@ if PRES_SYS == 'am':
 
 # Load Kustomize YAML
 yaml = kustomize(KUBE_OVERLAY)
+yaml = add_enduro_config_secret(yaml)
 
 # The CHILD_WORKFLOW_PATHS environment variable is a colon-separated list of 
 # paths to child workflow directories. If set, we load each child workflow's

--- a/docs/src/dev-manual/archivematica.md
+++ b/docs/src/dev-manual/archivematica.md
@@ -35,8 +35,3 @@ The dev-am overlay ships a fixed host key and the matching known_hosts entry.
 
 If you want different credentials or endpoints, provide your own secret and
 update the dev-am overlay to reference it.
-
-## Applying changes
-
-If you edit `.tilt.env` or `enduro.toml` while Tilt is running, refresh the
-Tiltfile and the `enduro-am` resource to apply the changes inside the cluster.

--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -202,6 +202,12 @@ CHILD_WORKFLOW_PATHS='../preprocessing-acme:../acme-enduro-workflows'
 MOUNT_PREPROCESSING_VOLUME=true
 ```
 
+Tilt also renders the `enduro-config` Kubernetes secret from a TOML file in the
+project root. If `enduro.local.toml` exists, Tilt uses it instead of
+`enduro.toml`. When you change either file while Tilt is running, refresh the
+Tiltfile and then refresh the `enduro` and active worker resource
+(`enduro-am` or `enduro-a3m`) so the updated secret is applied in the cluster.
+
 ### TRIGGER_MODE_AUTO
 
 Enables live updates on code changes for the enduro services.

--- a/hack/kube/base/enduro.yaml
+++ b/hack/kube/base/enduro.yaml
@@ -27,6 +27,11 @@ spec:
       containers:
         - name: enduro
           image: ghcr.io/artefactual-sdps/enduro:main
+          command:
+            - /home/enduro/bin/enduro
+          args:
+            - --config
+            - /home/enduro/enduro-config/enduro.toml
           env:
             - name: MYSQL_USER
               valueFrom:
@@ -73,7 +78,15 @@ spec:
           ports:
             - containerPort: 9000
             - containerPort: 9002
+          volumeMounts:
+            - name: enduro-config
+              mountPath: /home/enduro/enduro-config
+              readOnly: true
           resources: {}
+      volumes:
+        - name: enduro-config
+          secret:
+            secretName: enduro-config
 ---
 apiVersion: v1
 kind: Service

--- a/hack/kube/overlays/dev-a3m/enduro-a3m.yaml
+++ b/hack/kube/overlays/dev-a3m/enduro-a3m.yaml
@@ -30,6 +30,11 @@ spec:
       containers:
         - name: enduro-a3m-worker
           image: ghcr.io/artefactual-sdps/enduro-a3m-worker:main
+          command:
+            - /home/enduro/bin/enduro-a3m-worker
+          args:
+            - --config
+            - /home/enduro/enduro-config/enduro.toml
           env:
             - name: MYSQL_USER
               valueFrom:
@@ -74,6 +79,9 @@ spec:
             - name: ENDURO_TELEMETRY_TRACES_SAMPLING_RATIO
               value: "1.0"
           volumeMounts:
+            - name: enduro-config
+              mountPath: /home/enduro/enduro-config
+              readOnly: true
             - name: enduro-a3m
               mountPath: /home/a3m/.local/share/a3m/share
         - name: a3m
@@ -87,6 +95,10 @@ spec:
           volumeMounts:
             - name: enduro-a3m
               mountPath: /home/a3m/.local/share/a3m/share
+      volumes:
+        - name: enduro-config
+          secret:
+            secretName: enduro-config
   volumeClaimTemplates:
     - metadata:
         name: enduro-a3m

--- a/hack/kube/overlays/dev-am/enduro-am.yaml
+++ b/hack/kube/overlays/dev-am/enduro-am.yaml
@@ -30,6 +30,11 @@ spec:
       containers:
         - name: enduro-am-worker
           image: ghcr.io/artefactual-sdps/enduro-am-worker:main
+          command:
+            - /home/enduro/bin/enduro-am-worker
+          args:
+            - --config
+            - /home/enduro/enduro-config/enduro.toml
           env:
             - name: MYSQL_USER
               valueFrom:
@@ -122,10 +127,16 @@ spec:
                   name: enduro-am-secret
                   key: sftp_private_key_passphrase
           volumeMounts:
+            - name: enduro-config
+              mountPath: /home/enduro/enduro-config
+              readOnly: true
             - name: ssh-volume
               mountPath: "/etc/ssh"
               readOnly: true
       volumes:
+        - name: enduro-config
+          secret:
+            secretName: enduro-config
         - name: ssh-volume
           secret:
             secretName: enduro-am-secret


### PR DESCRIPTION
Mount the `enduro-config` secret into Enduro pods so cluster manifests can supply runtime configuration, and have Tilt create that secret to support custom local configuration.