### PR TITLE
Pass SIP file counts to postbatch workflow

### DIFF
--- a/internal/childwf/postbatch.go
+++ b/internal/childwf/postbatch.go
@@ -18,7 +18,8 @@ type PostbatchBatch struct {
 }
 
 type PostbatchSIP struct {
-	UUID  uuid.UUID
-	Name  string
-	AIPID *uuid.UUID // Nullable.
+	UUID      uuid.UUID
+	Name      string
+	AIPID     *uuid.UUID // Nullable.
+	FileCount int32
 }

--- a/internal/workflow/activities/poll_sip_statuses.go
+++ b/internal/workflow/activities/poll_sip_statuses.go
@@ -11,6 +11,7 @@ import (
 	temporal_tools "go.artefactual.dev/tools/temporal"
 
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
 	"github.com/artefactual-sdps/enduro/internal/entfilter"
 	"github.com/artefactual-sdps/enduro/internal/enums"
 	"github.com/artefactual-sdps/enduro/internal/ingest"
@@ -35,8 +36,14 @@ type PollSIPStatusesActivityParams struct {
 }
 
 type PollSIPStatusesActivityResult struct {
+	// AllExpectedStatus is true if all SIPs in the batch have the
+	// ExpectedStatus.
 	AllExpectedStatus bool
-	SIPIDstoAIPIDs    map[uuid.UUID]uuid.UUID
+
+	// SIPs is a sparse list of the SIPs in this batch, containing only the
+	// AIPID and FileCount fields, so they can be passed to the postbatch
+	// workflow without needing to query the ingest service again.
+	SIPs map[uuid.UUID]datatypes.SIP
 }
 
 // PollSIPStatusesActivity polls the ingest service until all SIPs in a batch
@@ -76,7 +83,7 @@ func (a *PollSIPStatusesActivity) Execute(
 			if result.done {
 				return &PollSIPStatusesActivityResult{
 					AllExpectedStatus: result.allExpected,
-					SIPIDstoAIPIDs:    result.aipIDs,
+					SIPs:              result.sips,
 				}, nil
 			}
 		}
@@ -86,7 +93,7 @@ func (a *PollSIPStatusesActivity) Execute(
 type checkResult struct {
 	done        bool
 	allExpected bool
-	aipIDs      map[uuid.UUID]uuid.UUID
+	sips        map[uuid.UUID]datatypes.SIP
 }
 
 func (a *PollSIPStatusesActivity) checkSIPStatuses(
@@ -95,8 +102,6 @@ func (a *PollSIPStatusesActivity) checkSIPStatuses(
 	expectedSIPCount int,
 	expectedStatus enums.SIPStatus,
 ) (*checkResult, error) {
-	aipIDs := make(map[uuid.UUID]uuid.UUID, expectedSIPCount)
-
 	// Query all SIPs for this batch. Limit to the maximum page size for now,
 	// we may switch to a stats-based or aggregated query approach in the future.
 	result, err := a.ingestsvc.ListSips(ctx, &goaingest.ListSipsPayload{
@@ -113,10 +118,11 @@ func (a *PollSIPStatusesActivity) checkSIPStatuses(
 	}
 
 	expectedStatusCount := 0
-	for _, sip := range result.Items {
-		status, err := enums.ParseSIPStatus(sip.Status)
+	sips := make(map[uuid.UUID]datatypes.SIP, len(result.Items))
+	for _, item := range result.Items {
+		status, err := enums.ParseSIPStatus(item.Status)
 		if err != nil {
-			return nil, fmt.Errorf("invalid SIP status: %s", sip.Status)
+			return nil, fmt.Errorf("invalid SIP status: %s", item.Status)
 		}
 
 		// Check if this SIP has the expected status.
@@ -127,22 +133,30 @@ func (a *PollSIPStatusesActivity) checkSIPStatuses(
 			return &checkResult{done: false}, nil
 		}
 
-		if status == enums.SIPStatusIngested && sip.AipUUID != nil {
-			id, err := uuid.Parse(*sip.AipUUID)
-			if err != nil {
-				return nil, fmt.Errorf("parse AIP UUID: %v", err)
-			}
-			aipIDs[sip.UUID] = id
-		}
+		sips[item.UUID] = goaSIPtoSIP(item)
 	}
 
 	res := &checkResult{
 		done:        true,
 		allExpected: expectedStatusCount == expectedSIPCount,
-	}
-	if len(aipIDs) > 0 {
-		res.aipIDs = aipIDs
+		sips:        sips,
 	}
 
 	return res, nil
+}
+
+func goaSIPtoSIP(goaSIP *goaingest.SIP) datatypes.SIP {
+	sip := datatypes.SIP{
+		UUID:      goaSIP.UUID,
+		FileCount: ref.DerefZero(goaSIP.FileCount),
+	}
+
+	if goaSIP.AipUUID != nil {
+		id, err := uuid.Parse(*goaSIP.AipUUID)
+		if err == nil {
+			sip.AIPID = uuid.NullUUID{UUID: id, Valid: true}
+		}
+	}
+
+	return sip
 }

--- a/internal/workflow/activities/poll_sip_statuses_test.go
+++ b/internal/workflow/activities/poll_sip_statuses_test.go
@@ -14,6 +14,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
 	"github.com/artefactual-sdps/enduro/internal/entfilter"
 	"github.com/artefactual-sdps/enduro/internal/enums"
 	ingestfake "github.com/artefactual-sdps/enduro/internal/ingest/fake"
@@ -52,11 +53,23 @@ func TestPollSIPStatusesActivity(t *testing.T) {
 			mock: func(r *ingestfake.MockServiceMockRecorder) {
 				r.ListSips(mockutil.Context(), payload).
 					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
-						{UUID: sip1UUID, Status: enums.SIPStatusValidated.String()},
-						{UUID: sip2UUID, Status: enums.SIPStatusValidated.String()},
+						{
+							UUID:   sip1UUID,
+							Status: enums.SIPStatusValidated.String(),
+						},
+						{
+							UUID:   sip2UUID,
+							Status: enums.SIPStatusValidated.String(),
+						},
 					}}, nil)
 			},
-			want: &activities.PollSIPStatusesActivityResult{AllExpectedStatus: true},
+			want: &activities.PollSIPStatusesActivityResult{
+				AllExpectedStatus: true,
+				SIPs: map[uuid.UUID]datatypes.SIP{
+					sip1UUID: {UUID: sip1UUID},
+					sip2UUID: {UUID: sip2UUID},
+				},
+			},
 		},
 		{
 			name: "Returns true when all SIPs have ingested status",
@@ -69,22 +82,32 @@ func TestPollSIPStatusesActivity(t *testing.T) {
 				r.ListSips(mockutil.Context(), payload).
 					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
 						{
-							UUID:    sip1UUID,
-							Status:  enums.SIPStatusIngested.String(),
-							AipUUID: new(aip1UUID.String()),
+							UUID:      sip1UUID,
+							Status:    enums.SIPStatusIngested.String(),
+							AipUUID:   new(aip1UUID.String()),
+							FileCount: new(int32(8)),
 						},
 						{
-							UUID:    sip2UUID,
-							Status:  enums.SIPStatusIngested.String(),
-							AipUUID: new(aip2UUID.String()),
+							UUID:      sip2UUID,
+							Status:    enums.SIPStatusIngested.String(),
+							AipUUID:   new(aip2UUID.String()),
+							FileCount: new(int32(16)),
 						},
 					}}, nil)
 			},
 			want: &activities.PollSIPStatusesActivityResult{
 				AllExpectedStatus: true,
-				SIPIDstoAIPIDs: map[uuid.UUID]uuid.UUID{
-					sip1UUID: aip1UUID,
-					sip2UUID: aip2UUID,
+				SIPs: map[uuid.UUID]datatypes.SIP{
+					sip1UUID: {
+						UUID:      sip1UUID,
+						AIPID:     uuid.NullUUID{UUID: aip1UUID, Valid: true},
+						FileCount: 8,
+					},
+					sip2UUID: {
+						UUID:      sip2UUID,
+						AIPID:     uuid.NullUUID{UUID: aip2UUID, Valid: true},
+						FileCount: 16,
+					},
 				},
 			},
 		},
@@ -98,11 +121,23 @@ func TestPollSIPStatusesActivity(t *testing.T) {
 			mock: func(r *ingestfake.MockServiceMockRecorder) {
 				r.ListSips(mockutil.Context(), payload).
 					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
-						{UUID: sip1UUID, Status: enums.SIPStatusValidated.String()},
-						{UUID: sip2UUID, Status: enums.SIPStatusFailed.String()},
+						{
+							UUID:   sip1UUID,
+							Status: enums.SIPStatusValidated.String(),
+						},
+						{
+							UUID:   sip2UUID,
+							Status: enums.SIPStatusFailed.String(),
+						},
 					}}, nil)
 			},
-			want: &activities.PollSIPStatusesActivityResult{AllExpectedStatus: false},
+			want: &activities.PollSIPStatusesActivityResult{
+				AllExpectedStatus: false,
+				SIPs: map[uuid.UUID]datatypes.SIP{
+					sip1UUID: {UUID: sip1UUID},
+					sip2UUID: {UUID: sip2UUID},
+				},
+			},
 		},
 		{
 			name: "Returns false when some SIPs have error status",
@@ -114,11 +149,23 @@ func TestPollSIPStatusesActivity(t *testing.T) {
 			mock: func(r *ingestfake.MockServiceMockRecorder) {
 				r.ListSips(mockutil.Context(), payload).
 					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
-						{UUID: sip1UUID, Status: enums.SIPStatusValidated.String()},
-						{UUID: sip2UUID, Status: enums.SIPStatusError.String()},
+						{
+							UUID:   sip1UUID,
+							Status: enums.SIPStatusValidated.String(),
+						},
+						{
+							UUID:   sip2UUID,
+							Status: enums.SIPStatusError.String(),
+						},
 					}}, nil)
 			},
-			want: &activities.PollSIPStatusesActivityResult{AllExpectedStatus: false},
+			want: &activities.PollSIPStatusesActivityResult{
+				AllExpectedStatus: false,
+				SIPs: map[uuid.UUID]datatypes.SIP{
+					sip1UUID: {UUID: sip1UUID},
+					sip2UUID: {UUID: sip2UUID},
+				},
+			},
 		},
 		{
 			name: "Returns false when some SIPs have canceled status",
@@ -130,11 +177,23 @@ func TestPollSIPStatusesActivity(t *testing.T) {
 			mock: func(r *ingestfake.MockServiceMockRecorder) {
 				r.ListSips(mockutil.Context(), payload).
 					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
-						{UUID: sip1UUID, Status: enums.SIPStatusCanceled.String()},
-						{UUID: sip2UUID, Status: enums.SIPStatusValidated.String()},
+						{
+							UUID:   sip1UUID,
+							Status: enums.SIPStatusCanceled.String(),
+						},
+						{
+							UUID:   sip2UUID,
+							Status: enums.SIPStatusValidated.String(),
+						},
 					}}, nil)
 			},
-			want: &activities.PollSIPStatusesActivityResult{AllExpectedStatus: false},
+			want: &activities.PollSIPStatusesActivityResult{
+				AllExpectedStatus: false,
+				SIPs: map[uuid.UUID]datatypes.SIP{
+					sip1UUID: {UUID: sip1UUID},
+					sip2UUID: {UUID: sip2UUID},
+				},
+			},
 		},
 		{
 			name: "Continues polling when SIPs are not in a final status",
@@ -147,23 +206,47 @@ func TestPollSIPStatusesActivity(t *testing.T) {
 				// First call: SIPs in progress.
 				r.ListSips(mockutil.Context(), payload).
 					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
-						{UUID: sip1UUID, Status: enums.SIPStatusProcessing.String()},
-						{UUID: sip2UUID, Status: enums.SIPStatusQueued.String()},
+						{
+							UUID:   sip1UUID,
+							Status: enums.SIPStatusProcessing.String(),
+						},
+						{
+							UUID:   sip2UUID,
+							Status: enums.SIPStatusQueued.String(),
+						},
 					}}, nil)
 				// Second call: one SIP validated and the other in progress.
 				r.ListSips(mockutil.Context(), payload).
 					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
-						{UUID: sip1UUID, Status: enums.SIPStatusValidated.String()},
-						{UUID: sip2UUID, Status: enums.SIPStatusProcessing.String()},
+						{
+							UUID:   sip1UUID,
+							Status: enums.SIPStatusValidated.String(),
+						},
+						{
+							UUID:   sip2UUID,
+							Status: enums.SIPStatusProcessing.String(),
+						},
 					}}, nil)
 				// Third call: SIPs validated.
 				r.ListSips(mockutil.Context(), payload).
 					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
-						{UUID: sip1UUID, Status: enums.SIPStatusValidated.String()},
-						{UUID: sip2UUID, Status: enums.SIPStatusValidated.String()},
+						{
+							UUID:   sip1UUID,
+							Status: enums.SIPStatusValidated.String(),
+						},
+						{
+							UUID:   sip2UUID,
+							Status: enums.SIPStatusValidated.String(),
+						},
 					}}, nil)
 			},
-			want: &activities.PollSIPStatusesActivityResult{AllExpectedStatus: true},
+			want: &activities.PollSIPStatusesActivityResult{
+				AllExpectedStatus: true,
+				SIPs: map[uuid.UUID]datatypes.SIP{
+					sip1UUID: {UUID: sip1UUID},
+					sip2UUID: {UUID: sip2UUID},
+				},
+			},
 		},
 		{
 			name: "Fails when SIP count doesn't match expected",
@@ -209,26 +292,6 @@ func TestPollSIPStatusesActivity(t *testing.T) {
 					}}, nil)
 			},
 			wantErr: "check SIP statuses: invalid SIP status: unknown",
-		},
-		{
-			name: "Fails on invalid AIP UUID",
-			params: &activities.PollSIPStatusesActivityParams{
-				BatchUUID:        batchUUID,
-				ExpectedSIPCount: 2,
-				ExpectedStatus:   enums.SIPStatusValidated,
-			},
-			mock: func(r *ingestfake.MockServiceMockRecorder) {
-				r.ListSips(mockutil.Context(), payload).
-					Return(&goaingest.SIPs{Items: []*goaingest.SIP{
-						{
-							UUID:    sip1UUID,
-							Status:  enums.SIPStatusIngested.String(),
-							AipUUID: new("invalid-uuid"),
-						},
-						{UUID: sip2UUID, Status: enums.SIPStatusIngested.String()},
-					}}, nil)
-			},
-			wantErr: "check SIP statuses: parse AIP UUID: invalid UUID length: 12",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/workflow/batch.go
+++ b/internal/workflow/batch.go
@@ -155,10 +155,10 @@ func (w *BatchWorkflow) Execute(ctx temporalsdk_workflow.Context, req *ingest.Ba
 	}
 
 	// Update SIP state AIP IDs so they can be used in the post-storage
-	//  workflow.
-	state.updateAIPIDs(pollIngestedResult.SIPIDstoAIPIDs)
+	// workflow.
+	state.updateFromPollIngest(pollIngestedResult.SIPs)
 
-	// Run post-storage child workflow, if one is configured.
+	// Run postbatch child workflow, if one is configured.
 	if w.cfg.ChildWorkflows.ByType(enums.ChildWorkflowTypePostbatch) != nil {
 		if err := w.postbatchWorkflow(ctx, state); err != nil {
 			return err

--- a/internal/workflow/batch_state.go
+++ b/internal/workflow/batch_state.go
@@ -81,11 +81,11 @@ func (s *batchWorkflowState) addSIPDetails(
 func (s *batchWorkflowState) postbatchSIPs() []*childwf.PostbatchSIP {
 	sips := s.SIPs()
 	pbs := make([]*childwf.PostbatchSIP, len(sips))
-
 	for i, sip := range sips {
 		s := &childwf.PostbatchSIP{
-			UUID: sip.UUID,
-			Name: sip.Name,
+			UUID:      sip.UUID,
+			Name:      sip.Name,
+			FileCount: sip.FileCount,
 		}
 		if sip.AIPID.Valid {
 			s.AIPID = &sip.AIPID.UUID
@@ -96,15 +96,13 @@ func (s *batchWorkflowState) postbatchSIPs() []*childwf.PostbatchSIP {
 	return pbs
 }
 
-// updateAIPIDs updates the AIP IDs of the SIPs in the batch workflow state
-// based on the provided map of SIP UUIDs to AIP UUIDs.
-func (state *batchWorkflowState) updateAIPIDs(aipIDs map[uuid.UUID]uuid.UUID) {
+// updateFromPollIngest updates the SIPs state with data from the poll ingest
+// activity result.
+func (state *batchWorkflowState) updateFromPollIngest(sips map[uuid.UUID]datatypes.SIP) {
 	for _, sd := range state.sipDetails {
-		aipID, ok := aipIDs[sd.sip.UUID]
-		if !ok {
-			continue
+		if sip, ok := sips[sd.sip.UUID]; ok {
+			sd.sip.FileCount = sip.FileCount
+			sd.sip.AIPID = sip.AIPID
 		}
-
-		sd.sip.AIPID = uuid.NullUUID{UUID: aipID, Valid: true}
 	}
 }

--- a/internal/workflow/batch_test.go
+++ b/internal/workflow/batch_test.go
@@ -237,9 +237,17 @@ func (s *BatchWorkflowTestSuite) TestBatch() {
 		},
 	).Return(&activities.PollSIPStatusesActivityResult{
 		AllExpectedStatus: true,
-		SIPIDstoAIPIDs: map[uuid.UUID]uuid.UUID{
-			batchSIP1UUID: batchAIP1UUID,
-			batchSIP2UUID: batchAIP2UUID,
+		SIPs: map[uuid.UUID]datatypes.SIP{
+			batchSIP1UUID: {
+				UUID:      batchSIP1UUID,
+				AIPID:     uuid.NullUUID{UUID: batchAIP1UUID, Valid: true},
+				FileCount: 8,
+			},
+			batchSIP2UUID: {
+				UUID:      batchSIP2UUID,
+				AIPID:     uuid.NullUUID{UUID: batchAIP2UUID, Valid: true},
+				FileCount: 16,
+			},
 		},
 	}, nil)
 
@@ -254,14 +262,16 @@ func (s *BatchWorkflowTestSuite) TestBatch() {
 			},
 			SIPs: []*childwf.PostbatchSIP{
 				{
-					UUID:  batchSIP1UUID,
-					Name:  batchSIP1Key,
-					AIPID: &batchAIP1UUID,
+					UUID:      batchSIP1UUID,
+					Name:      batchSIP1Key,
+					AIPID:     &batchAIP1UUID,
+					FileCount: 8,
 				},
 				{
-					UUID:  batchSIP2UUID,
-					Name:  batchSIP2Key,
-					AIPID: &batchAIP2UUID,
+					UUID:      batchSIP2UUID,
+					Name:      batchSIP2Key,
+					AIPID:     &batchAIP2UUID,
+					FileCount: 16,
 				},
 			},
 		},


### PR DESCRIPTION
Refs #1595.

- Get SIP file_count when polling SIP statuses in the batch workflow
- Update the SIP data in the `batch.state` with the DB data return from the `PollSIPStatusesActivity`
- Pass the SIP file counts to the postbatch workflow