### PR TITLE
Support preprocessing workflow decision requests

### DIFF
--- a/internal/childwf/signals.go
+++ b/internal/childwf/signals.go
@@ -1,0 +1,24 @@
+package childwf
+
+const (
+	// DecisionRequestSignalName is sent by a child workflow to its parent when
+	// execution requires a user decision.
+	DecisionRequestSignalName = "decision-request-signal"
+
+	// DecisionResponseSignalName is sent by the parent workflow back to the
+	// child workflow once a decision has been made.
+	DecisionResponseSignalName = "decision-response-signal"
+)
+
+type DecisionRequest struct {
+	// Message is a human-readable description of the decision point.
+	Message string
+
+	// Options is the list of allowed decision values.
+	Options []string
+}
+
+type DecisionResponse struct {
+	// Option is the selected decision value.
+	Option string
+}

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -1054,8 +1055,7 @@ func (w *ProcessingWorkflow) preprocessing(ctx temporalsdk_workflow.Context, sta
 		WorkflowID:        fmt.Sprintf("%s-%s", cfg.WorkflowName, state.sip.uuid.String()),
 		ParentClosePolicy: temporalapi_enums.PARENT_CLOSE_POLICY_TERMINATE,
 	})
-	var ppResult childwf.PreprocessingResult
-	err = temporalsdk_workflow.ExecuteChildWorkflow(
+	childWorkflow := temporalsdk_workflow.ExecuteChildWorkflow(
 		preCtx,
 		cfg.WorkflowName,
 		childwf.PreprocessingParams{
@@ -1064,9 +1064,56 @@ func (w *ProcessingWorkflow) preprocessing(ctx temporalsdk_workflow.Context, sta
 			BatchID:      state.req.BatchUUID,
 			SIPName:      state.sip.name,
 		},
-	).Get(preCtx, &ppResult)
-	if err != nil {
+	)
+
+	var childExecution temporalsdk_workflow.Execution
+	if err := childWorkflow.GetChildWorkflowExecution().Get(preCtx, &childExecution); err != nil {
 		return err
+	}
+
+	var ppResult childwf.PreprocessingResult
+	for {
+		var (
+			err  error
+			req  childwf.DecisionRequest
+			done bool
+		)
+
+		// Wait for either the child workflow to complete or a decision request signal.
+		selector := temporalsdk_workflow.NewSelector(preCtx)
+		selector.AddFuture(childWorkflow, func(f temporalsdk_workflow.Future) {
+			done = true
+			err = f.Get(preCtx, &ppResult)
+		})
+		selector.AddReceive(
+			temporalsdk_workflow.GetSignalChannel(preCtx, childwf.DecisionRequestSignalName),
+			func(c temporalsdk_workflow.ReceiveChannel, more bool) {
+				if open := c.Receive(preCtx, &req); !open {
+					err = errors.New("child workflow decision request channel closed")
+				}
+			},
+		)
+		selector.Select(preCtx)
+
+		if err != nil {
+			return err
+		}
+
+		// If the child workflow completed, break the loop.
+		if done {
+			break
+		}
+
+		// Otherwise, handle the decision request and loop again.
+		if err := w.handleChildDecisionRequest(
+			preCtx,
+			state,
+			"Preprocessing workflow is waiting for user decision",
+			childExecution,
+			req,
+		); err != nil {
+			return err
+		}
 	}
 
 	// Set SIP info from preprocessing result on success.
@@ -1108,6 +1155,128 @@ func (w *ProcessingWorkflow) preprocessing(ctx temporalsdk_workflow.Context, sta
 		state.status = enums.WorkflowStatusError
 		return fmt.Errorf("preprocessing workflow: unknown outcome %d", ppResult.Outcome)
 	}
+}
+
+// handleChildDecisionRequest records a pending child decision, waits for the
+// selected response, and forwards that response to the child execution.
+func (w *ProcessingWorkflow) handleChildDecisionRequest(
+	ctx temporalsdk_workflow.Context,
+	state *workflowState,
+	taskName string,
+	childExecution temporalsdk_workflow.Execution,
+	req childwf.DecisionRequest,
+) (e error) {
+	if strings.TrimSpace(req.Message) == "" {
+		return errors.New("child workflow decision request is missing a message")
+	}
+	if len(req.Options) == 0 {
+		return errors.New("child workflow decision request is missing options")
+	}
+
+	taskNote := req.Message + "\n\nAvailable options:\n- " + strings.Join(req.Options, "\n- ")
+	taskID, err := w.createTask(
+		ctx,
+		&datatypes.Task{
+			Name:         taskName,
+			Status:       enums.TaskStatusPending,
+			Note:         taskNote,
+			WorkflowUUID: state.workflowUUID,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	decision := childwf.DecisionResponse{}
+	defer func() {
+		status := enums.TaskStatusDone
+		note := taskNote + fmt.Sprintf("\n\nUser selected option: %s", decision.Option)
+		if e != nil {
+			status = enums.TaskStatusError
+			note = taskNote + fmt.Sprintf("\n\nSystem error: %v", e)
+		}
+
+		err := w.completeTask(
+			ctx,
+			datatypes.Task{
+				ID:     taskID,
+				Status: status,
+				Note:   note,
+			},
+		)
+		if err != nil {
+			e = errors.Join(e, fmt.Errorf("complete child decision task: %v", err))
+		}
+	}()
+
+	if err := w.updateStatuses(ctx, state, enums.SIPStatusPending, enums.WorkflowStatusPending); err != nil {
+		return err
+	}
+
+	// TODO: Persist/expose the decision request so the API can show it to
+	// the user and submit the selected response back to this workflow.
+	// Use the following command to signal a decision response for testing:
+	// kubectl exec -it -n enduro-sdps deploy/temporal-admintools -- \
+	//   temporal workflow signal \
+	//   --namespace default \
+	//   --workflow-id processing-workflow-<sip-uuid> \
+	//   --name decision-response-signal \
+	//   --input '{"Option":"Continue and overwrite"}'
+	decision, err = w.waitForChildDecisionResponse(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if err := temporalsdk_workflow.SignalExternalWorkflow(
+		ctx,
+		childExecution.ID,
+		childExecution.RunID,
+		childwf.DecisionResponseSignalName,
+		decision,
+	).Get(ctx, nil); err != nil {
+		return err
+	}
+
+	return w.updateStatuses(ctx, state, enums.SIPStatusProcessing, enums.WorkflowStatusInProgress)
+}
+
+func (w *ProcessingWorkflow) updateStatuses(
+	ctx temporalsdk_workflow.Context, state *workflowState, ss enums.SIPStatus, ws enums.WorkflowStatus,
+) error {
+	activityOpts := withLocalActivityOpts(ctx)
+	if err := temporalsdk_workflow.ExecuteLocalActivity(
+		activityOpts,
+		setStatusLocalActivity,
+		w.ingestsvc,
+		state.sip.uuid,
+		ss,
+	).Get(activityOpts, nil); err != nil {
+		return err
+	}
+
+	return temporalsdk_workflow.ExecuteLocalActivity(
+		activityOpts,
+		setWorkflowStatusLocalActivity,
+		w.ingestsvc,
+		state.workflowID,
+		ws,
+	).Get(activityOpts, nil)
+}
+
+// waitForChildDecisionResponse blocks until the parent receives a child decision
+// response signal and rejects any option that was not in the corresponding request.
+func (w *ProcessingWorkflow) waitForChildDecisionResponse(
+	ctx temporalsdk_workflow.Context, req childwf.DecisionRequest,
+) (childwf.DecisionResponse, error) {
+	var decision childwf.DecisionResponse
+	open := temporalsdk_workflow.GetSignalChannel(ctx, childwf.DecisionResponseSignalName).Receive(ctx, &decision)
+	if !open {
+		return childwf.DecisionResponse{}, fmt.Errorf("%s channel closed", childwf.DecisionResponseSignalName)
+	}
+	if !slices.Contains(req.Options, decision.Option) {
+		return childwf.DecisionResponse{}, fmt.Errorf("invalid child workflow decision option %q", decision.Option)
+	}
+	return decision, nil
 }
 
 // poststorage executes the configured poststorage child workflows. It uses

--- a/internal/workflow/processing_setup_test.go
+++ b/internal/workflow/processing_setup_test.go
@@ -52,12 +52,10 @@ type ProcessingWorkflowTestSuite struct {
 	workflow *ProcessingWorkflow
 }
 
-func preprocessingChildWorkflow(
+type preprocessingChildWorkflowFunc func(
 	ctx temporalsdk_workflow.Context,
 	params *childwf.PreprocessingParams,
-) (*childwf.PreprocessingResult, error) {
-	return nil, nil
-}
+) (*childwf.PreprocessingResult, error)
 
 func poststorageChildWorkflow(
 	ctx temporalsdk_workflow.Context,
@@ -72,10 +70,22 @@ func (s *ProcessingWorkflowTestSuite) CreateTransferDir() string {
 	return s.transferDir
 }
 
-func (s *ProcessingWorkflowTestSuite) SetupWorkflowTest(cfg config.Configuration) {
+func (s *ProcessingWorkflowTestSuite) SetupWorkflowTest(
+	cfg config.Configuration,
+	preprocessingChildWorkflowFn preprocessingChildWorkflowFunc,
+) {
 	s.env = s.NewTestWorkflowEnvironment()
 	s.env.SetWorkerOptions(temporalsdk_worker.Options{EnableSessionWorker: true})
 	s.env.SetStartTime(startTime)
+
+	if preprocessingChildWorkflowFn == nil {
+		preprocessingChildWorkflowFn = func(
+			ctx temporalsdk_workflow.Context,
+			params *childwf.PreprocessingParams,
+		) (*childwf.PreprocessingResult, error) {
+			return nil, nil
+		}
+	}
 
 	ctrl := gomock.NewController(s.T())
 	ingestsvc := ingest_fake.NewMockService(ctrl)
@@ -160,7 +170,7 @@ func (s *ProcessingWorkflowTestSuite) SetupWorkflowTest(cfg config.Configuration
 	)
 
 	s.env.RegisterWorkflowWithOptions(
-		preprocessingChildWorkflow,
+		preprocessingChildWorkflowFn,
 		temporalsdk_workflow.RegisterOptions{Name: "preprocessing"},
 	)
 	s.env.RegisterWorkflowWithOptions(

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	temporalsdk_workflow "go.temporal.io/sdk/workflow"
 
 	"github.com/artefactual-sdps/enduro/internal/a3m"
 	"github.com/artefactual-sdps/enduro/internal/am"
@@ -45,7 +46,7 @@ func (s *ProcessingWorkflowTestSuite) TestConfirmation() {
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
 		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
-	})
+	}, nil)
 
 	// Signal handler that mimics SIP/AIP confirmation.
 	s.env.RegisterDelayedCallback(
@@ -102,7 +103,7 @@ func (s *ProcessingWorkflowTestSuite) TestRejection() {
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
 		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
-	})
+	}, nil)
 
 	// Signal handler that mimics SIP/AIP rejection.
 	s.env.RegisterDelayedCallback(
@@ -154,7 +155,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
 		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
-	})
+	}, nil)
 
 	params := defaultParams()
 	downloadExpectations(s, params)
@@ -190,7 +191,7 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 		Preservation:   pres.Config{TaskQueue: temporal.AmWorkerTaskQueue},
 		Ingest:         ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: amssLocationID}},
 		ValidatePREMIS: premis.Config{Enabled: true, XSDPath: "/home/enduro/premis.xsd"},
-	})
+	}, nil)
 
 	params := defaultParams()
 	downloadExpectations(s, params)
@@ -318,7 +319,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 				WorkflowName: "poststorage",
 			},
 		},
-	})
+	}, nil)
 
 	params := defaultParams()
 	params.downloadDestPath = prepSharedPath
@@ -327,7 +328,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	downloadExpectations(s, params)
 
 	s.env.OnWorkflow(
-		preprocessingChildWorkflow,
+		"preprocessing",
 		internalCtx,
 		&childwf.PreprocessingParams{
 			RelativePath: strings.TrimPrefix(prepDownloadPath+"/"+key, prepSharedPath),
@@ -401,6 +402,124 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	}, false)
 }
 
+// TestPreprocessingDecisionFlow tests:
+// - a3m as preservation system.
+// - The "create AIP" workflow type.
+// - preprocessing child workflow requesting a human decision from the parent.
+// - parent signaling the selected option back to the child.
+func (s *ProcessingWorkflowTestSuite) TestPreprocessingDecisionFlow() {
+	const preprocessingDecisionTaskID = 109
+
+	s.SetupWorkflowTest(config.Configuration{
+		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
+		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
+		ChildWorkflows: childwf.Configs{
+			{
+				Type:         enums.ChildWorkflowTypePreprocessing,
+				Namespace:    "default",
+				TaskQueue:    "preprocessing",
+				WorkflowName: "preprocessing",
+				Extract:      true,
+				SharedPath:   prepSharedPath,
+			},
+		},
+	}, func(
+		ctx temporalsdk_workflow.Context,
+		params *childwf.PreprocessingParams,
+	) (*childwf.PreprocessingResult, error) {
+		parent := temporalsdk_workflow.GetInfo(ctx).ParentWorkflowExecution
+		err := temporalsdk_workflow.SignalExternalWorkflow(
+			ctx,
+			parent.ID,
+			parent.RunID,
+			childwf.DecisionRequestSignalName,
+			childwf.DecisionRequest{
+				Message: "Preprocessing requires human decision.",
+				Options: []string{"Cancel", "Continue"},
+			},
+		).Get(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var decision childwf.DecisionResponse
+		_ = temporalsdk_workflow.GetSignalChannel(ctx, childwf.DecisionResponseSignalName).Receive(ctx, &decision)
+		s.Equal(decision.Option, "Continue")
+
+		return &childwf.PreprocessingResult{
+			Outcome:      childwf.OutcomeSuccess,
+			RelativePath: strings.TrimPrefix(prepExtractPath, prepSharedPath),
+		}, nil
+	})
+
+	s.env.RegisterDelayedCallback(func() {
+		s.env.SignalWorkflow(
+			childwf.DecisionResponseSignalName,
+			childwf.DecisionResponse{Option: "Continue"},
+		)
+	}, 0)
+
+	params := defaultParams()
+	params.downloadDestPath = prepSharedPath
+	params.downloadPath = prepDownloadPath + "/" + key
+	params.extractPath = prepExtractPath
+	downloadExpectations(s, params)
+
+	params.updateTaskParams(
+		preprocessingDecisionTaskID,
+		enums.TaskStatusPending,
+		"Preprocessing workflow is waiting for user decision",
+		"Preprocessing requires human decision.\n\nAvailable options:\n- Cancel\n- Continue",
+	)
+	expectations["createTask"](s, params)
+	params.sipStatus = enums.SIPStatusPending
+	expectations["setStatus"](s, params)
+	params.workflowStatus = enums.WorkflowStatusPending
+	expectations["setWorkflowStatus"](s, params)
+	params.sipStatus = enums.SIPStatusProcessing
+	expectations["setStatus"](s, params)
+	params.workflowStatus = enums.WorkflowStatusInProgress
+	expectations["setWorkflowStatus"](s, params)
+	params.updateTaskParams(
+		preprocessingDecisionTaskID,
+		enums.TaskStatusDone,
+		"",
+		"Preprocessing requires human decision.\n\nAvailable options:\n- Cancel\n- Continue\n\nUser selected option: Continue",
+	)
+	expectations["completeTask"](s, params)
+
+	params.sipType = enums.SIPTypeBagIt
+	expectations["classifySIP"](s, params)
+	params.updateTaskParams(valBagTaskID, enums.TaskStatusInProgress, "Validate Bag", "")
+	expectations["createTask"](s, params)
+	expectations["validateBag"](s, params)
+	params.updateTaskParams(valBagTaskID, enums.TaskStatusDone, "", "Bag successfully validated")
+	expectations["completeTask"](s, params)
+	CountSIPFilesExpectations(s, params)
+	s.env.OnActivity(
+		updateSIPLocalActivity,
+		ctx,
+		s.workflow.ingestsvc,
+		&updateSIPLocalActivityParams{
+			UUID:      sipUUID,
+			FileCount: fileCount,
+		},
+	).Return(nil, nil)
+	autoApproveA3mExpectations(s, params)
+	params.removePaths = []string{prepDownloadPath, transferPath}
+	cleanupExpectations(s, params)
+
+	s.ExecuteAndValidateWorkflow(&ingest.ProcessingWorkflowRequest{
+		WatcherName:     watcherName,
+		RetentionPeriod: retentionPeriod,
+		Type:            enums.WorkflowTypeCreateAip,
+		Key:             key,
+		SIPUUID:         sipUUID,
+		SIPName:         sipName,
+	}, false)
+}
+
 // TestFailedSIP tests:
 // - a3m as preservation system.
 // - The "create AIP" workflow type.
@@ -423,7 +542,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 				SharedPath:   prepSharedPath,
 			},
 		},
-	})
+	}, nil)
 
 	params := defaultParams()
 	params.downloadDestPath = prepSharedPath
@@ -432,7 +551,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 
 	// Fail the workflow on preprocessing.
 	s.env.OnWorkflow(
-		preprocessingChildWorkflow,
+		"preprocessing",
 		internalCtx,
 		&childwf.PreprocessingParams{
 			RelativePath: strings.TrimPrefix(prepDownloadPath+"/"+key, prepSharedPath),
@@ -479,7 +598,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPA3m() {
 		Preservation:   pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
 		Ingest:         ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
 		ValidatePREMIS: premis.Config{Enabled: true, XSDPath: "/home/enduro/premis.xsd"},
-	})
+	}, nil)
 
 	params := defaultParams()
 	downloadExpectations(s, params)
@@ -546,7 +665,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPAM() {
 		AM:           am.Config{ZipPIP: true},
 		Preservation: pres.Config{TaskQueue: temporal.AmWorkerTaskQueue},
 		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: amssLocationID}},
-	})
+	}, nil)
 
 	params := defaultParams()
 	downloadExpectations(s, params)
@@ -593,7 +712,7 @@ func (s *ProcessingWorkflowTestSuite) TestInternalUpload() {
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
 		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
-	})
+	}, nil)
 
 	params := defaultParams()
 	expectations["setStatusInProgress"](s, params)
@@ -663,7 +782,7 @@ func (s *ProcessingWorkflowTestSuite) TestInternalUploadError() {
 				SharedPath:   prepSharedPath,
 			},
 		},
-	})
+	}, nil)
 
 	downloadDir := filepath.Join(prepSharedPath, sipUUID.String())
 	params := defaultParams()
@@ -731,7 +850,7 @@ func (s *ProcessingWorkflowTestSuite) TestSIPSourceUpload() {
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
 		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
-	})
+	}, nil)
 
 	params := defaultParams()
 	expectations["setStatusInProgress"](s, params)
@@ -794,7 +913,7 @@ func (s *ProcessingWorkflowTestSuite) TestSIPDeletionError() {
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
 		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
-	})
+	}, nil)
 
 	params := defaultParams()
 	downloadExpectations(s, params)
@@ -850,7 +969,7 @@ func (s *ProcessingWorkflowTestSuite) TestBatchSignalDoNotContinue() {
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
 		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
-	})
+	}, nil)
 
 	params := defaultParams()
 	downloadExpectations(s, params)


### PR DESCRIPTION
Handle decision requests from the preprocessing child workflow while the processing workflow waits for it to complete. Add decision signal names and payload types, record a pending decision task, update SIP and workflow statuses, and forward the selected response back to preprocessing.

Refs #1536.