### PR TITLE
Load Tiltfile from child workflow paths

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -89,13 +89,12 @@ yaml = add_enduro_config_secret(yaml)
 
 # The CHILD_WORKFLOW_PATHS environment variable is a colon-separated list of 
 # paths to child workflow directories. If set, we load each child workflow's
-# Tiltfile.enduro to load resources required by the workflow (e.g. a Temporal 
-# worker).
+# Tiltfile to load resources required by the workflow (e.g. a Temporal worker).
 CHILD_WORKFLOW_PATHS = os.environ.get("CHILD_WORKFLOW_PATHS", "")
 if CHILD_WORKFLOW_PATHS != "":
   for path in CHILD_WORKFLOW_PATHS.split(":"):
     # Load child workflow Tiltfile for Enduro
-    load_dynamic(path.strip() + "/Tiltfile.enduro")
+    load_dynamic(path.strip() + "/Tiltfile")
 
 # The preprocessing child workflow requires extra setup for a shared directory
 MOUNT_PREPROCESSING_VOLUME = os.environ.get("MOUNT_PREPROCESSING_VOLUME", "")

--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -234,8 +234,8 @@ image target and serves the dashboard with Nginx.
 ### CHILD_WORKFLOW_PATHS
 
 A colon (:) separated list of relative paths to child workflow repositories. At
-startup Tilt will attempt to load a `Tiltfile.enduro` file from each path which
-will add any workflow specific resources to the Tilt environment (e.g. a child
+startup Tilt will attempt to load a `Tiltfile` file from each path which will
+add any workflow specific resources to the Tilt environment (e.g. a child
 worker). See the [Administrator configuration] docs for instructions on
 configuring the child workflows.
 


### PR DESCRIPTION
We are removing the standalone Tilt environment in the child workflow repositories, so we are dropping the `.enduro` suffix from the Tiltfile expected by Enduro. See:

- https://github.com/artefactual-sdps/preprocessing-base/pull/28
- https://github.com/artefactual-sdps/preprocessing-sfa/pull/195
- https://github.com/artefactual-sdps/cva-enduro-workflows/pull/31
- https://github.com/artefactual-sdps/preprocessing-moma/pull/28