### PR TITLE
Pass custom preprocessing metadata to poststorage

### DIFF
--- a/internal/childwf/poststorage.go
+++ b/internal/childwf/poststorage.go
@@ -1,5 +1,10 @@
 package childwf
 
+import "encoding/json"
+
 type PostStorageParams struct {
 	AIPUUID string
+
+	// CustomMetadata is opaque metadata returned by earlier child workflows.
+	CustomMetadata map[string]json.RawMessage
 }

--- a/internal/childwf/preprocessing.go
+++ b/internal/childwf/preprocessing.go
@@ -1,6 +1,10 @@
 package childwf
 
-import "github.com/google/uuid"
+import (
+	"encoding/json"
+
+	"github.com/google/uuid"
+)
 
 type PreprocessingParams struct {
 	// Relative path to the shared path.
@@ -21,6 +25,9 @@ type PreprocessingResult struct {
 	// Outcome is an integer indicating if the workflow completed successfully,
 	// or with errors.
 	Outcome Outcome
+
+	// CustomMetadata is opaque metadata to carry to later child workflows.
+	CustomMetadata map[string]json.RawMessage
 
 	// Relative path to the shared path.
 	RelativePath string

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -854,7 +854,7 @@ func (w *ProcessingWorkflow) transferA3m(
 			}
 		}
 
-		if err := w.poststorage(sessCtx, state.aip.id); err != nil {
+		if err := w.poststorage(sessCtx, state); err != nil {
 			return sessCtx, err
 		}
 	} else if state.req.Type == enums.WorkflowTypeCreateAndReviewAip {
@@ -1056,7 +1056,7 @@ func (w *ProcessingWorkflow) transferAM(
 		}
 	}
 
-	if err := w.poststorage(sessCtx, state.aip.id); err != nil {
+	if err := w.poststorage(sessCtx, state); err != nil {
 		return sessCtx, err
 	}
 
@@ -1162,6 +1162,7 @@ func (w *ProcessingWorkflow) preprocessing(ctx temporalsdk_workflow.Context, sta
 		state.sip.path = filepath.Join(cfg.SharedPath, filepath.Clean(ppResult.RelativePath))
 		state.sip.isDir = true
 		state.sip.transformed = true
+		state.customMetadata = ppResult.CustomMetadata
 	}
 
 	// Save preprocessing task data.
@@ -1320,7 +1321,7 @@ func (w *ProcessingWorkflow) waitForChildDecisionResponse(
 // poststorage executes the configured poststorage child workflows. It uses
 // a disconnected context, abandon as parent close policy and only waits
 // until the workflows are started, ignoring their results.
-func (w *ProcessingWorkflow) poststorage(ctx temporalsdk_workflow.Context, aipUUID string) error {
+func (w *ProcessingWorkflow) poststorage(ctx temporalsdk_workflow.Context, state *workflowState) error {
 	cfg := w.cfg.ChildWorkflows.ByType(enums.ChildWorkflowTypePoststorage)
 	if cfg == nil {
 		return nil
@@ -1332,14 +1333,17 @@ func (w *ProcessingWorkflow) poststorage(ctx temporalsdk_workflow.Context, aipUU
 		temporalsdk_workflow.ChildWorkflowOptions{
 			Namespace:         cfg.Namespace,
 			TaskQueue:         cfg.TaskQueue,
-			WorkflowID:        fmt.Sprintf("%s-%s", cfg.WorkflowName, aipUUID),
+			WorkflowID:        fmt.Sprintf("%s-%s", cfg.WorkflowName, state.aip.id),
 			ParentClosePolicy: temporalapi_enums.PARENT_CLOSE_POLICY_ABANDON,
 		},
 	)
 	err := temporalsdk_workflow.ExecuteChildWorkflow(
 		ctx,
 		cfg.WorkflowName,
-		childwf.PostStorageParams{AIPUUID: aipUUID},
+		childwf.PostStorageParams{
+			AIPUUID:        state.aip.id,
+			CustomMetadata: state.customMetadata,
+		},
 	).GetChildWorkflowExecution().Get(ctx, nil)
 
 	return err

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -294,6 +295,7 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 // - a3m as preservation system.
 // - The "create AIP" workflow type.
 // - preprocessing child workflow.
+// - custom metadata from preprocessing to poststorage.
 // - poststorage child workflows.
 // - Bag validation.
 // - Watched bucket download.
@@ -326,6 +328,10 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	params.downloadPath = prepDownloadPath + "/" + key
 	params.extractPath = prepExtractPath
 	downloadExpectations(s, params)
+	customMetadata := map[string]json.RawMessage{
+		"external_id": json.RawMessage(`"12345"`),
+		"flags":       json.RawMessage(`{"validated":true}`),
+	}
 
 	s.env.OnWorkflow(
 		"preprocessing",
@@ -337,8 +343,9 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 		},
 	).Return(
 		&childwf.PreprocessingResult{
-			Outcome:      childwf.OutcomeSuccess,
-			RelativePath: strings.TrimPrefix(prepExtractPath, prepSharedPath),
+			Outcome:        childwf.OutcomeSuccess,
+			CustomMetadata: customMetadata,
+			RelativePath:   strings.TrimPrefix(prepExtractPath, prepSharedPath),
 			PreservationTasks: []childwf.Task{
 				{
 					Name:        "Identify SIP structure",
@@ -385,7 +392,10 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	s.env.OnWorkflow(
 		"poststorage",
 		internalCtx,
-		&childwf.PostStorageParams{AIPUUID: aipUUID.String()},
+		&childwf.PostStorageParams{
+			AIPUUID:        aipUUID.String(),
+			CustomMetadata: customMetadata,
+		},
 	).Return(nil, nil)
 
 	params.removePaths = []string{prepDownloadPath, transferPath}

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"encoding/json"
 	"slices"
 
 	"github.com/google/uuid"
@@ -41,6 +42,9 @@ type workflowState struct {
 	// sip and aip track the state of the respective packages.
 	sip *sipInfo
 	aip *aipInfo
+
+	// customMetadata is opaque metadata shared between child workflows.
+	customMetadata map[string]json.RawMessage
 
 	// childDecisionRequest tracks an active child workflow decision request.
 	childDecisionRequest *childwf.DecisionRequest


### PR DESCRIPTION
Carry opaque custom metadata returned by the preprocessing child workflow in processing workflow state and pass it to the poststorage child workflow params.

Refs #1621.