### PR TITLE
Pass custom metadata to postbatch

### DIFF
--- a/internal/childwf/childwf.go
+++ b/internal/childwf/childwf.go
@@ -1,5 +1,7 @@
 package childwf
 
+import "encoding/json"
+
 // Outcome is a status code indicating the overall result of the child
 // workflow, with 0 being reserved for success, 1 indicating a critical system
 // error, and 2 indicating a non-critical content error. Further outcome codes
@@ -11,3 +13,6 @@ const (
 	OutcomeSystemError
 	OutcomeContentError
 )
+
+// CustomMetadata is opaque JSON metadata carried between child workflows.
+type CustomMetadata map[string]json.RawMessage

--- a/internal/childwf/postbatch.go
+++ b/internal/childwf/postbatch.go
@@ -22,6 +22,9 @@ type PostbatchSIP struct {
 	Name      string
 	AIPID     *uuid.UUID // Nullable.
 	FileCount int32
+
+	// CustomMetadata is opaque metadata returned by the processing workflow.
+	CustomMetadata CustomMetadata
 }
 
 type PostbatchResult struct {

--- a/internal/childwf/poststorage.go
+++ b/internal/childwf/poststorage.go
@@ -1,12 +1,10 @@
 package childwf
 
-import "encoding/json"
-
 type PostStorageParams struct {
 	AIPUUID string
 
 	// CustomMetadata is opaque metadata returned by earlier child workflows.
-	CustomMetadata map[string]json.RawMessage
+	CustomMetadata CustomMetadata
 }
 
 type PostStorageResult struct {
@@ -15,7 +13,7 @@ type PostStorageResult struct {
 	Outcome Outcome
 
 	// CustomMetadata is opaque metadata to carry to later child workflows.
-	CustomMetadata map[string]json.RawMessage
+	CustomMetadata CustomMetadata
 
 	// PreservationTasks is a log of the tasks performed by poststorage.
 	PreservationTasks []Task

--- a/internal/childwf/preprocessing.go
+++ b/internal/childwf/preprocessing.go
@@ -1,10 +1,6 @@
 package childwf
 
-import (
-	"encoding/json"
-
-	"github.com/google/uuid"
-)
+import "github.com/google/uuid"
 
 type PreprocessingParams struct {
 	// Relative path to the shared path.
@@ -27,7 +23,7 @@ type PreprocessingResult struct {
 	Outcome Outcome
 
 	// CustomMetadata is opaque metadata to carry to later child workflows.
-	CustomMetadata map[string]json.RawMessage
+	CustomMetadata CustomMetadata
 
 	// Relative path to the shared path.
 	RelativePath string

--- a/internal/ingest/workflows.go
+++ b/internal/ingest/workflows.go
@@ -9,6 +9,7 @@ import (
 	temporalsdk_api_enums "go.temporal.io/api/enums/v1"
 	temporalsdk_client "go.temporal.io/sdk/client"
 
+	"github.com/artefactual-sdps/enduro/internal/childwf"
 	"github.com/artefactual-sdps/enduro/internal/datatypes"
 	"github.com/artefactual-sdps/enduro/internal/enums"
 )
@@ -98,6 +99,13 @@ type (
 
 		// BatchUUID is the UUID of the batch this SIP belongs to, if any.
 		BatchUUID uuid.UUID
+	}
+
+	// ProcessingWorkflowResult is returned by the SIP processing workflow to
+	// the batch workflow.
+	ProcessingWorkflowResult struct {
+		// CustomMetadata is opaque metadata to carry to later child workflows.
+		CustomMetadata childwf.CustomMetadata
 	}
 
 	ReviewPerformedSignal struct {

--- a/internal/workflow/batch.go
+++ b/internal/workflow/batch.go
@@ -100,7 +100,10 @@ func (w *BatchWorkflow) Execute(ctx temporalsdk_workflow.Context, req *ingest.Ba
 	// TODO: consider errors in child workflows and handle failures, retries, or compensations.
 
 	defer func() {
-		// Always wait for all SIP workflows to complete from this point.
+		// If the batch workflow returns early after starting SIP workflows, still
+		// wait for them to finish. A final SIP status update is not necessarily
+		// the end of the processing workflow because it may still need to run
+		// cleanup operations.
 		if err := w.waitForWorkflowsCompletion(ctx, state); err != nil {
 			e = errors.Join(e, err)
 		}
@@ -157,6 +160,12 @@ func (w *BatchWorkflow) Execute(ctx temporalsdk_workflow.Context, req *ingest.Ba
 	// Update SIP state AIP IDs so they can be used in the post-storage
 	// workflow.
 	state.updateFromPollIngest(pollIngestedResult.SIPs)
+
+	// On the successful path, wait for processing workflow results before
+	// constructing postbatch params so opaque SIP metadata can be forwarded.
+	if err := w.waitForWorkflowsCompletion(ctx, state); err != nil {
+		return err
+	}
 
 	// Run postbatch child workflow, if one is configured.
 	if w.cfg.ChildWorkflows.ByType(enums.ChildWorkflowTypePostbatch) != nil {
@@ -305,11 +314,17 @@ func (w *BatchWorkflow) waitForBatchDecision(ctx temporalsdk_workflow.Context, s
 }
 
 func (w *BatchWorkflow) waitForWorkflowsCompletion(ctx temporalsdk_workflow.Context, state *batchWorkflowState) error {
+	if state.workflowsCompleted {
+		return nil
+	}
+
 	selector := temporalsdk_workflow.NewSelector(ctx)
 	for _, sd := range state.sipDetails {
 		selector.AddFuture(sd.workflowFuture, func(f temporalsdk_workflow.Future) {
-			// Ignore error and result, we just want to know when it's done.
-			_ = f.Get(ctx, nil)
+			var res ingest.ProcessingWorkflowResult
+			if err := f.Get(ctx, &res); err == nil {
+				sd.customMetadata = res.CustomMetadata
+			}
 		})
 	}
 
@@ -321,6 +336,8 @@ func (w *BatchWorkflow) waitForWorkflowsCompletion(ctx temporalsdk_workflow.Cont
 			return fmt.Errorf("waiting for workflows: %v", err)
 		}
 	}
+
+	state.workflowsCompleted = true
 
 	return nil
 }

--- a/internal/workflow/batch_state.go
+++ b/internal/workflow/batch_state.go
@@ -21,6 +21,12 @@ type batchWorkflowState struct {
 
 	// sipDetails contains details for each SIP in the batch.
 	sipDetails []*sipDetails
+
+	// workflowsCompleted prevents consuming child processing workflow futures
+	// twice. The batch workflow waits explicitly before postbatch to collect
+	// processing results, and also defers a wait to let child workflows finish
+	// cleanup after they have reported final SIP statuses.
+	workflowsCompleted bool
 }
 
 // sipDetails holds information about a single SIP within a batch workflow.
@@ -34,6 +40,9 @@ type sipDetails struct {
 
 	// workflowExecution contains the execution details of the child workflow.
 	workflowExecution temporalsdk_workflow.Execution
+
+	// customMetadata is opaque metadata returned by the processing workflow.
+	customMetadata childwf.CustomMetadata
 }
 
 // newBatchWorkflowState initializes a new batchWorkflowState with the given
@@ -56,14 +65,6 @@ func (s *batchWorkflowState) PostbatchParams() *childwf.PostbatchParams {
 	}
 }
 
-func (s *batchWorkflowState) SIPs() []datatypes.SIP {
-	sips := make([]datatypes.SIP, len(s.sipDetails))
-	for i, sd := range s.sipDetails {
-		sips[i] = sd.sip
-	}
-	return sips
-}
-
 // addSIPDetails adds a new sipDetails entry to the batchWorkflowState at the specified index.
 func (s *batchWorkflowState) addSIPDetails(
 	index int,
@@ -79,16 +80,16 @@ func (s *batchWorkflowState) addSIPDetails(
 }
 
 func (s *batchWorkflowState) postbatchSIPs() []*childwf.PostbatchSIP {
-	sips := s.SIPs()
-	pbs := make([]*childwf.PostbatchSIP, len(sips))
-	for i, sip := range sips {
+	pbs := make([]*childwf.PostbatchSIP, len(s.sipDetails))
+	for i, sd := range s.sipDetails {
 		s := &childwf.PostbatchSIP{
-			UUID:      sip.UUID,
-			Name:      sip.Name,
-			FileCount: sip.FileCount,
+			UUID:           sd.sip.UUID,
+			Name:           sd.sip.Name,
+			FileCount:      sd.sip.FileCount,
+			CustomMetadata: sd.customMetadata,
 		}
-		if sip.AIPID.Valid {
-			s.AIPID = &sip.AIPID.UUID
+		if sd.sip.AIPID.Valid {
+			s.AIPID = &sd.sip.AIPID.UUID
 		}
 		pbs[i] = s
 	}

--- a/internal/workflow/batch_test.go
+++ b/internal/workflow/batch_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -51,6 +52,9 @@ type BatchWorkflowTestSuite struct {
 
 	// childSignals holds the signals received by the child processing workflows.
 	childSignals []ingest.BatchSignal
+
+	// childResults holds the results returned by child processing workflows.
+	childResults map[uuid.UUID]*ingest.ProcessingWorkflowResult
 }
 
 func (s *BatchWorkflowTestSuite) SetupWorkflowTest(cfg config.Configuration) {
@@ -85,13 +89,17 @@ func (s *BatchWorkflowTestSuite) SetupWorkflowTest(cfg config.Configuration) {
 // used in tests to capture requests and signals.
 func (s *BatchWorkflowTestSuite) processingChildWorkflow(
 	ctx temporalsdk_workflow.Context, req *ingest.ProcessingWorkflowRequest,
-) error {
+) (*ingest.ProcessingWorkflowResult, error) {
 	s.childRequests = append(s.childRequests, *req)
 	var signal ingest.BatchSignal
 	_ = temporalsdk_workflow.GetSignalChannel(ctx, ingest.BatchSignalName).Receive(ctx, &signal)
 	s.childSignals = append(s.childSignals, signal)
 
-	return nil
+	if res := s.childResults[req.SIPUUID]; res != nil {
+		return res, nil
+	}
+
+	return &ingest.ProcessingWorkflowResult{}, nil
 }
 
 // postBatchChildWorkflow is a no-op workflow that will be replaced with a
@@ -107,6 +115,7 @@ func (s *BatchWorkflowTestSuite) AfterTest(suiteName, testName string) {
 	s.env.AssertExpectations(s.T())
 	s.childRequests = nil
 	s.childSignals = nil
+	s.childResults = nil
 }
 
 // ExecuteAndValidateWorkflow executes the batch workflow with the given request,
@@ -158,6 +167,18 @@ func (s *BatchWorkflowTestSuite) TestBatch() {
 		},
 	}
 	s.SetupWorkflowTest(cfg)
+	s.childResults = map[uuid.UUID]*ingest.ProcessingWorkflowResult{
+		batchSIP1UUID: {
+			CustomMetadata: childwf.CustomMetadata{
+				"external_id": json.RawMessage(`"sip-1"`),
+			},
+		},
+		batchSIP2UUID: {
+			CustomMetadata: childwf.CustomMetadata{
+				"external_id": json.RawMessage(`"sip-2"`),
+			},
+		},
+	}
 
 	// Mock initial batch status update.
 	s.env.OnActivity(
@@ -266,12 +287,18 @@ func (s *BatchWorkflowTestSuite) TestBatch() {
 					Name:      batchSIP1Key,
 					AIPID:     &batchAIP1UUID,
 					FileCount: 8,
+					CustomMetadata: childwf.CustomMetadata{
+						"external_id": json.RawMessage(`"sip-1"`),
+					},
 				},
 				{
 					UUID:      batchSIP2UUID,
 					Name:      batchSIP2Key,
 					AIPID:     &batchAIP2UUID,
 					FileCount: 16,
+					CustomMetadata: childwf.CustomMetadata{
+						"external_id": json.RawMessage(`"sip-2"`),
+					},
 				},
 			},
 		},

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -3,7 +3,6 @@
 package workflow
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -210,11 +209,14 @@ func (w *ProcessingWorkflow) sessionCleanup(ctx temporalsdk_workflow.Context, st
 // Retrying this workflow would result in a new Archivematica transfer. We  do
 // not have a retry policy in place. The user could trigger a new instance via
 // the API.
-func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *ingest.ProcessingWorkflowRequest) error {
+func (w *ProcessingWorkflow) Execute(
+	ctx temporalsdk_workflow.Context,
+	req *ingest.ProcessingWorkflowRequest,
+) (*ingest.ProcessingWorkflowResult, error) {
 	// Create the initial workflow state.
 	state := newWorkflowState(ctx, req)
 	if err := w.registerChildDecisionHandlers(ctx, state); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Persist the SIP as early as possible if the request comes from a watcher.
@@ -233,7 +235,7 @@ func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *inge
 			},
 		).Get(activityOpts, nil)
 		if err != nil {
-			return fmt.Errorf("error persisting SIP: %v", err)
+			return nil, fmt.Errorf("error persisting SIP: %v", err)
 		}
 	}
 
@@ -256,7 +258,7 @@ func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *inge
 				ExecutionTimeout: forever,
 			})
 			if err != nil {
-				return fmt.Errorf("error creating session: %v", err)
+				return nil, fmt.Errorf("error creating session: %v", err)
 			}
 
 			sessErr = w.SessionHandler(ctx, sessCtx, attempt, state)
@@ -269,7 +271,7 @@ func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *inge
 				(errors.Is(sessErr, temporalsdk_workflow.ErrSessionFailed) || temporalsdk_temporal.IsCanceledError(sessErr)) {
 				// Root context canceled, hence workflow canceled.
 				if ctx.Err() == temporalsdk_workflow.ErrCanceled {
-					return nil
+					return &ingest.ProcessingWorkflowResult{}, nil
 				}
 
 				state.logger.Error(
@@ -287,12 +289,12 @@ func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *inge
 		}
 
 		if sessErr != nil {
-			return sessErr
+			return nil, sessErr
 		}
 	}
 
 	if state.status != enums.WorkflowStatusDone {
-		return nil
+		return &ingest.ProcessingWorkflowResult{}, nil
 	}
 
 	// Schedule deletion or disposal of the original SIP.
@@ -323,7 +325,9 @@ func (w *ProcessingWorkflow) Execute(ctx temporalsdk_workflow.Context, req *inge
 		"status", state.status,
 	)
 
-	return nil
+	return &ingest.ProcessingWorkflowResult{
+		CustomMetadata: state.customMetadata,
+	}, nil
 }
 
 // SessionHandler runs activities that belong to the same session.
@@ -1328,14 +1332,14 @@ func (w *ProcessingWorkflow) savePreservationTasks(
 }
 
 func mergeCustomMetadata(
-	base map[string]json.RawMessage,
-	override map[string]json.RawMessage,
-) map[string]json.RawMessage {
+	base childwf.CustomMetadata,
+	override childwf.CustomMetadata,
+) childwf.CustomMetadata {
 	if len(override) == 0 {
 		return base
 	}
 	if base == nil {
-		base = make(map[string]json.RawMessage, len(override))
+		base = make(childwf.CustomMetadata, len(override))
 	}
 
 	for _, k := range temporalsdk_workflow.DeterministicKeys(override) {

--- a/internal/workflow/processing_setup_test.go
+++ b/internal/workflow/processing_setup_test.go
@@ -272,13 +272,17 @@ func (s *ProcessingWorkflowTestSuite) AfterTest(suiteName, testName string) {
 
 func (s *ProcessingWorkflowTestSuite) ExecuteAndValidateWorkflow(
 	req *ingest.ProcessingWorkflowRequest,
+	expected *ingest.ProcessingWorkflowResult,
 	shouldError bool,
 ) {
 	s.env.ExecuteWorkflow(s.workflow.Execute, req)
 	s.True(s.env.IsWorkflowCompleted())
 	if shouldError {
 		s.Error(s.env.GetWorkflowResult(nil))
-	} else {
-		s.NoError(s.env.GetWorkflowResult(nil))
+		return
 	}
+
+	var res ingest.ProcessingWorkflowResult
+	s.NoError(s.env.GetWorkflowResult(&res))
+	s.Equal(expected, &res)
 }

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -90,7 +90,7 @@ func (s *ProcessingWorkflowTestSuite) TestConfirmation() {
 		Type:            enums.WorkflowTypeCreateAndReviewAip,
 		SIPUUID:         sipUUID,
 		SIPName:         sipName,
-	}, false)
+	}, &ingest.ProcessingWorkflowResult{}, false)
 }
 
 // TestRejection tests:
@@ -143,7 +143,7 @@ func (s *ProcessingWorkflowTestSuite) TestRejection() {
 		Type:            enums.WorkflowTypeCreateAndReviewAip,
 		SIPUUID:         sipUUID,
 		SIPName:         sipName,
-	}, false)
+	}, &ingest.ProcessingWorkflowResult{}, false)
 }
 
 // TestAutoApprovedAIP tests:
@@ -175,7 +175,7 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 		Type:            enums.WorkflowTypeCreateAip,
 		SIPUUID:         sipUUID,
 		SIPName:         sipName,
-	}, false)
+	}, &ingest.ProcessingWorkflowResult{}, false)
 }
 
 // TestAMWorkflow tests:
@@ -288,7 +288,7 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 		SIPUUID:         sipUUID,
 		SIPName:         sipName,
 		BatchUUID:       batchUUID,
-	}, false)
+	}, &ingest.ProcessingWorkflowResult{}, false)
 }
 
 // TestChildWorkflows tests:
@@ -328,9 +328,13 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	params.downloadPath = prepDownloadPath + "/" + key
 	params.extractPath = prepExtractPath
 	downloadExpectations(s, params)
-	customMetadata := map[string]json.RawMessage{
+	preprocessingMetadata := childwf.CustomMetadata{
 		"external_id": json.RawMessage(`"12345"`),
 		"flags":       json.RawMessage(`{"validated":true}`),
+	}
+	poststorageMetadata := childwf.CustomMetadata{
+		"package": json.RawMessage(`{"type":"aip","identifier":"AIP-67890"}`),
+		"storage": json.RawMessage(`{"notified":true,"location":"permanent"}`),
 	}
 
 	s.env.OnWorkflow(
@@ -344,7 +348,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	).Return(
 		&childwf.PreprocessingResult{
 			Outcome:        childwf.OutcomeSuccess,
-			CustomMetadata: customMetadata,
+			CustomMetadata: preprocessingMetadata,
 			RelativePath:   strings.TrimPrefix(prepExtractPath, prepSharedPath),
 			PreservationTasks: []childwf.Task{
 				{
@@ -394,15 +398,12 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 		internalCtx,
 		&childwf.PostStorageParams{
 			AIPUUID:        aipUUID.String(),
-			CustomMetadata: customMetadata,
+			CustomMetadata: preprocessingMetadata,
 		},
 	).Return(
 		&childwf.PostStorageResult{
-			Outcome: childwf.OutcomeSuccess,
-			CustomMetadata: map[string]json.RawMessage{
-				"package": json.RawMessage(`{"type":"aip","identifier":"AIP-67890"}`),
-				"storage": json.RawMessage(`{"notified":true,"location":"permanent"}`),
-			},
+			Outcome:        childwf.OutcomeSuccess,
+			CustomMetadata: poststorageMetadata,
 			PreservationTasks: []childwf.Task{
 				{
 					Name:        "Notify external system",
@@ -446,6 +447,13 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 		Type:            enums.WorkflowTypeCreateAip,
 		SIPUUID:         sipUUID,
 		SIPName:         sipName,
+	}, &ingest.ProcessingWorkflowResult{
+		CustomMetadata: childwf.CustomMetadata{
+			"external_id": json.RawMessage(`"12345"`),
+			"flags":       json.RawMessage(`{"validated":true}`),
+			"package":     json.RawMessage(`{"type":"aip","identifier":"AIP-67890"}`),
+			"storage":     json.RawMessage(`{"notified":true,"location":"permanent"}`),
+		},
 	}, false)
 }
 
@@ -573,7 +581,7 @@ func (s *ProcessingWorkflowTestSuite) TestPreprocessingDecisionFlow() {
 		Key:             key,
 		SIPUUID:         sipUUID,
 		SIPName:         sipName,
-	}, false)
+	}, &ingest.ProcessingWorkflowResult{}, false)
 }
 
 // TestFailedSIP tests:
@@ -638,7 +646,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 		Type:        enums.WorkflowTypeCreateAip,
 		SIPUUID:     sipUUID,
 		SIPName:     sipName,
-	}, true)
+	}, nil, true)
 }
 
 // TestFailedSIP tests:
@@ -707,7 +715,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPA3m() {
 		Type:        enums.WorkflowTypeCreateAip,
 		SIPUUID:     sipUUID,
 		SIPName:     sipName,
-	}, true)
+	}, nil, true)
 }
 
 // TestFailedPIPAM tests:
@@ -755,7 +763,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPAM() {
 		Key:         key,
 		SIPUUID:     sipUUID,
 		SIPName:     sipName,
-	}, true)
+	}, nil, true)
 }
 
 // TestInternalUpload tests:
@@ -817,7 +825,7 @@ func (s *ProcessingWorkflowTestSuite) TestInternalUpload() {
 		SIPUUID:         sipUUID,
 		SIPName:         sipName,
 		Extension:       ".zip",
-	}, false)
+	}, &ingest.ProcessingWorkflowResult{}, false)
 }
 
 // TestInternalUploadError tests:
@@ -893,7 +901,7 @@ func (s *ProcessingWorkflowTestSuite) TestInternalUploadError() {
 		SIPUUID:   sipUUID,
 		SIPName:   sipName,
 		Extension: ".zip",
-	}, true)
+	}, nil, true)
 }
 
 // TestSIPSourceUpload tests:
@@ -956,7 +964,7 @@ func (s *ProcessingWorkflowTestSuite) TestSIPSourceUpload() {
 		SIPUUID:         sipUUID,
 		SIPName:         sipName,
 		SIPSourceID:     uuid.New(),
-	}, false)
+	}, &ingest.ProcessingWorkflowResult{}, false)
 }
 
 // TestSIPDeletionError tests:
@@ -1012,7 +1020,7 @@ func (s *ProcessingWorkflowTestSuite) TestSIPDeletionError() {
 		Type:            enums.WorkflowTypeCreateAip,
 		SIPUUID:         sipUUID,
 		SIPName:         sipName,
-	}, false)
+	}, &ingest.ProcessingWorkflowResult{}, false)
 }
 
 // TestBatchSignalDoNotContinue tests:
@@ -1077,5 +1085,5 @@ func (s *ProcessingWorkflowTestSuite) TestBatchSignalDoNotContinue() {
 		SIPUUID:         sipUUID,
 		SIPName:         sipName,
 		BatchUUID:       batchUUID,
-	}, true)
+	}, nil, true)
 }

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -1,7 +1,6 @@
 package workflow
 
 import (
-	"encoding/json"
 	"slices"
 
 	"github.com/google/uuid"
@@ -44,7 +43,7 @@ type workflowState struct {
 	aip *aipInfo
 
 	// customMetadata is opaque metadata shared between child workflows.
-	customMetadata map[string]json.RawMessage
+	customMetadata childwf.CustomMetadata
 
 	// childDecisionRequest tracks an active child workflow decision request.
 	childDecisionRequest *childwf.DecisionRequest


### PR DESCRIPTION
Add a processing workflow result carrying custom metadata so batch workflows can collect SIP metadata from completed processing children. Forward that metadata into postbatch SIP params.

Based on #1623. Refs #1621.