### PR TITLE
Reset resource stores on unmount

### DIFF
--- a/dashboard/src/components/LocationDialog.spec.ts
+++ b/dashboard/src/components/LocationDialog.spec.ts
@@ -1,0 +1,28 @@
+import { createTestingPinia } from "@pinia/testing";
+import { mount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import LocationDialog from "@/components/LocationDialog.vue";
+import { useLocationStore } from "@/stores/location";
+
+vi.mock("bootstrap/js/dist/modal", () => ({
+  default: class {
+    show() {}
+  },
+}));
+
+vi.mock("vue3-promise-dialog", () => ({ closeDialog: vi.fn() }));
+
+describe("LocationDialog.vue", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("resets the location store on unmount", () => {
+    const wrapper = mount(LocationDialog, {
+      global: { plugins: [createTestingPinia({ createSpy: vi.fn })] },
+    });
+
+    const reset = vi.spyOn(useLocationStore(), "$reset");
+    wrapper.unmount();
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/components/LocationDialog.vue
+++ b/dashboard/src/components/LocationDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import Modal from "bootstrap/js/dist/modal";
-import { onMounted, ref } from "vue";
+import { onMounted, onUnmounted, ref } from "vue";
 import { closeDialog } from "vue3-promise-dialog";
 
 import useEventListener from "@/composables/useEventListener";
@@ -35,6 +35,10 @@ const onChoose = (locationId: string) => {
   data = locationId;
   modal.value?.hide();
 };
+
+onUnmounted(() => {
+  locationStore.$reset();
+});
 </script>
 
 <template>

--- a/dashboard/src/components/SipReviewAlert.spec.ts
+++ b/dashboard/src/components/SipReviewAlert.spec.ts
@@ -1,0 +1,23 @@
+import { createTestingPinia } from "@pinia/testing";
+import { mount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import SipReviewAlert from "@/components/SipReviewAlert.vue";
+import { useAipStore } from "@/stores/aip";
+
+vi.mock("vue3-promise-dialog", () => ({ openDialog: vi.fn() }));
+
+describe("SipReviewAlert.vue", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("resets the AIP store on unmount", () => {
+    const wrapper = mount(SipReviewAlert, {
+      props: { expandCounter: 0 },
+      global: { plugins: [createTestingPinia({ createSpy: vi.fn })] },
+    });
+
+    const reset = vi.spyOn(useAipStore(), "$reset");
+    wrapper.unmount();
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/components/SipReviewAlert.vue
+++ b/dashboard/src/components/SipReviewAlert.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { onUnmounted } from "vue";
 import { openDialog } from "vue3-promise-dialog";
 
 import LocationDialog from "@/components/LocationDialog.vue";
@@ -25,6 +26,10 @@ const confirm = async () => {
   if (!locationId) return;
   sipStore.confirm(locationId);
 };
+
+onUnmounted(() => {
+  aipStore.$reset();
+});
 </script>
 
 <template>

--- a/dashboard/src/pages/ingest/batches/[id].spec.ts
+++ b/dashboard/src/pages/ingest/batches/[id].spec.ts
@@ -1,0 +1,34 @@
+import { createTestingPinia } from "@pinia/testing";
+import { shallowMount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMemoryHistory, createRouter } from "vue-router";
+
+import Page from "@/pages/ingest/batches/[id].vue";
+import { useBatchStore } from "@/stores/batch";
+
+describe("ingest/batches/[id].vue", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("resets the batch store on unmount", async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        {
+          name: "/ingest/batches/[id]/",
+          path: "/ingest/batches/:id/",
+          component: {},
+        },
+      ],
+    });
+    await router.push("/ingest/batches/batch-uuid/");
+    const pinia = createTestingPinia({ createSpy: vi.fn });
+    vi.mocked(useBatchStore(pinia).fetchCurrent).mockResolvedValue(undefined);
+    const wrapper = shallowMount(Page, {
+      global: { plugins: [pinia, router] },
+    });
+
+    const reset = vi.spyOn(useBatchStore(), "$reset");
+    wrapper.unmount();
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/pages/ingest/batches/[id].vue
+++ b/dashboard/src/pages/ingest/batches/[id].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useAsyncState } from "@vueuse/core";
+import { onUnmounted } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import IconDetails from "~icons/clarity/details-line?font-size=20px";
@@ -31,6 +32,10 @@ const tabs = [
     show: authStore.checkAttributes(["ingest:batches:read"]),
   },
 ];
+
+onUnmounted(() => {
+  batchStore.$reset();
+});
 </script>
 
 <template>

--- a/dashboard/src/pages/ingest/batches/index.spec.ts
+++ b/dashboard/src/pages/ingest/batches/index.spec.ts
@@ -1,0 +1,44 @@
+import { createTestingPinia } from "@pinia/testing";
+import { shallowMount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMemoryHistory, createRouter } from "vue-router";
+
+import Page from "@/pages/ingest/batches/index.vue";
+import { useBatchStore } from "@/stores/batch";
+import { useUserStore } from "@/stores/user";
+
+vi.mock("bootstrap/js/dist/dropdown", () => ({ default: class {} }));
+vi.mock("bootstrap/js/dist/tooltip", () => ({ default: class {} }));
+
+describe("ingest/batches/index.vue", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("resets the batch and user stores on unmount", async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { name: "/ingest/batches/", path: "/ingest/batches/", component: {} },
+      ],
+    });
+    await router.push("/ingest/batches/");
+    const wrapper = shallowMount(Page, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              auth: { config: { enabled: true, abac: { enabled: true } } },
+            },
+          }),
+          router,
+        ],
+      },
+    });
+
+    const resetBatch = vi.spyOn(useBatchStore(), "$reset");
+    const resetUser = vi.spyOn(useUserStore(), "$reset");
+    wrapper.unmount();
+    expect(resetBatch).toHaveBeenCalledOnce();
+    expect(resetUser).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/pages/ingest/batches/index.vue
+++ b/dashboard/src/pages/ingest/batches/index.vue
@@ -2,7 +2,7 @@
 import { useAsyncState } from "@vueuse/core";
 import Dropdown from "bootstrap/js/dist/dropdown";
 import Tooltip from "bootstrap/js/dist/tooltip";
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import type { LocationQueryValue } from "vue-router";
 
@@ -333,6 +333,11 @@ onMounted(() => {
       error.value = "Failed to fetch users";
     });
   }
+});
+
+onUnmounted(() => {
+  batchStore.$reset();
+  userStore.$reset();
 });
 </script>
 

--- a/dashboard/src/pages/ingest/sips/[id].spec.ts
+++ b/dashboard/src/pages/ingest/sips/[id].spec.ts
@@ -1,0 +1,34 @@
+import { createTestingPinia } from "@pinia/testing";
+import { shallowMount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMemoryHistory, createRouter } from "vue-router";
+
+import Page from "@/pages/ingest/sips/[id].vue";
+import { useSipStore } from "@/stores/sip";
+
+describe("ingest/sips/[id].vue", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("resets the SIP store on unmount", async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        {
+          name: "/ingest/sips/[id]/",
+          path: "/ingest/sips/:id/",
+          component: {},
+        },
+      ],
+    });
+    await router.push("/ingest/sips/sip-uuid/");
+    const pinia = createTestingPinia({ createSpy: vi.fn });
+    vi.mocked(useSipStore(pinia).fetchCurrent).mockResolvedValue(undefined);
+    const wrapper = shallowMount(Page, {
+      global: { plugins: [pinia, router] },
+    });
+
+    const reset = vi.spyOn(useSipStore(), "$reset");
+    wrapper.unmount();
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/pages/ingest/sips/[id].vue
+++ b/dashboard/src/pages/ingest/sips/[id].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useAsyncState } from "@vueuse/core";
+import { onUnmounted } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import IconDetails from "~icons/clarity/details-line?font-size=20px";
@@ -42,6 +43,10 @@ const tabs = [
     show: authStore.checkAttributes(["ingest:sips:read"]),
   },
 ];
+
+onUnmounted(() => {
+  sipStore.$reset();
+});
 </script>
 
 <template>

--- a/dashboard/src/pages/ingest/sips/index.spec.ts
+++ b/dashboard/src/pages/ingest/sips/index.spec.ts
@@ -1,0 +1,42 @@
+import { createTestingPinia } from "@pinia/testing";
+import { shallowMount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMemoryHistory, createRouter } from "vue-router";
+
+import Page from "@/pages/ingest/sips/index.vue";
+import { useSipStore } from "@/stores/sip";
+import { useUserStore } from "@/stores/user";
+
+vi.mock("bootstrap/js/dist/dropdown", () => ({ default: class {} }));
+vi.mock("bootstrap/js/dist/tooltip", () => ({ default: class {} }));
+
+describe("ingest/sips/index.vue", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("resets the SIP and user stores on unmount", async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ name: "/ingest/sips/", path: "/ingest/sips/", component: {} }],
+    });
+    await router.push("/ingest/sips/");
+    const wrapper = shallowMount(Page, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              auth: { config: { enabled: true, abac: { enabled: true } } },
+            },
+          }),
+          router,
+        ],
+      },
+    });
+
+    const resetSip = vi.spyOn(useSipStore(), "$reset");
+    const resetUser = vi.spyOn(useUserStore(), "$reset");
+    wrapper.unmount();
+    expect(resetSip).toHaveBeenCalledOnce();
+    expect(resetUser).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/pages/ingest/sips/index.vue
+++ b/dashboard/src/pages/ingest/sips/index.vue
@@ -2,7 +2,7 @@
 import { useAsyncState } from "@vueuse/core";
 import Dropdown from "bootstrap/js/dist/dropdown";
 import Tooltip from "bootstrap/js/dist/tooltip";
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import type { LocationQueryValue } from "vue-router";
 
@@ -371,6 +371,11 @@ onMounted(() => {
       error.value = "Failed to fetch users";
     });
   }
+});
+
+onUnmounted(() => {
+  sipStore.$reset();
+  userStore.$reset();
 });
 </script>
 

--- a/dashboard/src/pages/storage/aips/[id].spec.ts
+++ b/dashboard/src/pages/storage/aips/[id].spec.ts
@@ -1,0 +1,34 @@
+import { createTestingPinia } from "@pinia/testing";
+import { shallowMount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMemoryHistory, createRouter } from "vue-router";
+
+import Page from "@/pages/storage/aips/[id].vue";
+import { useAipStore } from "@/stores/aip";
+
+describe("storage/aips/[id].vue", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("resets the AIP store on unmount", async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        {
+          name: "/storage/aips/[id]/",
+          path: "/storage/aips/:id/",
+          component: {},
+        },
+      ],
+    });
+    await router.push("/storage/aips/aip-uuid/");
+    const pinia = createTestingPinia({ createSpy: vi.fn });
+    vi.mocked(useAipStore(pinia).fetchCurrent).mockResolvedValue(undefined);
+    const wrapper = shallowMount(Page, {
+      global: { plugins: [pinia, router] },
+    });
+
+    const reset = vi.spyOn(useAipStore(), "$reset");
+    wrapper.unmount();
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/pages/storage/aips/[id].vue
+++ b/dashboard/src/pages/storage/aips/[id].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useAsyncState } from "@vueuse/core";
+import { onUnmounted } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import IconAIPs from "~icons/clarity/bundle-line";
@@ -34,6 +35,10 @@ const tabs = [
     show: authStore.checkAttributes(["storage:aips:read"]),
   },
 ];
+
+onUnmounted(() => {
+  aipStore.$reset();
+});
 </script>
 
 <template>

--- a/dashboard/src/pages/storage/aips/index.spec.ts
+++ b/dashboard/src/pages/storage/aips/index.spec.ts
@@ -1,0 +1,30 @@
+import { createTestingPinia } from "@pinia/testing";
+import { shallowMount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMemoryHistory, createRouter } from "vue-router";
+
+import Page from "@/pages/storage/aips/index.vue";
+import { useAipStore } from "@/stores/aip";
+
+vi.mock("bootstrap/js/dist/tooltip", () => ({ default: class {} }));
+
+describe("storage/aips/index.vue", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("resets the AIP store on unmount", async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { name: "/storage/aips/", path: "/storage/aips/", component: {} },
+      ],
+    });
+    await router.push("/storage/aips/");
+    const wrapper = shallowMount(Page, {
+      global: { plugins: [createTestingPinia({ createSpy: vi.fn }), router] },
+    });
+
+    const reset = vi.spyOn(useAipStore(), "$reset");
+    wrapper.unmount();
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/pages/storage/aips/index.vue
+++ b/dashboard/src/pages/storage/aips/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useAsyncState } from "@vueuse/core";
 import Tooltip from "bootstrap/js/dist/tooltip";
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import type { LocationQueryValue } from "vue-router";
 
@@ -272,6 +272,10 @@ const statuses = [
       "The AIP is about to be part of an active workflow and is awaiting processing.",
   },
 ];
+
+onUnmounted(() => {
+  aipStore.$reset();
+});
 </script>
 
 <template>

--- a/dashboard/src/pages/storage/locations/[id].spec.ts
+++ b/dashboard/src/pages/storage/locations/[id].spec.ts
@@ -1,0 +1,39 @@
+import { createTestingPinia } from "@pinia/testing";
+import { shallowMount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMemoryHistory, createRouter } from "vue-router";
+
+import Page from "@/pages/storage/locations/[id].vue";
+import { useLocationStore } from "@/stores/location";
+
+describe("storage/locations/[id].vue", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("resets the location store on unmount", async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        {
+          name: "/storage/locations/[id]/",
+          path: "/storage/locations/:id/",
+          component: {},
+        },
+        {
+          name: "/storage/locations/[id]/aips",
+          path: "/storage/locations/:id/aips",
+          component: {},
+        },
+      ],
+    });
+    await router.push("/storage/locations/location-uuid/");
+    const pinia = createTestingPinia({ createSpy: vi.fn });
+    vi.mocked(useLocationStore(pinia).fetchCurrent).mockResolvedValue();
+    const wrapper = shallowMount(Page, {
+      global: { plugins: [pinia, router] },
+    });
+
+    const reset = vi.spyOn(useLocationStore(), "$reset");
+    wrapper.unmount();
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/pages/storage/locations/[id].vue
+++ b/dashboard/src/pages/storage/locations/[id].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useAsyncState } from "@vueuse/core";
+import { onUnmounted } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import IconAIPs from "~icons/clarity/bundle-line?font-size=20px";
@@ -41,6 +42,10 @@ const tabs = [
     show: authStore.checkAttributes(["storage:locations:aips:list"]),
   },
 ];
+
+onUnmounted(() => {
+  locationStore.$reset();
+});
 </script>
 
 <template>

--- a/dashboard/src/pages/storage/locations/index.spec.ts
+++ b/dashboard/src/pages/storage/locations/index.spec.ts
@@ -1,0 +1,23 @@
+import { createTestingPinia } from "@pinia/testing";
+import { shallowMount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import Page from "@/pages/storage/locations/index.vue";
+import { useLocationStore } from "@/stores/location";
+
+describe("storage/locations/index.vue", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("resets the location store on unmount", () => {
+    const wrapper = shallowMount(Page, {
+      global: {
+        plugins: [createTestingPinia({ createSpy: vi.fn })],
+        stubs: { RouterLink: true },
+      },
+    });
+
+    const reset = vi.spyOn(useLocationStore(), "$reset");
+    wrapper.unmount();
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/pages/storage/locations/index.vue
+++ b/dashboard/src/pages/storage/locations/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useAsyncState } from "@vueuse/core";
+import { onUnmounted } from "vue";
 
 import IconLocations from "~icons/octicon/server-24";
 
@@ -17,6 +18,10 @@ const locationStore = useLocationStore();
 const { execute, error } = useAsyncState(() => {
   return locationStore.fetchLocations();
 }, null);
+
+onUnmounted(() => {
+  locationStore.$reset();
+});
 </script>
 
 <template>


### PR DESCRIPTION
Clear selected and listed resource state when dashboard resource views are unmounted. This prevents stale SIP, batch, AIP, location, and related user state from leaking into the next resource view.

Refs #1637.