### PR TITLE
Show loading state on AIP download button

### DIFF
--- a/dashboard/src/components/AipLocationCard.spec.ts
+++ b/dashboard/src/components/AipLocationCard.spec.ts
@@ -41,7 +41,7 @@ describe("AipLocationCard.vue", () => {
         </div></span></p>
         <div data-v-09f60ec4="">
           <transition-stub data-v-09f60ec4="" mode="out-in" appear="false" persisted="false" css="true">
-            <div data-v-09f60ec4="" class="d-flex flex-wrap gap-2"><button data-v-09f60ec4="" type="button" class="btn btn-primary btn-sm"> Download </button>
+            <div data-v-09f60ec4="" class="d-flex flex-wrap gap-2"><button data-v-09f60ec4="" type="button" class="btn btn-primary btn-sm">Download</button>
               <!--v-if--><button data-v-09f60ec4="" type="button" class="btn btn-primary btn-sm"> Delete </button>
             </div>
           </transition-stub>
@@ -274,6 +274,32 @@ describe("AipLocationCard.vue", () => {
     });
 
     getByRole("button", { name: "Download" });
+  });
+
+  it("disables the download button and shows a spinner while downloading", async () => {
+    const { getByRole, getByText } = render(AipLocationCard, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              aip: {
+                current: {
+                  status: api.EnduroStorageAipStatusEnum.Stored,
+                  locationUuid: "f8635e46-a320-4152-9a2c-98a28eeb50d1",
+                } as api.EnduroStorageAip,
+                downloading: true,
+              },
+            },
+          }),
+        ],
+      },
+    });
+
+    const button = getByRole("button", { name: /Downloading/ });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(button.querySelector(".spinner-grow")).not.toBeNull();
+    getByText("Downloading...");
   });
 
   it("hides the download button", async () => {

--- a/dashboard/src/components/AipLocationCard.vue
+++ b/dashboard/src/components/AipLocationCard.vue
@@ -67,9 +67,18 @@ const requestDeletion = async () => {
               "
               type="button"
               class="btn btn-primary btn-sm"
+              :disabled="aipStore.downloading"
               @click="aipStore.download()"
             >
-              Download
+              <template v-if="aipStore.downloading">
+                <span
+                  class="spinner-grow spinner-grow-sm me-2"
+                  role="status"
+                  aria-hidden="true"
+                />
+                Downloading...
+              </template>
+              <template v-else>Download</template>
             </button>
             <button
               v-if="

--- a/dashboard/src/stores/aip.spec.ts
+++ b/dashboard/src/stores/aip.spec.ts
@@ -1,7 +1,7 @@
 import { createPinia, setActivePinia } from "pinia";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { api, client } from "@/client";
+import { api, client, getPath } from "@/client";
 import { ResponseError } from "@/openapi-generator";
 import { useAipStore } from "@/stores/aip";
 import { useLayoutStore } from "@/stores/layout";
@@ -435,5 +435,159 @@ describe("canCancelDeletion", () => {
       "Internal Server Error",
     );
     expect(res).toBe(false);
+  });
+});
+
+describe("download", () => {
+  let originalOpen: typeof window.open;
+
+  beforeEach(() => {
+    originalOpen = window.open;
+    window.open = vi.fn();
+  });
+
+  afterEach(() => {
+    window.open = originalOpen;
+  });
+
+  it("does nothing if current is null", async () => {
+    const store = useAipStore();
+    store.$patch({ current: null });
+
+    await store.download();
+
+    expect(window.open).not.toHaveBeenCalled();
+    expect(store.downloading).toBe(false);
+  });
+
+  it("downloads in a new window", async () => {
+    const store = useAipStore();
+    store.$patch({
+      current: {
+        createdAt: new Date(),
+        uuid: "00000000-0000-0000-0000-000000000000",
+        status: api.EnduroStorageAipStatusEnum.Stored,
+      },
+    });
+    client.storage.storageDownloadAipRequest = vi.fn().mockResolvedValue({});
+
+    await store.download();
+
+    expect(window.open).toHaveBeenCalledWith(
+      getPath() + "/storage/aips/00000000-0000-0000-0000-000000000000/download",
+      "_blank",
+    );
+    expect(store.downloadError).toBeNull();
+    expect(store.downloading).toBe(false);
+  });
+
+  it("sets downloading state while download is in progress", async () => {
+    const store = useAipStore();
+    store.$patch({
+      current: {
+        createdAt: new Date(),
+        uuid: "00000000-0000-0000-0000-000000000000",
+        status: api.EnduroStorageAipStatusEnum.Stored,
+      },
+    });
+
+    let resolveDownload: () => void;
+    client.storage.storageDownloadAipRequest = vi.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDownload = resolve;
+      }),
+    );
+
+    const downloadPromise = store.download();
+
+    expect(store.downloading).toBe(true);
+    expect(window.open).not.toHaveBeenCalled();
+
+    // Resolve the download request to allow the method to complete.
+    resolveDownload!();
+    await downloadPromise;
+
+    expect(store.downloading).toBe(false);
+    expect(window.open).toHaveBeenCalledWith(
+      getPath() + "/storage/aips/00000000-0000-0000-0000-000000000000/download",
+      "_blank",
+    );
+  });
+
+  it("sets downloadError from response body when request fails", async () => {
+    const store = useAipStore();
+    store.$patch({
+      current: {
+        createdAt: new Date(),
+        uuid: "00000000-0000-0000-0000-000000000000",
+        status: api.EnduroStorageAipStatusEnum.Stored,
+      },
+    });
+    const errorMsg = "an error occurred";
+    client.storage.storageDownloadAipRequest = vi
+      .fn()
+      .mockRejectedValue(
+        new ResponseError(
+          new Response(JSON.stringify({ message: errorMsg })),
+          "API error",
+        ),
+      );
+
+    await store.download();
+
+    expect(window.open).not.toHaveBeenCalled();
+    expect(store.downloadError).toBe(errorMsg);
+    expect(store.downloading).toBe(false);
+
+    // Error message should be cleared after 5 seconds.
+    vi.advanceTimersByTime(5000);
+    expect(store.downloadError).toBeNull();
+  });
+
+  it("sets a generic downloadError when ResponseError has no message", async () => {
+    const store = useAipStore();
+    store.$patch({
+      current: {
+        createdAt: new Date(),
+        uuid: "00000000-0000-0000-0000-000000000000",
+        status: api.EnduroStorageAipStatusEnum.Stored,
+      },
+    });
+    client.storage.storageDownloadAipRequest = vi
+      .fn()
+      .mockRejectedValue(
+        new ResponseError(new Response(JSON.stringify({})), "API error"),
+      );
+
+    await store.download();
+
+    expect(store.downloadError).toBe("Unexpected error downloading AIP");
+    expect(store.downloading).toBe(false);
+
+    vi.advanceTimersByTime(5000);
+    expect(store.downloadError).toBeNull();
+  });
+
+  it("sets a generic downloadError for unexpected (non-ResponseError) errors", async () => {
+    const store = useAipStore();
+    store.$patch({
+      current: {
+        createdAt: new Date(),
+        uuid: "00000000-0000-0000-0000-000000000000",
+        status: api.EnduroStorageAipStatusEnum.Stored,
+      },
+    });
+    client.storage.storageDownloadAipRequest = vi
+      .fn()
+      .mockRejectedValue(new Error("network failure"));
+
+    await store.download();
+
+    expect(window.open).not.toHaveBeenCalled();
+    expect(store.downloadError).toBe("Unexpected error downloading AIP");
+    expect(store.downloading).toBe(false);
+
+    vi.advanceTimersByTime(5000);
+    expect(store.downloadError).toBeNull();
   });
 });

--- a/dashboard/src/stores/aip.ts
+++ b/dashboard/src/stores/aip.ts
@@ -33,6 +33,7 @@ export const useAipStore = defineStore("aip", {
       earliestCreatedTime: undefined as Date | undefined,
       latestCreatedTime: undefined as Date | undefined,
     },
+    downloading: false,
     downloadError: null as string | null,
   }),
   getters: {
@@ -262,6 +263,7 @@ export const useAipStore = defineStore("aip", {
     },
     async download() {
       if (!this.current) return;
+      this.downloading = true;
       try {
         await client.storage.storageDownloadAipRequest({
           uuid: this.current.uuid,
@@ -283,6 +285,8 @@ export const useAipStore = defineStore("aip", {
         }
         this.downloadError = errorMsg;
         setTimeout(() => (this.downloadError = null), 5000);
+      } finally {
+        this.downloading = false;
       }
     },
     async fetchAipsDebounced(page: number) {


### PR DESCRIPTION
Fixes #1629.

Disable the Download button and display a spinner with "Downloading..." text while the download API request is in-flight, preventing duplicate clicks.