### PR TITLE
Support filesystem bucket configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,25 +63,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends libxml2-utils
 RUN groupadd --gid 1000 enduro \
 	&& useradd --uid 1000 --gid 1000 -m enduro
 USER enduro
+COPY --link --chown=1000:1000 hack/xsd/premis.xsd /home/enduro/premis.xsd
+RUN ["mkdir", "-m", "700", "-p", \
+    "/home/enduro/logs", \
+    "/home/enduro/internal-storage/ingest", \
+    "/home/enduro/internal-storage/storage", \
+    "/home/enduro/internal-storage/sip-source"]
 
 FROM base AS enduro
 COPY --link --chown=1000:1000 --from=build-enduro /out/enduro /home/enduro/bin/enduro
 COPY --link --chown=1000:1000 --from=build-enduro /src/enduro.toml /home/enduro/.config/enduro.toml
 COPY --link --chown=1000:1000 assets/Enduro_AIP_deletion_report_v3.tmpl.pdf /home/enduro/Enduro_AIP_deletion_report_v3.tmpl.pdf
-COPY --link --chown=1000:1000 hack/xsd/premis.xsd /home/enduro/premis.xsd
-RUN ["mkdir", "-m", "700", "-p", "/home/enduro/logs"]
 CMD ["/home/enduro/bin/enduro", "--config", "/home/enduro/.config/enduro.toml"]
 
 FROM base AS enduro-a3m-worker
-COPY --link --from=build-enduro-a3m-worker /out/enduro-a3m-worker /home/enduro/bin/enduro-a3m-worker
-COPY --link --from=build-enduro-a3m-worker /src/enduro.toml /home/enduro/.config/enduro.toml
-COPY --link hack/xsd/premis.xsd /home/enduro/premis.xsd
+COPY --link --chown=1000:1000 --from=build-enduro-a3m-worker /out/enduro-a3m-worker /home/enduro/bin/enduro-a3m-worker
+COPY --link --chown=1000:1000 --from=build-enduro-a3m-worker /src/enduro.toml /home/enduro/.config/enduro.toml
 CMD ["/home/enduro/bin/enduro-a3m-worker", "--config", "/home/enduro/.config/enduro.toml"]
 
 FROM base AS enduro-am-worker
-COPY --link --from=build-enduro-am-worker /out/enduro-am-worker /home/enduro/bin/enduro-am-worker
-COPY --link --from=build-enduro-am-worker /src/enduro.toml /home/enduro/.config/enduro.toml
-COPY --link hack/xsd/premis.xsd /home/enduro/premis.xsd
+COPY --link --chown=1000:1000 --from=build-enduro-am-worker /out/enduro-am-worker /home/enduro/bin/enduro-am-worker
+COPY --link --chown=1000:1000 --from=build-enduro-am-worker /src/enduro.toml /home/enduro/.config/enduro.toml
 CMD ["/home/enduro/bin/enduro-am-worker", "--config", "/home/enduro/.config/enduro.toml"]
 
 FROM ${TARGET}

--- a/docs/src/admin-manual/configuration.md
+++ b/docs/src/admin-manual/configuration.md
@@ -523,8 +523,7 @@ workflowType = "create aip"
 * `redisAddress`: Binds Redis to a specific address and port.
 * `redisList`: The name of the queue that Redis should use for the watched
   location SIP deposit events.
-* `endpoint`: API endpoint for the target MinIO instance. Used by Enduro to read
-  contents of a watched bucket, or for any other MinIO interactions.
+* `endpoint`: API endpoint for the target S3-compatible object store.
 * `pathStyle`: Currently Amazon Web Services support two different URL
   construction methods when interacting with an object store bucket via API. The
   "path-style" method constructs the bucket's access URL using the configured
@@ -533,7 +532,7 @@ workflowType = "create aip"
   supported so if using an S3-like object store, ensure this is set to `true`.
 * `key`: Username for accessing the configured S3-like bucket.
 * `secret`: Password for accessing the configured S3-like bucket.
-* `region`:  = AWS S3 buckets are created in a specific region. When interacting
+* `region`: AWS S3 buckets are created in a specific region. When interacting
   with S3, you can specify the region during the bucket creation process. For
   a full list of available regions and the syntax to specify them, consult the
   [AWS S3 documentation][S3-regions].
@@ -544,6 +543,147 @@ workflowType = "create aip"
   SIPs are deposited in the watched location. Currently the only supported
   values are "create aip" and "create and review aip". The latter review
   workflow also only works if [a3m] is the configured [preservation engine].
+
+### Bucket configuration options
+
+Several Enduro settings use the same bucket configuration shape for filesystem
+or object store locations:
+
+* `[storage.internal]`
+* `[internalStorage]`
+* `[sipsource.bucket]`
+
+Each bucket can be configured with either a URL or provider-specific fields.
+When `url` is set, it takes precedence over the S3-compatible fields listed
+below. The URL form supports local filesystem locations, S3-compatible buckets,
+and [Azure Blob Storage][Azure] containers. S3-compatible buckets can
+alternatively be configured with the endpoint, credentials, region, and bucket
+fields below.
+
+Use the examples below with the section you are configuring. Replace
+`[example.bucket]` with `[storage.internal]`, `[internalStorage]`, or
+`[sipsource.bucket]` as appropriate.
+
+**Example filesystem URL configuration**:
+
+```toml
+[example.bucket]
+url = "file:///home/enduro/example-bucket?metadata=skip&no_tmp_dir=true"
+```
+
+For filesystem-backed storage, the directory referenced by `url` must exist
+before Enduro starts, and the process user running Enduro must have the read,
+write, or delete permissions required by that bucket's role. When Enduro
+processes run on different hosts or containers, the filesystem path must refer
+to shared storage that is mounted at the same path for every process that needs
+to access the bucket.
+
+Enduro implements `file://` bucket URLs with the Go CDK `fileblob` package.
+By default, `fileblob` stores blob metadata in `.attrs` sidecar files, and
+writes objects to the system temporary directory before renaming them to the
+final path to avoid partial writes. These defaults are useful for general
+filesystem-backed buckets, but they can be surprising in Enduro deployments:
+metadata sidecars appear beside package files, and renames can fail when the
+system temporary directory and bucket directory are on different filesystems or
+container mounts.
+
+For this reason, Enduro filesystem bucket examples use `metadata=skip` to
+prevent `.attrs` sidecar files. Use `no_tmp_dir=true` for filesystem buckets
+that are written through `fileblob`; the bucket-specific sections below note
+when this applies. This keeps temporary write files next to the final object,
+avoiding cross-device rename failures. Both parameters are documented in the Go
+CDK [fileblob URL opener] documentation.
+
+**Example S3-compatible URL configuration**:
+
+```toml
+[example.bucket]
+url = "s3://example-bucket?region=us-west-1"
+```
+
+**Example S3-compatible field configuration**:
+
+```toml
+[example.bucket]
+url = ""
+endpoint = "http://minio.enduro-sdps:9000"
+pathStyle = true
+accessKey = "minio"
+secretKey = "minio123"
+region = "us-west-1"
+bucket = "example-bucket"
+```
+
+* `url`: URL for the target bucket or filesystem location. This can be used for
+  local filesystems, S3-compatible object storage, or [Azure Blob
+  Storage][Azure]. When `url` is set, it takes precedence over the individual
+  S3-compatible settings below.
+* `endpoint`: API endpoint for the target S3-compatible object store.
+* `pathStyle`: Currently Amazon Web Services support two different URL
+  construction methods when interacting with an object store bucket via API. The
+  "path-style" method constructs the bucket's access URL using the configured
+  properties, such as region, bucket name, and object key. For Enduro
+  integrations, the second virtual "host-style" method is not currently
+  supported so if using an S3-compatible object store, ensure this is set to
+  `true`.
+* `accessKey`: Username for accessing the configured S3-compatible bucket.
+* `secretKey`: Password for accessing the configured S3-compatible bucket.
+* `region`: AWS S3 buckets are created in a specific region. When interacting
+  with S3, you can specify the region during the bucket creation process. For
+  a full list of available regions and the syntax to specify them, consult the
+  [AWS S3 documentation][S3-regions].
+* `bucket`: A configured object store may have more than one bucket. This
+  parameter specifies the target bucket name to be used by the configured
+  section. Because the default configuration uses multiple buckets, ensure that
+  each bucket name is unique.
+
+For [Azure Blob Storage][Azure], set an Azure bucket `url` using the
+`azblob://` scheme and leave the S3-compatible fields empty. The Azure bucket
+name is included in the URL, so there is no need for a separate bucket config
+value. Then add the matching Azure authentication section:
+
+* `[storage.internal]` uses `[storage.internal.azure]`.
+* `[internalStorage]` uses `[internalStorage.azure]`.
+* `[sipsource.bucket]` uses `[sipsource.bucket.azure]`.
+
+**Example Azure shared key configuration**:
+
+```toml
+[example.bucket]
+url = "azblob://example-bucket"
+
+[example.bucket.azure]
+storageAccount = "my-account"
+storageKey = "dGVzdA==" # Must be base64 encoded
+```
+
+**Example Azure client secret configuration**:
+
+```toml
+[example.bucket]
+url = "azblob://example-bucket"
+
+[example.bucket.azure]
+storageAccount = "my-account"
+tenantID = "my-tenant-id"
+clientID = "my-client-id"
+clientSecret = "my-secret"
+```
+
+* `storageAccount`: The name of the Azure storage account.
+* `storageKey`: The shared key that Enduro should use to authenticate.
+* `tenantID`: Azure tenant ID for client secret authentication.
+* `clientID`: Azure client ID for client secret authentication.
+* `clientSecret`: Azure client secret for client secret authentication.
+
+When using Azure Blob Storage, Enduro supports two authentication modes:
+
+* Shared key authentication using `storageKey`.
+* Client secret authentication using `tenantID`, `clientID`, and
+  `clientSecret`.
+
+If both authentication modes are configured, the client secret settings take
+precedence.
 
 ### Ingest storage settings
 
@@ -648,113 +788,35 @@ migrate = true
 
 #### Internal location used for storing staging AIPs and reports
 
-These settings are used to configure a local object store bucket or filesystem
-directory where the storage service places reports, and staging AIPs when the
-configured [preservation engine] is [a3m]. Archivematica includes its own
+These settings are used to configure an internal filesystem directory or object
+store bucket where the storage service places reports, and stages AIPs when
+[a3m] is the configured [preservation engine]. Archivematica includes its own
 [Storage Service] component, but as a lightweight command-line derivative, a3m
 does not.
 
-The defaults included below use Amazon [S3] syntax to configure a [MinIO]
-bucket. Other third-party object store providers (such as Azure) will have their
-own syntax - consult the provider's documentation for more information.
+Configure this bucket with the shared
+[bucket configuration options](#bucket-configuration-options), using
+`[storage.internal]` as the bucket section. For Azure Blob Storage, use
+`[storage.internal.azure]` as the matching authentication section.
 
-For **local filesystems**, the only required field is a `url` parameter
-pointing to the target location - for example:
-
-```toml
-[storage.internal]
-url = "file:///home/enduro/storage"
-```
-
-If `url` is configured, it takes precedence over the individual S3-like
-configuration settings listed below.
-
-**Example configuration**:
+**Example filesystem configuration**:
 
 ```toml
 [storage.internal]
-url = ""
-endpoint = "http://minio.enduro-sdps:9000"
-pathStyle = true
-accessKey = "minio"
-secretKey = "minio123"
-region = "us-west-1"
-bucket = "enduro-storage"
+url = "file:///home/enduro/internal-storage/storage?metadata=skip&no_tmp_dir=true"
 ```
 
-* `url`: URL for the target bucket or filesystem location. This can be used for
-  local filesystems, such as `file:///home/enduro/storage`, S3-compatible
-  object storage, such as `s3://enduro-storage?region=us-west-1`, or Azure Blob
-  Storage, such as `azblob://enduro-storage`. When `url` is set, it takes
-  precedence over the individual S3-like settings below.
-* `endpoint`: API endpoint for the target MinIO instance. Used by Enduro to read
-  contents of a watched bucket, or for any other MinIO interactions.
-* `pathStyle`: Currently Amazon Web Services support two different URL
-  construction methods when interacting with an object store bucket via API. The
-  "path-style" method constructs the bucket's access URL using the configured
-  properties, such as region, bucket name, and object key. For Enduro
-  integrations, the second virtual "host-style" method is not currently
-  supported so if using an S3-like object store, ensure this is set to `true`.
-* `accessKey`: Username for accessing the configured S3-like bucket.
-* `secretKey`: Password for accessing the configured S3-like bucket.
-* `region`: AWS S3 buckets are created in a specific region. When interacting
-  with S3, you can specify the region during the bucket creation process. For
-  a full list of available regions and the syntax to specify them, consult the
-  [AWS S3 documentation][S3-regions].
-* `bucket`: A configured object store may have more than one bucket. This
-  parameter specifies the target bucket name to be used for the reports
-  location, and for the staging AIP location when using [a3m].
+For filesystem-backed storage, Enduro writes to this bucket, so the process
+user must have write access. If multiple Enduro processes need to access this
+bucket, the filesystem path must refer to storage shared by those processes.
+Because Enduro writes to this bucket through `fileblob`, include
+`no_tmp_dir=true` in the `file://` URL when the system temporary directory may
+be on another filesystem.
 
-#### Internal location used for storing staging AIPs and reports - Azure
-
-If you intend to use [Azure] for your internal storage, set an Azure bucket
-`url` using the `azblob://` schema in the `[storage.internal]` section, and
-remove all other configurations in that section. Note that the Azure bucket
-name is included in the URL (the bucket name in the example below is
-"enduro-storage") so there is no need for a separate bucket config value.
-
-Then add an `[storage.internal.azure]` section to configure Azure
-authentication via shared key or client secret.
-
-Example Azure shared key configuration:
-
-```toml
-[storage.internal]
-url = "azblob://enduro-storage"
-
-[storage.internal.azure]
-storageAccount = "my-account"
-storageKey = "dGVzdA==" # Must be base64 encoded
-```
-
-Example Azure client secret configuration:
-
-```toml
-[storage.internal]
-url = "azblob://enduro-storage"
-
-[storage.internal.azure]
-storageAccount = "my-account"
-tenantID = "my-tenant-id"
-clientID = "my-client-id"
-clientSecret = "my-secret"
-```
-
-* `storageAccount`: The name of the Azure storage account.
-* `storageKey`: The shared key that Enduro should use to authenticate.
-* `tenantID`: Azure tenant ID for client secret authentication.
-* `clientID`: Azure client ID for client secret authentication.
-* `clientSecret`: Azure client secret for client secret authentication.
-
-When using Azure Blob Storage, Enduro supports two authentication modes in this
-subsection:
-
-* Shared key authentication using `storageKey`.
-* Client secret authentication using `tenantID`, `clientID`, and
-`clientSecret`.
-
-If both authentication modes are configured, the client secret settings take
-precedence.
+For Archivematica deployments, this internal location is used for AIP deletion
+reports while final AIPs are stored in Archivematica Storage Service. The a3m
+AIP staging flow still requires an internal location backend that supports
+signed URLs.
 
 #### Storage event listener
 
@@ -1045,125 +1107,37 @@ maxSize = 4294967296
 
 ### Internal storage configuration
 
-The following two sections are to configure an internal upload and failed
-package storage space, used by Enduro for [uploads via the user
-interface][upload-ui] as well as SIPs or [PIPs][PIP] that encounter [content
-failures] or [system errors] during ingest, so they can be downloaded for
-inspection via the user interface by operators if desired. At least one of the
-sections below must be configured.
+This section configures an internal upload and failed package storage space,
+used by Enduro for [uploads via the user interface][upload-ui] as well as SIPs
+or [PIPs][PIP] that encounter [content failures] or [system errors] during
+ingest, so they can be downloaded for inspection via the user interface by
+operators if desired.
 
-#### Internal storage configuration - S3-like bucket or filesystem
+Configure this bucket with the shared
+[bucket configuration options](#bucket-configuration-options), using
+`[internalStorage]` as the bucket section. For Azure Blob Storage, use
+`[internalStorage.azure]` as the matching authentication section.
 
-This subsection allows an object store bucket or local filesystem location to be
-configured for UI uploads and failed packages. The default configuration
-included uses a [MinIO] bucket as the example location. MinIO uses Amazon [S3]
-syntax for its configuration properties. Different object stores may have
-different parameters to be configured. Consult the corresponding object store
-provider's documentation for more information.
-
-For **local filesystems**, the only required field is a `url` parameter
-pointing to the target location - for example:
+**Example filesystem configuration**:
 
 ```toml
 [internalStorage]
-url = "file:///home/enduro/ingest"
+url = "file:///home/enduro/internal-storage/ingest?metadata=skip&no_tmp_dir=true"
 ```
 
-If `url` is configured, it takes precedence over the individual S3-like
-configuration settings listed below.
-
-**Example configuration**:
-
-```toml
-[internalStorage]
-url = ""
-endpoint = "http://minio.enduro-sdps:9000"
-pathStyle = true
-accessKey = "minio"
-secretKey = "minio123"
-region = "us-west-1"
-bucket = "enduro-ingest"
-```
-
-* `url`: URL for the target bucket or filesystem location. This can be used for
-  local filesystems, such as `file:///home/enduro/ingest`, S3-compatible object
-  storage, such as `s3://enduro-ingest?region=us-west-1`, or Azure Blob
-  Storage, such as `azblob://enduro-ingest`. When `url` is set, it takes
-  precedence over the individual S3-like settings below.
-* `endpoint`: API endpoint for the target MinIO instance. Used by Enduro to read
-  contents of a bucket, or for any other MinIO interactions.
-* `pathStyle`: Currently Amazon Web Services support two different URL
-  construction methods when interacting with an object store bucket via API. The
-  "path-style" method constructs the bucket's access URL using the configured
-  properties, such as region, bucket name, and object key. For Enduro
-  integrations, the second virtual "host-style" method is not currently
-  supported so if using an S3-like object store, ensure this is set to `true`.
-* `accessKey`: Username for accessing the configured S3-like bucket.
-* `secretKey`: Password for accessing the configured S3-like bucket.
-* `region`:  = AWS S3 buckets are created in a specific region. When interacting
-  with S3, you can specify the region during the bucket creation process. For
-  a full list of available regions and the syntax to specify them, consult the
-  [AWS S3 documentation][S3-regions].
-* `bucket`: A configured object store may have more than one bucket. This
-  parameter specifies the target bucket name to be used for the uploaded SIPs
-  and failed packages location. Because the default configuration uses MinIO
-  buckets elsewhere as well, ensure that this bucket name is unique.
-
-#### Internal storage configuration - Azure
-
-If you intend to use [Azure] for your internal upload space, set an Azure bucket
-`url` using the `azblob://` schema in the `[internalStorage]` section, and
-remove all other configurations in that section. Note that the Azure bucket
-name is included in the URL (the bucket name in the example below is
-"enduro-ingest") so there is no need for a separate bucket config value.
-
-Then add an `[internalStorage.azure]` section to configure Azure authentication
-via shared key or client secret.
-
-Example Azure shared key configuration:
-
-```toml
-[internalStorage]
-url = "azblob://enduro-ingest"
-
-[internalStorage.azure]
-storageAccount = "my-account"
-storageKey = "dGVzdA==" # Must be base64 encoded
-```
-
-Example Azure client secret configuration:
-
-```toml
-[internalStorage]
-url = "azblob://enduro-ingest"
-
-[internalStorage.azure]
-storageAccount = "my-account"
-tenantID = "my-tenant-id"
-clientID = "my-client-id"
-clientSecret = "my-secret"
-```
-
-* `storageAccount`: The name of the Azure storage account.
-* `storageKey`: The shared key that Enduro should use to authenticate.
-* `tenantID`: Azure tenant ID for client secret authentication.
-* `clientID`: Azure client ID for client secret authentication.
-* `clientSecret`: Azure client secret for client secret authentication.
-
-When using Azure Blob Storage, Enduro supports two authentication modes in this
-subsection:
-
-* Shared key authentication using `storageKey`.
-* Client secret authentication using `tenantID`, `clientID`, and
-`clientSecret`.
-
-If both authentication modes are configured, the client secret settings take
-precedence.
+For filesystem-backed storage, Enduro writes API-uploaded SIPs and failed
+packages to this bucket, and later reads them for workflow processing or
+operator downloads. The process user must have read and write access. When the
+API and worker processes run on different hosts or containers, the filesystem
+path must refer to shared storage that is mounted at the same path for every
+process that needs to read from or write to the bucket. Because Enduro writes
+to this bucket through `fileblob`, include `no_tmp_dir=true` in the `file://`
+URL when the system temporary directory may be on another filesystem.
 
 ### SIP source location configuration
 
-The following sections configure a location to be used as a SIP source location
-for SIP selection and ingest — for more information, see:
+The following settings configure a location to be used as a SIP source location
+for SIP selection and ingest. For more information, see
 [Add SIPs via a source location][sip-source].
 
 The first set of parameters uniquely identify the source location in Enduro,
@@ -1179,7 +1153,7 @@ while the bucket subsection links the specified location.
 ```toml
 [sipsource]
 id = "e6ddb29a-66d1-480e-82eb-fcfef1c825c5"
-name = "MinIO SIP Source"
+name = "Filesystem SIP Source"
 ```
 
 * `id`: A UUID that unique identifies the SIP source location. Must be a valid
@@ -1188,111 +1162,28 @@ name = "MinIO SIP Source"
 
 #### SIP source location bucket
 
-This subsection allows either an S3-like object store bucket or a local
-filesystem location to be configured as a SIP source location. The
-default configuration included uses a [MinIO] bucket as the example location.
-MinIO uses Amazon [S3] syntax for its configuration properties. Different object
-stores may have different parameters to be configured. Consult the corresponding
-object store provider's documentation for more information.
+Configure this bucket with the shared
+[bucket configuration options](#bucket-configuration-options), using
+`[sipsource.bucket]` as the bucket section. For Azure Blob Storage, use
+`[sipsource.bucket.azure]` as the matching authentication section.
 
-For **local filesystems**, the only required field is a `url` parameter
-pointing to the target location - for example:
+**Example filesystem configuration**:
 
 ```toml
 [sipsource.bucket]
-url = "file:///home/enduro/sipsource"
+url = "file:///home/enduro/internal-storage/sip-source?metadata=skip"
 ```
 
-If `url` is configured, it takes precedence over the individual S3-like
-configuration settings listed below.
+For a filesystem-backed SIP source, the API lists objects from this bucket, and
+workers download selected objects for ingest. Depending on SIP retention
+settings, workers may also delete source objects after ingest, so the process
+user must be able to list the directory contents, and read and delete files.
+When the API and worker processes run on different hosts or containers, the
+filesystem path must refer to shared storage that is mounted at the same path
+for every process that needs to access the bucket.
 
-**Example configuration**:
-
-```toml
-[sipsource.bucket]
-url = ""
-endpoint = "http://minio.enduro-sdps:9000"
-pathStyle = true
-accessKey = "minio"
-secretKey = "minio123"
-region = "us-west-1"
-bucket = "sipsource"
-```
-
-* `url`: URL for the target bucket or filesystem location. This can be used for
-  local filesystems, such as `file:///home/enduro/sipsource`, S3-compatible
-  object storage, such as `s3://sipsource?region=us-west-1`, or Azure Blob
-  Storage, such as `azblob://sipsource`. When `url` is set, it takes
-  precedence over the individual S3-like settings below.
-* `endpoint`: API endpoint for the target MinIO instance. Used by Enduro to read
-  contents of a bucket, or for any other MinIO interactions.
-* `pathStyle`: Currently Amazon Web Services support two different URL
-  construction methods when interacting with an object store bucket via API. The
-  "path-style" method constructs the bucket's access URL using the configured
-  properties, such as region, bucket name, and object key. For Enduro
-  integrations, the second virtual "host-style" method is not currently
-  supported so if using an S3-like object store, ensure this is set to `true`.
-* `accessKey`: Username for accessing the configured S3-like bucket.
-* `secretKey`: Password for accessing the configured S3-like bucket.
-* `region`:  = AWS S3 buckets are created in a specific region. When interacting
-  with S3, you can specify the region during the bucket creation process. For
-  a full list of available regions and the syntax to specify them, consult the
-  [AWS S3 documentation][S3-regions].
-* `bucket`: A configured object store may have more than one bucket. This
-  parameter specifies the target bucket name to be used for the SIP source
-  location. Because the default configuration uses MinIO buckets elsewhere as
-  well, ensure that this bucket name is unique.
-
-#### SIP source location bucket - Azure
-
-If you intend to use [Azure] as SIP source, set an Azure bucket `url` using the
-`azblob://` schema in the `[sipsource.bucket]` section, and remove all other
-configurations in that section. Note that the Azure bucket name is included in
-the URL (the bucket name in the example below is "sipsource") so there is no
-need for a separate bucket config value.
-
-Then add an `[sipsource.bucket.azure]` section to configure Azure authentication
-via shared key or client secret.
-
-Example Azure shared key configuration:
-
-```toml
-[sipsource.bucket]
-url = "azblob://sipsource"
-
-[sipsource.bucket.azure]
-storageAccount = "my-account"
-storageKey = "dGVzdA==" # Must be base64 encoded
-```
-
-Example Azure client secret configuration:
-
-```toml
-[sipsource.bucket]
-url = "azblob://sipsource"
-
-[sipsource.bucket.azure]
-storageAccount = "my-account"
-tenantID = "my-tenant-id"
-clientID = "my-client-id"
-clientSecret = "my-secret"
-```
-
-* `storageAccount`: The name of the Azure storage account.
-* `storageKey`: The shared key that Enduro should use to authenticate.
-* `tenantID`: Azure tenant ID for client secret authentication.
-* `clientID`: Azure client ID for client secret authentication.
-* `clientSecret`: Azure client secret for client secret authentication.
-
-When using Azure Blob Storage, Enduro supports two authentication modes in this
-subsection:
-
-* Shared key authentication using `storageKey`.
-* Client secret authentication using `tenantID`, `clientID`, and
-`clientSecret`.
-
-If both authentication modes are configured, the client secret settings take
-precedence.
+Enduro does not write new source SIPs to this bucket through `fileblob`, so
+`no_tmp_dir=true` is not needed for Enduro's SIP source runtime behavior.
 
 ### Telemetry configuration
 
@@ -1477,6 +1368,7 @@ workflowName = "postbatch"
 [components]: ../user-manual/components.md
 [CORS]: https://en.wikipedia.org/wiki/Cross-origin_resource_sharing
 [Dashboard configuration]: ../admin-manual/dashboard-config.md
+[fileblob URL opener]: https://pkg.go.dev/gocloud.dev/blob/fileblob#URLOpener
 [Gibibytes]: https://www.difference.wiki/gigabyte-vs-gibibyte/
 [GoLang]: https://go.dev/
 [METS]: https://www.loc.gov/standards/mets/

--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -268,6 +268,18 @@ cURL by running the following make target:
 make upload-sample-transfer
 ```
 
+### Add a SIP to the filesystem SIP source
+
+When the local development configuration uses the filesystem-backed SIP source,
+copy a local SIP into the shared internal-storage PVC through the `enduro` pod:
+
+```bash
+POD=$(kubectl -n enduro-sdps get pod -l app=enduro -o jsonpath='{.items[0].metadata.name}')
+
+kubectl -n enduro-sdps -c enduro cp ./sip.zip \
+  "$POD":/home/enduro/internal-storage/sip-source/sip.zip
+```
+
 ### Flush
 
 Also in the Tilt UI header, click the trash button to flush the existing data.

--- a/enduro.toml
+++ b/enduro.toml
@@ -248,31 +248,9 @@ maxSize = 4294967296
 # It must be a string format compatible with https://pkg.go.dev/time#ParseDuration.
 retentionPeriod = "0"
 
-# internalStorage section configures a bucket where Enduro will place uploaded
-# SIPs and failed SIPs/PIPs. Make sure it doesn't match any of the watched buckets.
-# URL takes precedence over the individual settings below.
+# https://enduro.readthedocs.io/admin-manual/configuration/#internal-storage-configuration
 [internalStorage]
-url = "" # Azure example: "azblob://enduro-ingest"
-endpoint = "http://minio.enduro-sdps:9000"
-pathStyle = true
-accessKey = "minio"
-secretKey = "minio123"
-region = "us-west-1"
-bucket = "enduro-ingest"
-
-# Azure Blob Storage configuration. If the bucket is in Azure, set the URL as shown
-# in the example above and provide the storage account name and credentials here.
-[internalStorage.azure]
-storageAccount = ""
-
-# Shared key credential.
-storageKey = ""
-
-# Client secret credentials. All are required and they take precedence over the shared
-# key credential if both are provided.
-tenantID = ""
-clientID = ""
-clientSecret = ""
+url = "file:///home/enduro/internal-storage/ingest?metadata=skip&no_tmp_dir=true"
 
 # sipsource configures a SIP Source location where SIPs can be put and later
 # ingested via the Dashboard or API.
@@ -280,37 +258,16 @@ clientSecret = ""
 # id uniquely identifies the SIP Source and must be a valid Version 4 UUID.
 id = "e6ddb29a-66d1-480e-82eb-fcfef1c825c5"
 # name is a human-readable name for the SIP Source.
-name = "MinIO SIP Source"
+name = "Filesystem SIP Source"
 # retentionPeriod is the duration to retain SIPs before they are deleted after a
 # successful ingest. Set to a negative value to disable automatic deletion of SIPs.
 # Set to "0" (default) to delete SIPs immediately after they have been ingested.
 # It must be a string format compatible with https://pkg.go.dev/time#ParseDuration.
 retentionPeriod = "0"
 
-# sipsource.bucket is a bucket where SIPs can be put for ingest — make sure it doesn't
-# match any of the watched buckets. URL takes precedence over the individual settings below.
+# https://enduro.readthedocs.io/admin-manual/configuration/#sip-source-location-bucket
 [sipsource.bucket]
-url = "" # Azure example: "azblob://sipsource"
-endpoint = "http://minio.enduro-sdps:9000"
-pathStyle = true
-accessKey = "minio"
-secretKey = "minio123"
-region = "us-west-1"
-bucket = "sipsource"
-
-# Azure Blob Storage configuration. If the bucket is in Azure, set the URL as shown
-# in the example above and provide the storage account name and credentials here.
-[sipsource.bucket.azure]
-storageAccount = ""
-
-# Shared key credential.
-storageKey = ""
-
-# Client secret credentials. All are required and they take precedence over the shared
-# key credential if both are provided.
-tenantID = ""
-clientID = ""
-clientSecret = ""
+url = "file:///home/enduro/internal-storage/sip-source?metadata=skip"
 
 [telemetry.traces]
 enabled = false
@@ -415,31 +372,9 @@ driver = "mysql"
 dsn = "enduro:enduro123@tcp(mysql.enduro-sdps:3306)/enduro_storage"
 migrate = true
 
-# storage.internal section configures a bucket where Enduro will place staging AIPs
-# and reports. Make sure it doesn't match any of the ingest watched buckets.
-# URL takes precedence over the individual settings below.
+# https://enduro.readthedocs.io/admin-manual/configuration/#internal-location-used-for-storing-staging-aips-and-reports
 [storage.internal]
-url = "" # Azure example: "azblob://enduro-storage"
-endpoint = "http://minio.enduro-sdps:9000"
-pathStyle = true
-accessKey = "minio"
-secretKey = "minio123"
-region = "us-west-1"
-bucket = "enduro-storage"
-
-# Azure Blob Storage configuration. If the bucket is in Azure, set the URL as shown
-# in the example above and provide the storage account name and credentials here.
-[storage.internal.azure]
-storageAccount = ""
-
-# Shared key credential.
-storageKey = ""
-
-# Client secret credentials. All are required and they take precedence over the shared
-# key credential if both are provided.
-tenantID = ""
-clientID = ""
-clientSecret = ""
+url = "file:///home/enduro/internal-storage/storage?metadata=skip&no_tmp_dir=true"
 
 [storage.event]
 redisAddress = "redis://redis.enduro-sdps:6379"

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.artefactual.dev/amclient v0.4.1-0.20240705155055-0c5abef5207c
 	go.artefactual.dev/ssclient v0.11.0
-	go.artefactual.dev/tools v0.25.0
+	go.artefactual.dev/tools v0.25.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.63.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0

--- a/go.sum
+++ b/go.sum
@@ -1039,8 +1039,8 @@ go.artefactual.dev/amclient v0.4.1-0.20240705155055-0c5abef5207c h1:kMgKuV9yx0LT
 go.artefactual.dev/amclient v0.4.1-0.20240705155055-0c5abef5207c/go.mod h1:oAOlZHC78IWjWDCqRM1/8K1x/WYmRUL3peujKCdoXaA=
 go.artefactual.dev/ssclient v0.11.0 h1:mRjB8J0IQ+gjg6ICtZxJm+whG56tvIyxT+x4bO6CQGc=
 go.artefactual.dev/ssclient v0.11.0/go.mod h1:0tO5nOwQ8naw+GcPBi2A7lXzPt4HUn7MPXqQwi7H3jY=
-go.artefactual.dev/tools v0.25.0 h1:vBPSN/iSUATGit5oMJj/S4ZyOvRVkj/+4lhZYxgPQqA=
-go.artefactual.dev/tools v0.25.0/go.mod h1:tW9DHZzeQO6H3Fjp0NCaRPqzGNLsDpDWELR4rssyels=
+go.artefactual.dev/tools v0.25.1 h1:kpnaIyv+60ip0IdaY4V1S6B6A+NQzVOHS+CGubp/kWw=
+go.artefactual.dev/tools v0.25.1/go.mod h1:tW9DHZzeQO6H3Fjp0NCaRPqzGNLsDpDWELR4rssyels=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/hack/kube/base/enduro-internal-storage.yaml
+++ b/hack/kube/base/enduro-internal-storage.yaml
@@ -1,0 +1,12 @@
+# The default filesystem-backed internal storage assumes all Enduro
+# pods using this PVC are scheduled on the same Kubernetes node.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: enduro-internal-storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/hack/kube/base/enduro.yaml
+++ b/hack/kube/base/enduro.yaml
@@ -14,7 +14,21 @@ spec:
         app: enduro
     spec:
       serviceAccountName: sdps
+      securityContext:
+        fsGroup: 1000
       initContainers:
+        - name: init-internal-storage
+          image: busybox:1.37.0
+          imagePullPolicy: IfNotPresent
+          command:
+            [
+              "sh",
+              "-c",
+              "mkdir -p /home/enduro/internal-storage/ingest /home/enduro/internal-storage/storage /home/enduro/internal-storage/sip-source && chown -R 1000:1000 /home/enduro/internal-storage",
+            ]
+          volumeMounts:
+            - name: enduro-internal-storage
+              mountPath: /home/enduro/internal-storage
         - name: check-temporal
           image: busybox:1.37.0
           imagePullPolicy: IfNotPresent
@@ -82,11 +96,16 @@ spec:
             - name: enduro-config
               mountPath: /home/enduro/enduro-config
               readOnly: true
+            - name: enduro-internal-storage
+              mountPath: /home/enduro/internal-storage
           resources: {}
       volumes:
         - name: enduro-config
           secret:
             secretName: enduro-config
+        - name: enduro-internal-storage
+          persistentVolumeClaim:
+            claimName: enduro-internal-storage
 ---
 apiVersion: v1
 kind: Service

--- a/hack/kube/base/kustomization.yaml
+++ b/hack/kube/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: enduro-sdps
 resources:
   - enduro-dashboard.yaml
+  - enduro-internal-storage.yaml
   - enduro.yaml
   - minio-setup-buckets-job.yaml
   - minio.yaml

--- a/hack/kube/overlays/dev-a3m/enduro-a3m.yaml
+++ b/hack/kube/overlays/dev-a3m/enduro-a3m.yaml
@@ -18,6 +18,18 @@ spec:
       securityContext:
         fsGroup: 1000
       initContainers:
+        - name: init-internal-storage
+          image: busybox:1.37.0
+          imagePullPolicy: IfNotPresent
+          command:
+            [
+              "sh",
+              "-c",
+              "mkdir -p /home/enduro/internal-storage/ingest /home/enduro/internal-storage/storage /home/enduro/internal-storage/sip-source && chown -R 1000:1000 /home/enduro/internal-storage",
+            ]
+          volumeMounts:
+            - name: enduro-internal-storage
+              mountPath: /home/enduro/internal-storage
         - name: check-temporal
           image: busybox:1.37.0
           imagePullPolicy: IfNotPresent
@@ -82,6 +94,8 @@ spec:
             - name: enduro-config
               mountPath: /home/enduro/enduro-config
               readOnly: true
+            - name: enduro-internal-storage
+              mountPath: /home/enduro/internal-storage
             - name: enduro-a3m
               mountPath: /home/a3m/.local/share/a3m/share
         - name: a3m
@@ -99,6 +113,9 @@ spec:
         - name: enduro-config
           secret:
             secretName: enduro-config
+        - name: enduro-internal-storage
+          persistentVolumeClaim:
+            claimName: enduro-internal-storage
   volumeClaimTemplates:
     - metadata:
         name: enduro-a3m

--- a/hack/kube/overlays/dev-am/enduro-am.yaml
+++ b/hack/kube/overlays/dev-am/enduro-am.yaml
@@ -18,6 +18,18 @@ spec:
       securityContext:
         fsGroup: 1000
       initContainers:
+        - name: init-internal-storage
+          image: busybox:1.37.0
+          imagePullPolicy: IfNotPresent
+          command:
+            [
+              "sh",
+              "-c",
+              "mkdir -p /home/enduro/internal-storage/ingest /home/enduro/internal-storage/storage /home/enduro/internal-storage/sip-source && chown -R 1000:1000 /home/enduro/internal-storage",
+            ]
+          volumeMounts:
+            - name: enduro-internal-storage
+              mountPath: /home/enduro/internal-storage
         - name: check-temporal
           image: busybox:1.37.0
           imagePullPolicy: IfNotPresent
@@ -130,6 +142,8 @@ spec:
             - name: enduro-config
               mountPath: /home/enduro/enduro-config
               readOnly: true
+            - name: enduro-internal-storage
+              mountPath: /home/enduro/internal-storage
             - name: ssh-volume
               mountPath: "/etc/ssh"
               readOnly: true
@@ -137,6 +151,9 @@ spec:
         - name: enduro-config
           secret:
             secretName: enduro-config
+        - name: enduro-internal-storage
+          persistentVolumeClaim:
+            claimName: enduro-internal-storage
         - name: ssh-volume
           secret:
             secretName: enduro-am-secret

--- a/internal/ingest/download_sip_test.go
+++ b/internal/ingest/download_sip_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	"go.artefactual.dev/tools/bucket"
 	"go.uber.org/mock/gomock"
 	"gocloud.dev/blob"
-	"gocloud.dev/blob/memblob"
 	"gotest.tools/v3/assert"
 
 	"github.com/artefactual-sdps/enduro/internal/api/auth"
@@ -36,8 +36,12 @@ var (
 	content = []byte("zipcontent")
 )
 
-func setupBucket(t *testing.T) *blob.Bucket {
-	bucket := memblob.OpenBucket(nil)
+func setupBucket(t *testing.T, params string) *blob.Bucket {
+	bucket, err := bucket.NewWithConfig(
+		t.Context(),
+		&bucket.Config{URL: "file://" + t.TempDir() + params},
+	)
+	assert.NilError(t, err)
 	t.Cleanup(func() {
 		if err := bucket.Close(); err != nil {
 			t.Fatalf("close bucket: %v", err)
@@ -55,8 +59,6 @@ func setupBucket(t *testing.T) *blob.Bucket {
 
 func TestDownloadSipRequest(t *testing.T) {
 	t.Parallel()
-
-	bucket := setupBucket(t)
 
 	for _, tt := range []struct {
 		name    string
@@ -144,6 +146,7 @@ func TestDownloadSipRequest(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
+			bucket := setupBucket(t, "")
 			ticketStoreMock := auth_fake.NewMockTicketStore(gomock.NewController(t))
 			psvcMock := persistence_fake.NewMockService(gomock.NewController(t))
 			if tt.mock != nil {
@@ -174,15 +177,14 @@ func TestDownloadSipRequest(t *testing.T) {
 func TestDownloadSip(t *testing.T) {
 	t.Parallel()
 
-	bucket := setupBucket(t)
-
 	for _, tt := range []struct {
-		name     string
-		payload  *goaingest.DownloadSipPayload
-		mock     func(context.Context, *auth_fake.MockTicketStore, *persistence_fake.MockService)
-		wantErr  string
-		wantRes  *goaingest.DownloadSipResult
-		wantBody []byte
+		name         string
+		bucketParams string
+		payload      *goaingest.DownloadSipPayload
+		mock         func(context.Context, *auth_fake.MockTicketStore, *persistence_fake.MockService)
+		wantErr      string
+		wantRes      *goaingest.DownloadSipResult
+		wantBody     []byte
 	}{
 		{
 			name:    "Fails to download a SIP (missing ticket)",
@@ -283,11 +285,35 @@ func TestDownloadSip(t *testing.T) {
 				ContentLength:      int64(len(content)),
 			},
 		},
+		{
+			name:         "Downloads a SIP with metadata=skip in fileblob bucket URL",
+			bucketParams: "?metadata=skip",
+			payload: &goaingest.DownloadSipPayload{
+				Ticket: new("valid-ticket"),
+				UUID:   sipUUID.String(),
+			},
+			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
+				ts.EXPECT().GetDel(ctx, "valid-ticket", nil).Return(nil)
+				psvc.EXPECT().
+					ReadSIP(ctx, sipUUID).
+					Return(
+						&datatypes.SIP{UUID: sipUUID, FailedAs: enums.SIPFailedAsSIP, FailedKey: key},
+						nil,
+					)
+			},
+			wantBody: content,
+			wantRes: &goaingest.DownloadSipResult{
+				ContentDisposition: fmt.Sprintf("attachment; filename=%q", key),
+				ContentType:        "application/octet-stream",
+				ContentLength:      int64(len(content)),
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
+			bucket := setupBucket(t, tt.bucketParams)
 			ticketStoreMock := auth_fake.NewMockTicketStore(gomock.NewController(t))
 			psvcMock := persistence_fake.NewMockService(gomock.NewController(t))
 			if tt.mock != nil {

--- a/internal/storage/activities/aip_deletion_report_test.go
+++ b/internal/storage/activities/aip_deletion_report_test.go
@@ -13,8 +13,6 @@ import (
 	temporalsdk_activity "go.temporal.io/sdk/activity"
 	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
 	"go.uber.org/mock/gomock"
-	"gocloud.dev/blob"
-	_ "gocloud.dev/blob/memblob"
 	"gotest.tools/v3/assert"
 
 	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
@@ -71,7 +69,10 @@ func expectReadWorkflows(msvc *fake.MockService, id int) {
 func expectLocation(t *testing.T, msvc *fake.MockService) {
 	t.Helper()
 
-	loc, err := storage.NewInternalLocation(t.Context(), &bucket.Config{URL: "mem://"})
+	loc, err := storage.NewInternalLocation(
+		t.Context(),
+		&bucket.Config{URL: "file://" + t.TempDir() + "?metadata=skip&no_tmp_dir=true"},
+	)
 	if err != nil {
 		t.Fatalf("couldn't create internal location: %v", err)
 	}
@@ -292,12 +293,6 @@ func TestAIPDeletionReportActivity(t *testing.T) {
 			if tc.expectedFormFill != nil {
 				tc.expectedFormFill(t, mff, aipID)
 			}
-
-			bucket, err := blob.OpenBucket(t.Context(), "mem://")
-			if err != nil {
-				t.Fatalf("failed to open in-memory bucket: %v", err)
-			}
-			defer bucket.Close()
 
 			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
 			env := ts.NewTestActivityEnvironment()

--- a/internal/storage/location_test.go
+++ b/internal/storage/location_test.go
@@ -27,6 +27,10 @@ func TestNewInternalLocation(t *testing.T) {
 			config: &bucket.Config{URL: "mem://"},
 		},
 		{
+			name:   "Returns an internal filesystem location",
+			config: &bucket.Config{URL: "file://" + t.TempDir() + "?metadata=skip&no_tmp_dir=true"},
+		},
+		{
 			name:   "Errors on an empty configuration",
 			config: &bucket.Config{},
 			errMsg: "NewInternalLocation: open bucket: s3blob.OpenBucket: bucketName is required",

--- a/internal/storage/service_test.go
+++ b/internal/storage/service_test.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/mock/gomock"
 	goa "goa.design/goa/v3/pkg"
 	"gocloud.dev/blob"
-	_ "gocloud.dev/blob/fileblob"
 	"gotest.tools/v3/assert"
 	tfs "gotest.tools/v3/fs"
 

--- a/internal/storage/types/location_config_test.go
+++ b/internal/storage/types/location_config_test.go
@@ -194,7 +194,7 @@ func TestLocationConfigDecoding(t *testing.T) {
 			},
 			extra: func(c types.LocationConfig) {
 				_, err := c.Value.OpenBucket(context.Background())
-				assert.Error(t, err, `open bucket by URL: open blob.Bucket: no driver registered for "foo" for URL "foo://test-bucket"; available schemes: azblob, mem, s3, sftp`)
+				assert.Error(t, err, `open bucket by URL: open blob.Bucket: no driver registered for "foo" for URL "foo://test-bucket"; available schemes: azblob, file, mem, s3, sftp`)
 			},
 		},
 		"Rejects unknown config": {

--- a/internal/watcher/filesystem.go
+++ b/internal/watcher/filesystem.go
@@ -14,7 +14,6 @@ import (
 	"go.artefactual.dev/tools/bucket"
 	"go.artefactual.dev/tools/fsutil"
 	"gocloud.dev/blob"
-	_ "gocloud.dev/blob/fileblob"
 
 	"github.com/artefactual-sdps/enduro/internal/filenotify"
 )


### PR DESCRIPTION
Switch the sample config to filesystem internal storage and SIP source
buckets, with links to the relevant documentation. Update the gotools
dependency so fileblob support is registered centrally, and adjust tests
to cover filesystem bucket behavior.

Add shared documentation for bucket configuration, including filesystem
URLs, S3-compatible options, Azure URL auth sections, and fileblob URL
parameters.

**Add shared internal storage volume**

Add an enduro-internal-storage PVC to the development Kubernetes
manifests and mount it into the API and worker pods. Initialize the
ingest, storage, and SIP source directories on the volume before the
containers start so file:// buckets can open against a fresh PVC.

Create the same runtime directories in the container base image for
non-Kubernetes runs. Move the shared PREMIS schema copy into the base
stage and make the worker image copies owned by the enduro user for
consistent runtime permissions.

Refs #1660.