### PR TITLE
Stage a3m AIPs through a shared bucket

### DIFF
--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -33,6 +33,7 @@ import (
 	temporalsdk_contrib_opentelemetry "go.temporal.io/sdk/contrib/opentelemetry"
 	temporalsdk_interceptor "go.temporal.io/sdk/interceptor"
 	temporalsdk_worker "go.temporal.io/sdk/worker"
+	"gocloud.dev/blob"
 
 	"github.com/artefactual-sdps/enduro/internal/a3m"
 	"github.com/artefactual-sdps/enduro/internal/api/auth"
@@ -53,6 +54,9 @@ import (
 
 const (
 	appName = "enduro-a3m-worker"
+
+	// aipStagingPrefix must match storage.AIPPrefix.
+	aipStagingPrefix = "aips/"
 )
 
 func main() {
@@ -213,6 +217,22 @@ func main() {
 		}
 	}
 
+	// Set up the storage API client.
+	storageClient, err := ingest.NewStorageClient(ctx, tp, cfg.Ingest.Storage)
+	if err != nil {
+		logger.Error(err, "Error setting up storage API client.")
+		os.Exit(1)
+	}
+
+	// Set up the AIP staging bucket.
+	aipStagingBucket, err := bucket.NewWithConfig(ctx, &cfg.A3m.AIPStaging)
+	if err != nil {
+		logger.Error(err, "Error setting up AIP staging bucket.")
+		os.Exit(1)
+	}
+	aipStagingBucket = blob.PrefixedBucket(aipStagingBucket, aipStagingPrefix)
+	defer aipStagingBucket.Close()
+
 	var g run.Group
 
 	// Activity worker.
@@ -289,17 +309,10 @@ func main() {
 			removepaths.New().Execute,
 			temporalsdk_activity.RegisterOptions{Name: removepaths.Name},
 		)
-
-		storageClient, err := ingest.NewStorageClient(ctx, tp, cfg.Ingest.Storage)
-		if err != nil {
-			logger.Error(err, "Error setting up storage API client.")
-			os.Exit(1)
-		}
 		w.RegisterActivityWithOptions(
-			activities.NewUploadActivity(storageClient).Execute,
+			activities.NewUploadActivity(storageClient, aipStagingBucket).Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.UploadActivityName},
 		)
-
 		w.RegisterActivityWithOptions(
 			activities.NewMoveToPermanentStorageActivity(storageClient).Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.MoveToPermanentStorageActivityName},

--- a/docs/src/admin-manual/configuration.md
+++ b/docs/src/admin-manual/configuration.md
@@ -550,6 +550,7 @@ Several Enduro settings use the same bucket configuration shape for filesystem
 or object store locations:
 
 * `[storage.internal]`
+* `[a3m.aipStaging]`
 * `[internalStorage]`
 * `[sipsource.bucket]`
 
@@ -561,8 +562,8 @@ alternatively be configured with the endpoint, credentials, region, and bucket
 fields below.
 
 Use the examples below with the section you are configuring. Replace
-`[example.bucket]` with `[storage.internal]`, `[internalStorage]`, or
-`[sipsource.bucket]` as appropriate.
+`[example.bucket]` with `[storage.internal]`, `[internalStorage]`,
+`[a3m.aipStaging]`, or `[sipsource.bucket]` as appropriate.
 
 **Example filesystem URL configuration**:
 
@@ -644,6 +645,7 @@ value. Then add the matching Azure authentication section:
 
 * `[storage.internal]` uses `[storage.internal.azure]`.
 * `[internalStorage]` uses `[internalStorage.azure]`.
+* `[a3m.aipStaging]` uses `[a3m.aipStaging.azure]`.
 * `[sipsource.bucket]` uses `[sipsource.bucket.azure]`.
 
 **Example Azure shared key configuration**:
@@ -814,9 +816,17 @@ Because Enduro writes to this bucket through `fileblob`, include
 be on another filesystem.
 
 For Archivematica deployments, this internal location is used for AIP deletion
-reports while final AIPs are stored in Archivematica Storage Service. The a3m
-AIP staging flow still requires an internal location backend that supports
-signed URLs.
+reports while final AIPs are stored in Archivematica Storage Service.
+
+For a3m deployments, the a3m worker writes completed AIPs directly to this
+bucket through its own `[a3m.aipStaging]` configuration, and the storage
+service later reads staged AIPs from this bucket. Both sections must point to
+the same bucket root. For filesystem-backed storage, this means the configured
+path must be mounted at the same path for both processes.
+
+Staged a3m AIPs are written under the fixed `aips/` prefix inside
+`[storage.internal]`. Configure the bucket URL as the root of the internal
+storage bucket, not as the `aips/` directory itself.
 
 #### Storage event listener
 
@@ -903,6 +913,28 @@ capacity = 1
     ```
 
 * `capacity`: Limits the number of SIPs a worker can process at one time.
+
+#### a3m AIP staging bucket
+
+These settings configure the ingest-domain view of the bucket where the a3m
+worker writes completed AIPs before the storage domain reads them. Configure
+this bucket with the shared
+[bucket configuration options](#bucket-configuration-options), using
+`[a3m.aipStaging]` as the bucket section. For Azure Blob Storage, use
+`[a3m.aipStaging.azure]` as the matching authentication section.
+
+For a3m deployments, this bucket must point to the same bucket root as
+`[storage.internal]`. Staged AIPs are written under the fixed `aips/` prefix
+inside the bucket.
+
+For Archivematica deployments this bucket configuration is ignored.
+
+**Example filesystem configuration**:
+
+```toml
+[a3m.aipStaging]
+url = "file:///home/enduro/internal-storage/storage?metadata=skip&no_tmp_dir=true"
+```
 
 #### a3m processing configuration
 

--- a/enduro.toml
+++ b/enduro.toml
@@ -3,6 +3,14 @@
 # parameter can be turned into an environment variable. See the Enduro
 # Administrator's manual for further guidance.
 
+#########################################################################
+#                                                                       #
+#                         GLOBAL CONFIGURATION                          #
+#                                                                       #
+#  The settings below are used by both the ingest and storage domains.  #
+#                                                                       #
+#########################################################################
+
 debug = true
 debugListen = "127.0.0.1:9001"
 # verbosity supports values from 0-128, with 0 as least verbose and 128
@@ -112,6 +120,19 @@ maxSize = 100
 # (default: false).
 compress = false
 
+[telemetry.traces]
+enabled = false
+address = ""
+samplingRatio = 1.0
+
+#########################################################################
+#                                                                       #
+#                         INGEST CONFIGURATION                          #
+#                                                                       #
+#         The settings below are only used by the ingest domain.        #
+#                                                                       #
+#########################################################################
+
 [database]
 driver = "mysql"
 dsn = "enduro:enduro123@tcp(mysql.enduro-sdps:3306)/enduro"
@@ -170,6 +191,10 @@ taskqueue = "am"
 [a3m]
 address = "127.0.0.1:7000"
 shareDir = "/home/a3m/.local/share/a3m/share"
+
+# https://enduro.readthedocs.io/admin-manual/configuration/#a3m-aip-staging-bucket
+[a3m.aipStaging]
+url = "file:///home/enduro/internal-storage/storage?metadata=skip&no_tmp_dir=true"
 
 [a3m.processing]
 AssignUuidsToDirectories = true
@@ -269,11 +294,6 @@ retentionPeriod = "0"
 [sipsource.bucket]
 url = "file:///home/enduro/internal-storage/sip-source?metadata=skip"
 
-[telemetry.traces]
-enabled = false
-address = ""
-samplingRatio = 1.0
-
 # Configuration for a preprocessing child workflow run before preservation.
 # Uncomment to activate. All fields except "extract" are required.
 # [[childWorkflows]]
@@ -350,9 +370,9 @@ retryBackoffCoefficient = 2.0
 
 #########################################################################
 #                                                                       #
-#                     STORAGE SERVICE CONFIGURATION                     #
+#                         STORAGE CONFIGURATION                         #
 #                                                                       #
-# The configuration settings below are specific to the storage service. #
+#        The settings below are only used by the storage domain.        #
 #                                                                       #
 #########################################################################
 

--- a/internal/a3m/config.go
+++ b/internal/a3m/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	transferservice "buf.build/gen/go/artefactual/a3m/protocolbuffers/go/a3m/api/transferservice/v1beta1"
+	"go.artefactual.dev/tools/bucket"
 )
 
 const (
@@ -15,6 +16,8 @@ type Config struct {
 	Name     string
 	ShareDir string
 	Address  string
+
+	AIPStaging bucket.Config
 
 	Processing
 }

--- a/internal/workflow/activities/upload.go
+++ b/internal/workflow/activities/upload.go
@@ -3,12 +3,15 @@ package activities
 import (
 	"context"
 	"errors"
-	"net/http"
+	"io"
 	"os"
 	"time"
 
+	"gocloud.dev/blob"
+
 	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
 	"github.com/artefactual-sdps/enduro/internal/ingest"
+	"github.com/artefactual-sdps/enduro/internal/storage/enums"
 )
 
 type UploadActivityParams struct {
@@ -18,62 +21,50 @@ type UploadActivityParams struct {
 }
 
 type UploadActivity struct {
-	storageClient ingest.StorageClient
+	storageClient    ingest.StorageClient
+	aipStagingBucket *blob.Bucket
 }
 
 type UploadActivityResult struct{}
 
-func NewUploadActivity(storageClient ingest.StorageClient) *UploadActivity {
+func NewUploadActivity(storageClient ingest.StorageClient, aipStagingBucket *blob.Bucket) *UploadActivity {
 	return &UploadActivity{
-		storageClient: storageClient,
+		storageClient:    storageClient,
+		aipStagingBucket: aipStagingBucket,
 	}
 }
 
 func (a *UploadActivity) Execute(ctx context.Context, params *UploadActivityParams) (*UploadActivityResult, error) {
-	childCtx, cancel := context.WithTimeout(ctx, time.Second*5)
-	defer cancel()
-	res, err := a.storageClient.SubmitAip(childCtx, &goastorage.SubmitAipPayload{
-		UUID: params.AIPID,
-		Name: params.Name,
-	})
-	if err != nil {
+	if err := a.uploadToAIPStagingBucket(ctx, params); err != nil {
 		return &UploadActivityResult{}, err
 	}
 
-	// Upload to MinIO using the upload pre-signed URL.
-	{
-		f, err := os.Open(params.AIPPath)
-		if err != nil {
-			return &UploadActivityResult{}, err
-		}
-		defer f.Close()
-
-		uploadReq, err := http.NewRequestWithContext(ctx, http.MethodPut, res.URL, f)
-		if err != nil {
-			return &UploadActivityResult{}, err
-		}
-
-		fi, err := f.Stat()
-		if err != nil {
-			return &UploadActivityResult{}, err
-		}
-
-		uploadReq.ContentLength = fi.Size()
-
-		minioClient := &http.Client{}
-		resp, err := minioClient.Do(uploadReq)
-		if err != nil {
-			return &UploadActivityResult{}, err
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return &UploadActivityResult{}, errors.New("unexpected status code returned")
-		}
-	}
-
-	childCtx, cancel = context.WithTimeout(ctx, time.Second*5)
+	childCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
-	err = a.storageClient.SubmitAipComplete(childCtx, &goastorage.SubmitAipCompletePayload{UUID: params.AIPID})
+	_, err := a.storageClient.CreateAip(childCtx, &goastorage.CreateAipPayload{
+		UUID:      params.AIPID,
+		Name:      params.Name,
+		ObjectKey: params.AIPID,
+		Status:    enums.AIPStatusPending.String(),
+	})
 
 	return &UploadActivityResult{}, err
+}
+
+func (a *UploadActivity) uploadToAIPStagingBucket(ctx context.Context, params *UploadActivityParams) error {
+	f, err := os.Open(params.AIPPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	w, err := a.aipStagingBucket.NewWriter(ctx, params.AIPID, nil)
+	if err != nil {
+		return err
+	}
+
+	_, copyErr := io.Copy(w, f)
+	closeErr := w.Close()
+
+	return errors.Join(copyErr, closeErr)
 }

--- a/internal/workflow/activities/upload_test.go
+++ b/internal/workflow/activities/upload_test.go
@@ -3,114 +3,108 @@ package activities
 import (
 	"context"
 	"errors"
-	"io"
-	"net/http"
-	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/google/uuid"
+	"go.artefactual.dev/tools/bucket"
 	"go.artefactual.dev/tools/mockutil"
 	"go.uber.org/mock/gomock"
+	"gocloud.dev/blob"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"
 
 	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
 	"github.com/artefactual-sdps/enduro/internal/ingest/fake"
-	"github.com/artefactual-sdps/enduro/internal/storage"
+	storage_enums "github.com/artefactual-sdps/enduro/internal/storage/enums"
 )
 
-func MinIOUploadPreSignedURLHandler(t *testing.T) func(rw http.ResponseWriter, req *http.Request) {
-	return func(rw http.ResponseWriter, req *http.Request) {
-		bytes, err := io.ReadAll(req.Body)
-		defer req.Body.Close()
-
-		assert.NilError(t, err)
-		assert.DeepEqual(t, bytes, []byte("contents-of-the-aip"))
-	}
-}
-
 func TestUploadActivity(t *testing.T) {
-	t.Run("Activity runs successfully", func(t *testing.T) {
-		minioTestServer := httptest.NewServer(http.HandlerFunc(MinIOUploadPreSignedURLHandler(t)))
-		defer minioTestServer.Close()
+	t.Parallel()
 
-		aipUUID := uuid.New().String()
-		aipName := "aip.7z"
+	type test struct {
+		name        string
+		sourceFile  bool
+		createErr   error
+		wantErr     string
+		wantContent string
+	}
 
-		mockClient := fake.NewMockStorageClient(gomock.NewController(t))
-		mockClient.EXPECT().
-			SubmitAip(
-				mockutil.Context(),
-				&goastorage.SubmitAipPayload{
-					UUID: aipUUID,
-					Name: aipName,
+	for _, tc := range []test{
+		{
+			name:        "Activity runs successfully",
+			sourceFile:  true,
+			wantContent: "contents-of-the-aip",
+		},
+		{
+			name:       "Activity returns an error if CreateAIP fails",
+			sourceFile: true,
+			createErr:  errors.New("create failed"),
+			wantErr:    "create failed",
+		},
+		{
+			name:    "Activity returns an error if the source file is missing",
+			wantErr: "open",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			aipUUID := uuid.New().String()
+			aipName := "aip.7z"
+
+			mockClient := fake.NewMockStorageClient(gomock.NewController(t))
+			if tc.sourceFile {
+				mockClient.EXPECT().
+					CreateAip(
+						mockutil.Context(),
+						&goastorage.CreateAipPayload{
+							UUID:      aipUUID,
+							Name:      aipName,
+							ObjectKey: aipUUID,
+							Status:    storage_enums.AIPStatusPending.String(),
+						},
+					).
+					Return(&goastorage.AIP{}, tc.createErr)
+			}
+
+			var tmpDir *fs.Dir
+			if tc.sourceFile {
+				tmpDir = fs.NewDir(t, "", fs.WithFile("aip.7z", "contents-of-the-aip"))
+			} else {
+				tmpDir = fs.NewDir(t, "")
+			}
+			defer tmpDir.Remove()
+
+			sharedDir := fs.NewDir(t, "")
+			defer sharedDir.Remove()
+			stagingBucket, err := bucket.NewWithConfig(
+				t.Context(),
+				&bucket.Config{
+					URL: "file://" + sharedDir.Path() + "?metadata=skip&no_tmp_dir=true",
 				},
-			).
-			Return(
-				&goastorage.SubmitAIPResult{
-					URL: minioTestServer.URL + "/" + storage.AIPPrefix + "foobar.7z",
-				},
-				nil,
 			)
-		mockClient.EXPECT().
-			SubmitAipComplete(
-				mockutil.Context(),
-				&goastorage.SubmitAipCompletePayload{UUID: aipUUID},
-			).
-			Return(nil)
+			assert.NilError(t, err)
+			defer stagingBucket.Close()
 
-		tmpDir := fs.NewDir(t, "", fs.WithFile("aip.7z", "contents-of-the-aip"))
-		defer tmpDir.Remove()
+			activity := NewUploadActivity(mockClient, blob.PrefixedBucket(stagingBucket, "aips/"))
 
-		activity := NewUploadActivity(mockClient)
+			_, err = activity.Execute(context.Background(), &UploadActivityParams{
+				AIPPath: tmpDir.Join(aipName),
+				AIPID:   aipUUID,
+				Name:    aipName,
+			})
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			assert.NilError(t, err)
 
-		_, err := activity.Execute(context.Background(), &UploadActivityParams{
-			AIPPath: tmpDir.Join(aipName),
-			AIPID:   aipUUID,
-			Name:    aipName,
+			if tc.wantContent != "" {
+				contents, err := os.ReadFile(sharedDir.Join("aips/", aipUUID))
+				assert.NilError(t, err)
+				assert.DeepEqual(t, string(contents), tc.wantContent)
+			}
 		})
-		assert.NilError(t, err)
-	})
-
-	t.Run("Activity returns an error if final Update call fails", func(t *testing.T) {
-		minioTestServer := httptest.NewServer(http.HandlerFunc(MinIOUploadPreSignedURLHandler(t)))
-		defer minioTestServer.Close()
-
-		aipUUID := uuid.New().String()
-		aipName := "aip.7z"
-
-		mockClient := fake.NewMockStorageClient(gomock.NewController(t))
-		mockClient.EXPECT().
-			SubmitAip(
-				mockutil.Context(),
-				&goastorage.SubmitAipPayload{
-					UUID: aipUUID,
-					Name: aipName,
-				},
-			).
-			Return(
-				&goastorage.SubmitAIPResult{
-					URL: minioTestServer.URL + "/" + storage.AIPPrefix + "foobar.7z",
-				},
-				nil,
-			)
-		mockClient.EXPECT().
-			SubmitAipComplete(
-				mockutil.Context(),
-				&goastorage.SubmitAipCompletePayload{UUID: aipUUID},
-			).
-			Return(errors.New("update failed"))
-
-		tmpDir := fs.NewDir(t, "", fs.WithFile("aip.7z", "contents-of-the-aip"))
-		defer tmpDir.Remove()
-
-		activity := NewUploadActivity(mockClient)
-
-		_, err := activity.Execute(context.Background(), &UploadActivityParams{
-			AIPPath: tmpDir.Join(aipName),
-			AIPID:   aipUUID,
-			Name:    aipName,
-		})
-		assert.Error(t, err, "update failed")
-	})
+	}
 }

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -679,7 +679,7 @@ func (w *ProcessingWorkflow) transferA3m(
 		uploadTaskID = id
 	}
 
-	// Upload AIP to MinIO.
+	// Upload AIP to staging bucket.
 	{
 		activityOpts := temporalsdk_workflow.WithActivityOptions(sessCtx, temporalsdk_workflow.ActivityOptions{
 			StartToCloseTimeout: time.Hour * 24,

--- a/internal/workflow/processing_expectations_test.go
+++ b/internal/workflow/processing_expectations_test.go
@@ -25,6 +25,7 @@ const (
 	tempPath            = "/tmp/enduro123456"
 	extractPath         = "/tmp/enduro123456/extract"
 	transferPath        = "/home/a3m/.local/share/a3m/share/enduro2985726865"
+	a3mAIPPath          = "/home/a3m/.local/share/a3m/share/completed/name.zip-9e8161cc-2815-4d6f-8a75-f003c41b257b.7z"
 	prepSharedPath      = "/home/enduro/preprocessing/"
 	prepDownloadPath    = "/home/enduro/preprocessing/enduro123456"
 	prepExtractPath     = "/home/enduro/preprocessing/enduro123456/extract"
@@ -419,15 +420,16 @@ var expectations = map[string]expectationFunc{
 				Path:         transferPath,
 				WorkflowUUID: workflowUUID,
 			},
-		).Return(&a3m.CreateAIPActivityResult{UUID: aipUUID.String()}, nil)
+		).Return(&a3m.CreateAIPActivityResult{UUID: aipUUID.String(), Path: a3mAIPPath}, nil)
 	},
 	"uploadAIP": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
 		s.env.OnActivity(
 			activities.UploadActivityName,
 			sessionCtx,
 			&activities.UploadActivityParams{
-				Name:  sipName,
-				AIPID: aipUUID.String(),
+				Name:    sipName,
+				AIPID:   aipUUID.String(),
+				AIPPath: a3mAIPPath,
 			},
 		).Return(nil, nil)
 	},

--- a/internal/workflow/processing_setup_test.go
+++ b/internal/workflow/processing_setup_test.go
@@ -249,7 +249,7 @@ func (s *ProcessingWorkflowTestSuite) setupA3mWorkflowTest(
 		temporalsdk_activity.RegisterOptions{Name: a3m.CreateAIPActivityName},
 	)
 	s.env.RegisterActivityWithOptions(
-		activities.NewUploadActivity(nil).Execute,
+		activities.NewUploadActivity(nil, nil).Execute,
 		temporalsdk_activity.RegisterOptions{Name: activities.UploadActivityName},
 	)
 	s.env.RegisterActivityWithOptions(


### PR DESCRIPTION
Stage a3m AIPs through a bucket shared by the ingest and storage
domains instead of sending them through the storage signed URL
upload flow. The a3m worker now opens the ingest storage AIP
staging bucket, prefixes it with the fixed aips/ prefix and passes it
to the upload activity, which writes the AIP then creates the storage
AIP record with a pending status.

Add the [a3m.aipStaging] configuration section and document that
it must point to the same bucket root as [storage.internal]. Update
the sample config and admin manual to describe the shared bucket
requirement and the fixed aips/ prefix.

Refs #1660.