### PR TITLE
Check for duplicate SIP submissions

### DIFF
--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -273,6 +273,14 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: activities.GetSIPExtensionActivityName},
 		)
 		w.RegisterActivityWithOptions(
+			activities.NewCalcFileChecksumActivity().Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.CalcFileChecksumActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			activities.NewCheckDuplicateSIPActivity(ingestsvc).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.CheckDuplicateSIPActivityName},
+		)
+		w.RegisterActivityWithOptions(
 			archiveextract.New(cfg.ExtractActivity).Execute,
 			temporalsdk_activity.RegisterOptions{Name: archiveextract.Name},
 		)

--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -264,6 +264,14 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: activities.GetSIPExtensionActivityName},
 		)
 		w.RegisterActivityWithOptions(
+			activities.NewCalcFileChecksumActivity().Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.CalcFileChecksumActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			activities.NewCheckDuplicateSIPActivity(ingestsvc).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.CheckDuplicateSIPActivityName},
+		)
+		w.RegisterActivityWithOptions(
 			archiveextract.New(cfg.ExtractActivity).Execute,
 			temporalsdk_activity.RegisterOptions{Name: archiveextract.Name},
 		)

--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -508,7 +508,12 @@ func main() {
 
 		// Ingest processing workflow and activities.
 		w.RegisterWorkflowWithOptions(
-			workflow.NewProcessingWorkflow(cfg, rand.Reader, ingestsvc, wsvc).Execute,
+			workflow.NewProcessingWorkflow(
+				cfg,
+				rand.Reader,
+				ingestsvc,
+				wsvc,
+			).Execute,
 			temporalsdk_workflow.RegisterOptions{Name: ingest.ProcessingWorkflowName},
 		)
 		w.RegisterActivityWithOptions(

--- a/docs/src/admin-manual/configuration.md
+++ b/docs/src/admin-manual/configuration.md
@@ -691,6 +691,35 @@ When using Azure Blob Storage, Enduro supports two authentication modes:
 If both authentication modes are configured, the client secret settings take
 precedence.
 
+### Ingest settings
+
+The ingest configuration section configures the SIP ingest workflow.
+
+**Example configuration**:
+
+```toml
+[ingest]
+allowDuplicates = false
+```
+
+#### allowDuplicates
+
+The `allowDuplicates` setting toggles whether a SIP can be ingested more than
+once by Enduro. The default value (false) will stop ingest with a content error
+when a SIP archive file (e.g. a zip) is submitted that has the same checksum as
+a previously ingested SIP. SIPs submitted as a directory are not checked for
+duplicate contents.
+
+A SIP is only considered a duplicate if the checksum matches an existing
+SIP with a status of: "ingested", "pending", "processing", "queued", or
+"validated". If the SIP status is "error", "failed" or "canceled" the
+SIP will be ignored when checking for duplicates.
+
+A checksum is calculated and stored for every SIP archive ingested by Enduro,
+regardless of this setting. When `allowDuplicates` is false, a new ingest's
+checksum will be checked against all previously ingested SIP checksums, even if
+`allowDuplicates` was true when the old SIPs were ingested.
+
 ### Ingest storage settings
 
 This element configures the Enduro storage service API endpoint. Even when using

--- a/enduro.toml
+++ b/enduro.toml
@@ -84,8 +84,8 @@ claimPathSeparator = ""
 # to a value of ["*"] when `claimValuePrefix = "enduro:"`. The default "" will
 # not filter any value.
 claimValuePrefix = ""
-# Consider the values obtained from the claim as roles and use the `rolesMapping`
-# config below to map them to Enduro attributes.
+# Consider the values obtained from the claim as roles and use the 
+# `rolesMapping` config below to map them to Enduro attributes.
 useRoles = false
 # A JSON formatted string specifying a mapping from expected roles to Enduro
 # attributes. JSON format:
@@ -332,6 +332,19 @@ url = "file:///home/enduro/internal-storage/sip-source?metadata=skip"
 # namespace = "default"
 # taskQueue = "postbatch"
 # workflowName = "postbatch"
+
+# ingest configures the ingest service.
+[ingest]
+
+# allowDuplicates toggles whether a SIP can be ingested more than once.
+# The default value (false) will stop ingest with a content error when a SIP
+# archive file (e.g. zip) is submitted that has the same checksum as a
+# previously ingested SIP. SIPs submitted as a directory are not checked for
+# duplicate contents.
+#
+# See https://enduro.readthedocs.io/admin-manual/configuration/#allowduplicates 
+# for more details.
+allowDuplicates = false
 
 # [ingest.storage] configures ingest as a client of the storage API.
 # Use this section for cross-domain integration values:

--- a/internal/datatypes/checksum.go
+++ b/internal/datatypes/checksum.go
@@ -1,0 +1,10 @@
+package datatypes
+
+type ChecksumAlgo string
+
+const ChecksumAlgoSHA256 ChecksumAlgo = "SHA-256"
+
+type Checksum struct {
+	Algorithm ChecksumAlgo
+	Hash      string
+}

--- a/internal/datatypes/sip.go
+++ b/internal/datatypes/sip.go
@@ -41,6 +41,14 @@ type SIP struct {
 
 	// FileCount is the number of files in the SIP.
 	FileCount int32
+
+	// ChecksumAlgorithm is the algorithm used to calculate the checksum of the
+	// SIP.
+	ChecksumAlgorithm string
+
+	// ChecksumHash is the hash of a SIP archive (e.g. zip file) before it is
+	// extracted for processing.
+	ChecksumHash string
 }
 
 // Goa returns the API representation of the SIP.

--- a/internal/db/migrations/20260617185751_add_sip_checksum_columns.up.sql
+++ b/internal/db/migrations/20260617185751_add_sip_checksum_columns.up.sql
@@ -1,0 +1,2 @@
+-- Modify "sip" table
+ALTER TABLE `sip` ADD COLUMN `checksum_algorithm` varchar(255) NULL, ADD COLUMN `checksum_hash` varchar(255) NULL, ADD INDEX `sip_checksum_idx` (`checksum_algorithm`, `checksum_hash`);

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:SCNNo6ElQOyVdaaaPahyx3vTXaqfIPmBtHTqGdL0bGE=
+h1:RptdSZe/BOCD7awjIvIu7D5bhSb8Dl2D0KRqYu0YA+w=
 1570659451_init.up.sql h1:zyiKKl39RqMxuEhop5jeeiPTxPiSSq00Tn6u06gyNmk=
 1710442322_nullable_aip_id.up.sql h1:vL4eG5YELXr3k4ymhHuRD/R7KpNt3/DNRhH26t83x3A=
 20250207193001_rename_package_table.up.sql h1:d2RjfIturPoFYMMtFocrMvvjEXEqDXDdxQRttcknX/0=
@@ -19,3 +19,4 @@ h1:SCNNo6ElQOyVdaaaPahyx3vTXaqfIPmBtHTqGdL0bGE=
 20251121205505_add_batch_failed_status.up.sql h1:jfxlOIIF7+9jpPsCcm0GZ4KNt2+tcm8AaWmO+DWqaOU=
 20251124204400_add_sip_statuses.up.sql h1:EmniCLIzTUvVmmWfX7rQ75ZmO33v+hv3OlCP6ToRLPo=
 20260417140248_add_sip_file_count_column.up.sql h1:KZSZObToIAAAIy60Xo3MHMLun9uAY1SMyISD0s/Rmk8=
+20260617185751_add_sip_checksum_columns.up.sql h1:thgC5pgYbeFU1T5gPEm5G+ePwfQW4gVSMG6jLuVVLV4=

--- a/internal/ingest/config.go
+++ b/internal/ingest/config.go
@@ -10,6 +10,24 @@ import (
 )
 
 type Config struct {
+	// AllowDuplicates toggles whether a SIP can be ingested more than once.
+	// The default value (false) will stop ingest with a content error when a
+	// SIP archive file (e.g. zip) is submitted that has the same checksum as a
+	// previously ingested SIP. SIPs submitted as a directory are not checked
+	// for duplicate contents.
+	//
+	// A SIP is only considered a duplicate if the checksum matches an existing
+	// SIP with a status of: "ingested", "pending", "processing", "queued", or
+	// "validated". If the SIP status is "error", "failed" or "canceled" the
+	// SIP will be ignored when checking for duplicates.
+	//
+	// A checksum is calculated and stored for every SIP archive ingested by
+	// Enduro, regardless of this setting. When `allowDuplicates` is false, a
+	// new ingest's checksum will be checked against all previously ingested SIP
+	// checksums, even if `allowDuplicates` was true when the old SIPs were
+	// ingested.
+	AllowDuplicates bool
+
 	Storage StorageConfig
 }
 

--- a/internal/ingest/fake/mock_ingest.go
+++ b/internal/ingest/fake/mock_ingest.go
@@ -470,6 +470,45 @@ func (c *MockServiceDownloadSipRequestCall) DoAndReturn(f func(context.Context, 
 	return c
 }
 
+// FindDuplicateSIP mocks base method.
+func (m *MockService) FindDuplicateSIP(arg0 context.Context, arg1 uuid.UUID, arg2 datatypes.Checksum) (*datatypes.SIP, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindDuplicateSIP", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*datatypes.SIP)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindDuplicateSIP indicates an expected call of FindDuplicateSIP.
+func (mr *MockServiceMockRecorder) FindDuplicateSIP(arg0, arg1, arg2 any) *MockServiceFindDuplicateSIPCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDuplicateSIP", reflect.TypeOf((*MockService)(nil).FindDuplicateSIP), arg0, arg1, arg2)
+	return &MockServiceFindDuplicateSIPCall{Call: call}
+}
+
+// MockServiceFindDuplicateSIPCall wrap *gomock.Call
+type MockServiceFindDuplicateSIPCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockServiceFindDuplicateSIPCall) Return(arg0 *datatypes.SIP, arg1 error) *MockServiceFindDuplicateSIPCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockServiceFindDuplicateSIPCall) Do(f func(context.Context, uuid.UUID, datatypes.Checksum) (*datatypes.SIP, error)) *MockServiceFindDuplicateSIPCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockServiceFindDuplicateSIPCall) DoAndReturn(f func(context.Context, uuid.UUID, datatypes.Checksum) (*datatypes.SIP, error)) *MockServiceFindDuplicateSIPCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListBatches mocks base method.
 func (m *MockService) ListBatches(arg0 context.Context, arg1 *ingest.ListBatchesPayload) (*ingest.Batches, error) {
 	m.ctrl.T.Helper()

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -39,6 +40,7 @@ type Service interface {
 
 	CreateSIP(context.Context, *datatypes.SIP) error
 	UpdateSIP(context.Context, uuid.UUID, persistence.SIPUpdater) (*datatypes.SIP, error)
+	FindDuplicateSIP(context.Context, uuid.UUID, datatypes.Checksum) (*datatypes.SIP, error)
 	SetStatus(ctx context.Context, id uuid.UUID, status enums.SIPStatus) error
 	SetStatusInProgress(ctx context.Context, id uuid.UUID, startedAt time.Time) error
 	CreateWorkflow(ctx context.Context, w *datatypes.Workflow) error
@@ -141,6 +143,47 @@ func (svc *ingestImpl) UpdateSIP(
 	PublishEvent(ctx, svc.evsvc, ev)
 
 	return s, nil
+}
+
+func (svc *ingestImpl) FindDuplicateSIP(
+	ctx context.Context,
+	sipID uuid.UUID,
+	checksum datatypes.Checksum,
+) (*datatypes.SIP, error) {
+	// existingSIPStatuses is the list of SIP statuses that indicate a SIP has
+	// been ingested or is still active in the system. If a SIP has one of these
+	// statuses, its checksum should be considered a duplicate.
+	existingSIPStatuses := []enums.SIPStatus{
+		enums.SIPStatusIngested,
+		enums.SIPStatusPending,
+		enums.SIPStatusProcessing,
+		enums.SIPStatusQueued,
+		enums.SIPStatusValidated,
+	}
+
+	sips, _, err := svc.perSvc.ListSIPs(
+		ctx,
+		&persistence.SIPFilter{
+			ChecksumAlgorithm: new(string(checksum.Algorithm)),
+			ChecksumHash:      &checksum.Hash,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("find duplicate SIP: %v", err)
+	}
+
+	for _, sip := range sips {
+		// Don't check the current SIP's checksum against itself.
+		if sip.UUID == sipID {
+			continue
+		}
+
+		if slices.Contains(existingSIPStatuses, sip.Status) {
+			return sip, nil
+		}
+	}
+
+	return nil, nil
 }
 
 func (svc *ingestImpl) SetStatus(ctx context.Context, id uuid.UUID, status enums.SIPStatus) error {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/persistence"
 	persistence_fake "github.com/artefactual-sdps/enduro/internal/persistence/fake"
 	"github.com/artefactual-sdps/enduro/internal/sipsource"
+	"github.com/artefactual-sdps/enduro/internal/workflow/activities"
 )
 
 func testSvc(t *testing.T, internalBucket *blob.Bucket, uploadMaxSize int64) (
@@ -266,6 +267,189 @@ func TestUpdateSIP(t *testing.T) {
 
 			assert.NilError(t, err)
 			assert.DeepEqual(t, s, tt.want)
+		})
+	}
+}
+
+func TestFindDuplicateSIP(t *testing.T) {
+	t.Parallel()
+
+	sipID := uuid.MustParse("e8d32bd5-faa4-4ce1-bb50-55d9c28b306d")
+	hash := "abc123"
+	duplicateID := uuid.MustParse("f8d32bd5-faa4-4ce1-bb50-55d9c28b306d")
+
+	for _, tt := range []struct {
+		name      string
+		params    activities.CheckDuplicateSIPActivityParams
+		mockCalls func(*persistence_fake.MockServiceMockRecorder)
+		want      *datatypes.SIP
+		wantErr   string
+	}{
+		{
+			name: "Finds an ingested SIP with a duplicate checksum",
+			params: activities.CheckDuplicateSIPActivityParams{
+				SIPID: sipID,
+				Checksum: datatypes.Checksum{
+					Algorithm: datatypes.ChecksumAlgoSHA256,
+					Hash:      hash,
+				},
+			},
+			mockCalls: func(m *persistence_fake.MockServiceMockRecorder) {
+				m.ListSIPs(
+					mockutil.Context(),
+					&persistence.SIPFilter{
+						ChecksumAlgorithm: new(string(datatypes.ChecksumAlgoSHA256)),
+						ChecksumHash:      &hash,
+					},
+				).Return(
+					[]*datatypes.SIP{
+						{
+							UUID:              sipID,
+							Status:            enums.SIPStatusProcessing,
+							ChecksumAlgorithm: string(datatypes.ChecksumAlgoSHA256),
+							ChecksumHash:      hash,
+						},
+						{
+							UUID:              duplicateID,
+							Status:            enums.SIPStatusIngested,
+							ChecksumAlgorithm: string(datatypes.ChecksumAlgoSHA256),
+							ChecksumHash:      hash,
+						},
+					},
+					&persistence.Page{Total: 2},
+					nil,
+				)
+			},
+			want: &datatypes.SIP{
+				UUID:              duplicateID,
+				Status:            enums.SIPStatusIngested,
+				ChecksumAlgorithm: string(datatypes.ChecksumAlgoSHA256),
+				ChecksumHash:      hash,
+			},
+		},
+		{
+			name: "Finds a pending SIP with a duplicate checksum",
+			params: activities.CheckDuplicateSIPActivityParams{
+				SIPID: sipID,
+				Checksum: datatypes.Checksum{
+					Algorithm: datatypes.ChecksumAlgoSHA256,
+					Hash:      hash,
+				},
+			},
+			mockCalls: func(m *persistence_fake.MockServiceMockRecorder) {
+				m.ListSIPs(
+					mockutil.Context(),
+					&persistence.SIPFilter{
+						ChecksumAlgorithm: new(string(datatypes.ChecksumAlgoSHA256)),
+						ChecksumHash:      &hash,
+					},
+				).Return(
+					[]*datatypes.SIP{
+						{
+							UUID:              sipID,
+							Status:            enums.SIPStatusProcessing,
+							ChecksumAlgorithm: string(datatypes.ChecksumAlgoSHA256),
+							ChecksumHash:      hash,
+						},
+						{
+							UUID:              duplicateID,
+							Status:            enums.SIPStatusPending,
+							ChecksumAlgorithm: string(datatypes.ChecksumAlgoSHA256),
+							ChecksumHash:      hash,
+						},
+					},
+					&persistence.Page{Total: 2},
+					nil,
+				)
+			},
+			want: &datatypes.SIP{
+				UUID:              duplicateID,
+				Status:            enums.SIPStatusPending,
+				ChecksumAlgorithm: string(datatypes.ChecksumAlgoSHA256),
+				ChecksumHash:      hash,
+			},
+		},
+		{
+			name: "Ignores a failed SIP with a duplicate checksum",
+			params: activities.CheckDuplicateSIPActivityParams{
+				SIPID: sipID,
+				Checksum: datatypes.Checksum{
+					Algorithm: datatypes.ChecksumAlgoSHA256,
+					Hash:      hash,
+				},
+			},
+			mockCalls: func(m *persistence_fake.MockServiceMockRecorder) {
+				m.ListSIPs(
+					mockutil.Context(),
+					&persistence.SIPFilter{
+						ChecksumAlgorithm: new(string(datatypes.ChecksumAlgoSHA256)),
+						ChecksumHash:      &hash,
+					},
+				).Return(
+					[]*datatypes.SIP{
+						{
+							UUID:              sipID,
+							Status:            enums.SIPStatusProcessing,
+							ChecksumAlgorithm: string(datatypes.ChecksumAlgoSHA256),
+							ChecksumHash:      hash,
+						},
+						{
+							UUID:              duplicateID,
+							Status:            enums.SIPStatusFailed,
+							ChecksumAlgorithm: string(datatypes.ChecksumAlgoSHA256),
+							ChecksumHash:      hash,
+						},
+					},
+					&persistence.Page{Total: 2},
+					nil,
+				)
+			},
+			want: nil,
+		},
+		{
+			name: "Returns an error if the persistence service returns an error",
+			params: activities.CheckDuplicateSIPActivityParams{
+				SIPID: sipID,
+				Checksum: datatypes.Checksum{
+					Algorithm: datatypes.ChecksumAlgoSHA256,
+					Hash:      hash,
+				},
+			},
+			mockCalls: func(m *persistence_fake.MockServiceMockRecorder) {
+				m.ListSIPs(
+					mockutil.Context(),
+					&persistence.SIPFilter{
+						ChecksumAlgorithm: new(string(datatypes.ChecksumAlgoSHA256)),
+						ChecksumHash:      &hash,
+					},
+				).Return(nil, nil, fmt.Errorf("an error"))
+			},
+			wantErr: "find duplicate SIP: an error",
+			want:    nil,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ingestsvc, perSvc, _ := testSvc(t, nil, 0)
+			tt.mockCalls(perSvc.EXPECT())
+
+			got, err := ingestsvc.FindDuplicateSIP(
+				context.Background(),
+				sipID,
+				datatypes.Checksum{
+					Algorithm: datatypes.ChecksumAlgoSHA256,
+					Hash:      hash,
+				},
+			)
+
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
 		})
 	}
 }

--- a/internal/persistence/ent/client/convert.go
+++ b/internal/persistence/ent/client/convert.go
@@ -15,16 +15,18 @@ import (
 func convertSIP(sip *db.SIP) *datatypes.SIP {
 	// Convert required fields.
 	s := datatypes.SIP{
-		ID:          sip.ID,
-		UUID:        sip.UUID,
-		Name:        sip.Name,
-		Status:      sip.Status,
-		CreatedAt:   sip.CreatedAt,
-		StartedAt:   normalizeTime(sip.StartedAt),
-		CompletedAt: normalizeTime(sip.CompletedAt),
-		FailedAs:    sip.FailedAs,
-		FailedKey:   sip.FailedKey,
-		FileCount:   sip.FileCount,
+		ID:                sip.ID,
+		UUID:              sip.UUID,
+		Name:              sip.Name,
+		Status:            sip.Status,
+		CreatedAt:         sip.CreatedAt,
+		StartedAt:         normalizeTime(sip.StartedAt),
+		CompletedAt:       normalizeTime(sip.CompletedAt),
+		FailedAs:          sip.FailedAs,
+		FailedKey:         sip.FailedKey,
+		FileCount:         sip.FileCount,
+		ChecksumAlgorithm: sip.ChecksumAlgorithm,
+		ChecksumHash:      sip.ChecksumHash,
 	}
 
 	// Convert optional fields.

--- a/internal/persistence/ent/client/sip.go
+++ b/internal/persistence/ent/client/sip.go
@@ -55,6 +55,12 @@ func (c *client) CreateSIP(ctx context.Context, s *datatypes.SIP) error {
 	if s.FileCount > 0 {
 		q.SetFileCount(s.FileCount)
 	}
+	if s.ChecksumAlgorithm != "" {
+		q.SetChecksumAlgorithm(s.ChecksumAlgorithm)
+	}
+	if s.ChecksumHash != "" {
+		q.SetChecksumHash(s.ChecksumHash)
+	}
 
 	// If Uploader is set, find or create the user and link it to the SIP.
 	if s.Uploader != nil {
@@ -168,6 +174,12 @@ func (c *client) UpdateSIP(
 	if up.FileCount > 0 {
 		q.SetFileCount(up.FileCount)
 	}
+	if up.ChecksumAlgorithm != "" {
+		q.SetChecksumAlgorithm(up.ChecksumAlgorithm)
+	}
+	if up.ChecksumHash != "" {
+		q.SetChecksumHash(up.ChecksumHash)
+	}
 
 	// Save changes.
 	dbs, err = q.Save(ctx)
@@ -266,6 +278,8 @@ func filterSIPs(q *db.SIPQuery, f *persistence.SIPFilter) (page, whole *db.SIPQu
 	qf.Equals(sip.FieldAipID, f.AIPID)
 	qf.Equals(sip.FieldStatus, f.Status)
 	qf.AddDateRange(sip.FieldCreatedAt, f.CreatedAt)
+	qf.Equals(sip.FieldChecksumAlgorithm, f.ChecksumAlgorithm)
+	qf.Equals(sip.FieldChecksumHash, f.ChecksumHash)
 	qf.OrderBy(f.Sort)
 	qf.Page(f.Limit, f.Offset)
 

--- a/internal/persistence/ent/client/sip_test.go
+++ b/internal/persistence/ent/client/sip_test.go
@@ -39,24 +39,28 @@ func TestCreateSIP(t *testing.T) {
 		{
 			name: "Creates a new SIP in the DB",
 			sip: &datatypes.SIP{
-				UUID:        sipUUID,
-				Name:        "Test SIP 1",
-				AIPID:       aipID,
-				Status:      enums.SIPStatusProcessing,
-				StartedAt:   started,
-				CompletedAt: completed,
-				FileCount:   8,
+				UUID:              sipUUID,
+				Name:              "Test SIP 1",
+				AIPID:             aipID,
+				Status:            enums.SIPStatusProcessing,
+				StartedAt:         started,
+				CompletedAt:       completed,
+				FileCount:         8,
+				ChecksumAlgorithm: "SHA-256",
+				ChecksumHash:      "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049",
 			},
 			want: &datatypes.SIP{
-				ID:          1,
-				UUID:        sipUUID,
-				Name:        "Test SIP 1",
-				AIPID:       aipID,
-				Status:      enums.SIPStatusProcessing,
-				CreatedAt:   time.Now(),
-				StartedAt:   started,
-				CompletedAt: completed,
-				FileCount:   8,
+				ID:                1,
+				UUID:              sipUUID,
+				Name:              "Test SIP 1",
+				AIPID:             aipID,
+				Status:            enums.SIPStatusProcessing,
+				CreatedAt:         time.Now(),
+				StartedAt:         started,
+				CompletedAt:       completed,
+				FileCount:         8,
+				ChecksumAlgorithm: "SHA-256",
+				ChecksumHash:      "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049",
 			},
 		},
 		{
@@ -282,6 +286,8 @@ func TestUpdateSIP(t *testing.T) {
 					s.FailedKey = "failed-key"
 					s.Uploader = &datatypes.User{UUID: uuid.New()} // No-op, can't update Uploader.
 					s.FileCount = 8
+					s.ChecksumAlgorithm = "SHA-256"
+					s.ChecksumHash = "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049"
 					return s, nil
 				},
 			},
@@ -312,7 +318,9 @@ func TestUpdateSIP(t *testing.T) {
 					SIPSCount:  5,
 					CreatedAt:  time.Now(),
 				},
-				FileCount: 8,
+				FileCount:         8,
+				ChecksumAlgorithm: "SHA-256",
+				ChecksumHash:      "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049",
 			},
 		},
 		{
@@ -320,12 +328,14 @@ func TestUpdateSIP(t *testing.T) {
 			args: params{
 				sipUUID: sipUUID,
 				sip: &datatypes.SIP{
-					UUID:      sipUUID,
-					Name:      "Test SIP",
-					AIPID:     aipID,
-					Status:    enums.SIPStatusProcessing,
-					StartedAt: started,
-					FileCount: 0,
+					UUID:              sipUUID,
+					Name:              "Test SIP",
+					AIPID:             aipID,
+					Status:            enums.SIPStatusProcessing,
+					StartedAt:         started,
+					FileCount:         0,
+					ChecksumAlgorithm: "SHA-256",
+					ChecksumHash:      "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049",
 				},
 				updater: func(s *datatypes.SIP) (*datatypes.SIP, error) {
 					// Immutable.
@@ -340,15 +350,17 @@ func TestUpdateSIP(t *testing.T) {
 				},
 			},
 			want: &datatypes.SIP{
-				ID:          1,
-				UUID:        sipUUID,
-				Name:        "Test SIP",
-				AIPID:       aipID,
-				Status:      enums.SIPStatusIngested,
-				CreatedAt:   time.Now(),
-				StartedAt:   started,
-				CompletedAt: completed,
-				FileCount:   8,
+				ID:                1,
+				UUID:              sipUUID,
+				Name:              "Test SIP",
+				AIPID:             aipID,
+				Status:            enums.SIPStatusIngested,
+				CreatedAt:         time.Now(),
+				StartedAt:         started,
+				CompletedAt:       completed,
+				FileCount:         8,
+				ChecksumAlgorithm: "SHA-256",
+				ChecksumHash:      "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049",
 			},
 		},
 		{
@@ -532,7 +544,9 @@ func TestReadSIP(t *testing.T) {
 					SIPSCount:  5,
 					CreatedAt:  time.Now(),
 				},
-				FileCount: 8,
+				FileCount:         8,
+				ChecksumAlgorithm: "SHA-256",
+				ChecksumHash:      "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049",
 			},
 		},
 		{
@@ -569,6 +583,8 @@ func TestReadSIP(t *testing.T) {
 					SetUploader(user).
 					SetBatchID(tt.want.Batch.ID).
 					SetFileCount(8).
+					SetChecksumAlgorithm(tt.want.ChecksumAlgorithm).
+					SetChecksumHash(tt.want.ChecksumHash).
 					Save(ctx)
 				assert.NilError(t, err)
 			}
@@ -609,28 +625,34 @@ func TestListSIPs(t *testing.T) {
 	completed := started.Add(time.Second)
 	completed2 := started2.Add(time.Second)
 
+	checksumAlgo := "SHA-256"
+	checksum := "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049"
+	checksum2 := "3a6eb079e9e5c9f0d1caa8b1a7c0cfd8e311d278bfb0b1aabdcdcdcdedbbbd2"
+
 	type results struct {
 		data []*datatypes.SIP
 		page *persistence.Page
 	}
 	tests := []struct {
-		name      string
-		data      []*datatypes.SIP
-		sipFilter *persistence.SIPFilter
-		want      results
-		wantErr   string
+		name    string
+		data    []*datatypes.SIP
+		filter  *persistence.SIPFilter
+		want    results
+		wantErr string
 	}{
 		{
 			name: "Returns all SIPs",
 			data: []*datatypes.SIP{
 				{
-					UUID:        sipUUID,
-					Name:        "Test SIP 1",
-					AIPID:       aipID,
-					Status:      enums.SIPStatusIngested,
-					StartedAt:   started,
-					CompletedAt: completed,
-					FileCount:   3,
+					UUID:              sipUUID,
+					Name:              "Test SIP 1",
+					AIPID:             aipID,
+					Status:            enums.SIPStatusIngested,
+					StartedAt:         started,
+					CompletedAt:       completed,
+					FileCount:         3,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum,
 				},
 				{
 					UUID:        sipUUID2,
@@ -647,7 +669,9 @@ func TestListSIPs(t *testing.T) {
 						OIDCIss:   "https://example.com/oidc",
 						OIDCSub:   "1234567890",
 					},
-					FileCount: 6,
+					FileCount:         6,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum2,
 				},
 				{
 					UUID:        sipUUID3,
@@ -663,15 +687,17 @@ func TestListSIPs(t *testing.T) {
 			want: results{
 				data: []*datatypes.SIP{
 					{
-						ID:          1,
-						UUID:        sipUUID,
-						Name:        "Test SIP 1",
-						AIPID:       aipID,
-						Status:      enums.SIPStatusIngested,
-						CreatedAt:   time.Now(),
-						StartedAt:   started,
-						CompletedAt: completed,
-						FileCount:   3,
+						ID:                1,
+						UUID:              sipUUID,
+						Name:              "Test SIP 1",
+						AIPID:             aipID,
+						Status:            enums.SIPStatusIngested,
+						CreatedAt:         time.Now(),
+						StartedAt:         started,
+						CompletedAt:       completed,
+						FileCount:         3,
+						ChecksumAlgorithm: checksumAlgo,
+						ChecksumHash:      checksum,
 					},
 					{
 						ID:          2,
@@ -690,7 +716,9 @@ func TestListSIPs(t *testing.T) {
 							OIDCIss:   "https://example.com/oidc",
 							OIDCSub:   "1234567890",
 						},
-						FileCount: 6,
+						FileCount:         6,
+						ChecksumAlgorithm: checksumAlgo,
+						ChecksumHash:      checksum2,
 					},
 					{
 						ID:          3,
@@ -715,39 +743,45 @@ func TestListSIPs(t *testing.T) {
 			name: "Returns first page of SIPs",
 			data: []*datatypes.SIP{
 				{
-					UUID:        sipUUID,
-					Name:        "Test SIP 1",
-					AIPID:       aipID,
-					Status:      enums.SIPStatusIngested,
-					StartedAt:   started,
-					CompletedAt: completed,
-					FileCount:   3,
+					UUID:              sipUUID,
+					Name:              "Test SIP 1",
+					AIPID:             aipID,
+					Status:            enums.SIPStatusIngested,
+					StartedAt:         started,
+					CompletedAt:       completed,
+					FileCount:         3,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum,
 				},
 				{
-					UUID:        sipUUID2,
-					Name:        "Test SIP 2",
-					AIPID:       aipID2,
-					Status:      enums.SIPStatusProcessing,
-					StartedAt:   started2,
-					CompletedAt: completed2,
-					FileCount:   6,
+					UUID:              sipUUID2,
+					Name:              "Test SIP 2",
+					AIPID:             aipID2,
+					Status:            enums.SIPStatusProcessing,
+					StartedAt:         started2,
+					CompletedAt:       completed2,
+					FileCount:         6,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum,
 				},
 			},
-			sipFilter: &persistence.SIPFilter{
+			filter: &persistence.SIPFilter{
 				Page: persistence.Page{Limit: 1},
 			},
 			want: results{
 				data: []*datatypes.SIP{
 					{
-						ID:          1,
-						UUID:        sipUUID,
-						Name:        "Test SIP 1",
-						AIPID:       aipID,
-						Status:      enums.SIPStatusIngested,
-						CreatedAt:   time.Now(),
-						StartedAt:   started,
-						CompletedAt: completed,
-						FileCount:   3,
+						ID:                1,
+						UUID:              sipUUID,
+						Name:              "Test SIP 1",
+						AIPID:             aipID,
+						Status:            enums.SIPStatusIngested,
+						CreatedAt:         time.Now(),
+						StartedAt:         started,
+						CompletedAt:       completed,
+						FileCount:         3,
+						ChecksumAlgorithm: checksumAlgo,
+						ChecksumHash:      checksum,
 					},
 				},
 				page: &persistence.Page{
@@ -760,12 +794,14 @@ func TestListSIPs(t *testing.T) {
 			name: "Returns second page of SIPs",
 			data: []*datatypes.SIP{
 				{
-					UUID:        sipUUID,
-					Name:        "Test SIP 1",
-					AIPID:       aipID,
-					Status:      enums.SIPStatusIngested,
-					StartedAt:   started,
-					CompletedAt: completed,
+					UUID:              sipUUID,
+					Name:              "Test SIP 1",
+					AIPID:             aipID,
+					Status:            enums.SIPStatusIngested,
+					StartedAt:         started,
+					CompletedAt:       completed,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum,
 				},
 				{
 					UUID:        sipUUID2,
@@ -782,10 +818,12 @@ func TestListSIPs(t *testing.T) {
 						OIDCIss:   "https://example.com/oidc",
 						OIDCSub:   "1234567890",
 					},
-					FileCount: 6,
+					FileCount:         6,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum2,
 				},
 			},
-			sipFilter: &persistence.SIPFilter{
+			filter: &persistence.SIPFilter{
 				Page: persistence.Page{Limit: 1, Offset: 1},
 			},
 			want: results{
@@ -807,7 +845,9 @@ func TestListSIPs(t *testing.T) {
 							OIDCIss:   "https://example.com/oidc",
 							OIDCSub:   "1234567890",
 						},
-						FileCount: 6,
+						FileCount:         6,
+						ChecksumAlgorithm: checksumAlgo,
+						ChecksumHash:      checksum2,
 					},
 				},
 				page: &persistence.Page{
@@ -821,39 +861,45 @@ func TestListSIPs(t *testing.T) {
 			name: "Returns SIPs whose names contain a string",
 			data: []*datatypes.SIP{
 				{
-					UUID:        sipUUID,
-					Name:        "Test SIP",
-					AIPID:       aipID,
-					Status:      enums.SIPStatusIngested,
-					StartedAt:   started,
-					CompletedAt: completed,
-					FileCount:   3,
+					UUID:              sipUUID,
+					Name:              "Test SIP",
+					AIPID:             aipID,
+					Status:            enums.SIPStatusIngested,
+					StartedAt:         started,
+					CompletedAt:       completed,
+					FileCount:         3,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum,
 				},
 				{
-					UUID:        sipUUID2,
-					Name:        "small.zip",
-					AIPID:       aipID2,
-					Status:      enums.SIPStatusProcessing,
-					StartedAt:   started2,
-					CompletedAt: completed2,
-					FileCount:   6,
+					UUID:              sipUUID2,
+					Name:              "small.zip",
+					AIPID:             aipID2,
+					Status:            enums.SIPStatusProcessing,
+					StartedAt:         started2,
+					CompletedAt:       completed2,
+					FileCount:         6,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum2,
 				},
 			},
-			sipFilter: &persistence.SIPFilter{
+			filter: &persistence.SIPFilter{
 				Name: new("small"),
 			},
 			want: results{
 				data: []*datatypes.SIP{
 					{
-						ID:          2,
-						UUID:        sipUUID2,
-						Name:        "small.zip",
-						AIPID:       aipID2,
-						Status:      enums.SIPStatusProcessing,
-						CreatedAt:   time.Now(),
-						StartedAt:   started2,
-						CompletedAt: completed2,
-						FileCount:   6,
+						ID:                2,
+						UUID:              sipUUID2,
+						Name:              "small.zip",
+						AIPID:             aipID2,
+						Status:            enums.SIPStatusProcessing,
+						CreatedAt:         time.Now(),
+						StartedAt:         started2,
+						CompletedAt:       completed2,
+						FileCount:         6,
+						ChecksumAlgorithm: checksumAlgo,
+						ChecksumHash:      checksum2,
 					},
 				},
 				page: &persistence.Page{
@@ -866,39 +912,45 @@ func TestListSIPs(t *testing.T) {
 			name: "Returns SIPs filtered by AIPID",
 			data: []*datatypes.SIP{
 				{
-					UUID:        sipUUID,
-					Name:        "Test SIP 1",
-					AIPID:       aipID,
-					Status:      enums.SIPStatusIngested,
-					StartedAt:   started,
-					CompletedAt: completed,
-					FileCount:   3,
+					UUID:              sipUUID,
+					Name:              "Test SIP 1",
+					AIPID:             aipID,
+					Status:            enums.SIPStatusIngested,
+					StartedAt:         started,
+					CompletedAt:       completed,
+					FileCount:         3,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum,
 				},
 				{
-					UUID:        sipUUID2,
-					Name:        "Test SIP 2",
-					AIPID:       aipID2,
-					Status:      enums.SIPStatusProcessing,
-					StartedAt:   started2,
-					CompletedAt: completed2,
-					FileCount:   6,
+					UUID:              sipUUID2,
+					Name:              "Test SIP 2",
+					AIPID:             aipID2,
+					Status:            enums.SIPStatusProcessing,
+					StartedAt:         started2,
+					CompletedAt:       completed2,
+					FileCount:         6,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum2,
 				},
 			},
-			sipFilter: &persistence.SIPFilter{
+			filter: &persistence.SIPFilter{
 				AIPID: &aipID2.UUID,
 			},
 			want: results{
 				data: []*datatypes.SIP{
 					{
-						ID:          2,
-						UUID:        sipUUID2,
-						Name:        "Test SIP 2",
-						AIPID:       aipID2,
-						Status:      enums.SIPStatusProcessing,
-						CreatedAt:   time.Now(),
-						StartedAt:   started2,
-						CompletedAt: completed2,
-						FileCount:   6,
+						ID:                2,
+						UUID:              sipUUID2,
+						Name:              "Test SIP 2",
+						AIPID:             aipID2,
+						Status:            enums.SIPStatusProcessing,
+						CreatedAt:         time.Now(),
+						StartedAt:         started2,
+						CompletedAt:       completed2,
+						FileCount:         6,
+						ChecksumAlgorithm: checksumAlgo,
+						ChecksumHash:      checksum2,
 					},
 				},
 				page: &persistence.Page{
@@ -911,39 +963,45 @@ func TestListSIPs(t *testing.T) {
 			name: "Returns SIPs filtered by status",
 			data: []*datatypes.SIP{
 				{
-					UUID:        sipUUID,
-					Name:        "Test SIP 1",
-					AIPID:       aipID,
-					Status:      enums.SIPStatusIngested,
-					StartedAt:   started,
-					CompletedAt: completed,
-					FileCount:   3,
+					UUID:              sipUUID,
+					Name:              "Test SIP 1",
+					AIPID:             aipID,
+					Status:            enums.SIPStatusIngested,
+					StartedAt:         started,
+					CompletedAt:       completed,
+					FileCount:         3,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum,
 				},
 				{
-					UUID:        sipUUID2,
-					Name:        "Test SIP 2",
-					AIPID:       aipID2,
-					Status:      enums.SIPStatusProcessing,
-					StartedAt:   started2,
-					CompletedAt: completed2,
-					FileCount:   6,
+					UUID:              sipUUID2,
+					Name:              "Test SIP 2",
+					AIPID:             aipID2,
+					Status:            enums.SIPStatusProcessing,
+					StartedAt:         started2,
+					CompletedAt:       completed2,
+					FileCount:         6,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum2,
 				},
 			},
-			sipFilter: &persistence.SIPFilter{
+			filter: &persistence.SIPFilter{
 				Status: ref.New(enums.SIPStatusProcessing),
 			},
 			want: results{
 				data: []*datatypes.SIP{
 					{
-						ID:          2,
-						UUID:        sipUUID2,
-						Name:        "Test SIP 2",
-						AIPID:       aipID2,
-						Status:      enums.SIPStatusProcessing,
-						CreatedAt:   time.Now(),
-						StartedAt:   started2,
-						CompletedAt: completed2,
-						FileCount:   6,
+						ID:                2,
+						UUID:              sipUUID2,
+						Name:              "Test SIP 2",
+						AIPID:             aipID2,
+						Status:            enums.SIPStatusProcessing,
+						CreatedAt:         time.Now(),
+						StartedAt:         started2,
+						CompletedAt:       completed2,
+						FileCount:         6,
+						ChecksumAlgorithm: checksumAlgo,
+						ChecksumHash:      checksum2,
 					},
 				},
 				page: &persistence.Page{
@@ -956,25 +1014,29 @@ func TestListSIPs(t *testing.T) {
 			name: "Returns SIPs filtered by CreatedAt",
 			data: []*datatypes.SIP{
 				{
-					UUID:        sipUUID,
-					Name:        "Test SIP 1",
-					AIPID:       aipID,
-					Status:      enums.SIPStatusIngested,
-					StartedAt:   started,
-					CompletedAt: completed,
-					FileCount:   3,
+					UUID:              sipUUID,
+					Name:              "Test SIP 1",
+					AIPID:             aipID,
+					Status:            enums.SIPStatusIngested,
+					StartedAt:         started,
+					CompletedAt:       completed,
+					FileCount:         3,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum,
 				},
 				{
-					UUID:        sipUUID2,
-					Name:        "Test SIP 2",
-					AIPID:       aipID2,
-					Status:      enums.SIPStatusProcessing,
-					StartedAt:   started2,
-					CompletedAt: completed2,
-					FileCount:   6,
+					UUID:              sipUUID2,
+					Name:              "Test SIP 2",
+					AIPID:             aipID2,
+					Status:            enums.SIPStatusProcessing,
+					StartedAt:         started2,
+					CompletedAt:       completed2,
+					FileCount:         6,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum2,
 				},
 			},
-			sipFilter: &persistence.SIPFilter{
+			filter: &persistence.SIPFilter{
 				CreatedAt: func(t *testing.T) *timerange.Range {
 					r, err := timerange.New(
 						time.Now().Add(-1*time.Minute),
@@ -989,26 +1051,30 @@ func TestListSIPs(t *testing.T) {
 			want: results{
 				data: []*datatypes.SIP{
 					{
-						ID:          1,
-						UUID:        sipUUID,
-						Name:        "Test SIP 1",
-						AIPID:       aipID,
-						Status:      enums.SIPStatusIngested,
-						CreatedAt:   time.Now(),
-						StartedAt:   started,
-						CompletedAt: completed,
-						FileCount:   3,
+						ID:                1,
+						UUID:              sipUUID,
+						Name:              "Test SIP 1",
+						AIPID:             aipID,
+						Status:            enums.SIPStatusIngested,
+						CreatedAt:         time.Now(),
+						StartedAt:         started,
+						CompletedAt:       completed,
+						FileCount:         3,
+						ChecksumAlgorithm: checksumAlgo,
+						ChecksumHash:      checksum,
 					},
 					{
-						ID:          2,
-						UUID:        sipUUID2,
-						Name:        "Test SIP 2",
-						AIPID:       aipID2,
-						Status:      enums.SIPStatusProcessing,
-						CreatedAt:   time.Now(),
-						StartedAt:   started2,
-						CompletedAt: completed2,
-						FileCount:   6,
+						ID:                2,
+						UUID:              sipUUID2,
+						Name:              "Test SIP 2",
+						AIPID:             aipID2,
+						Status:            enums.SIPStatusProcessing,
+						CreatedAt:         time.Now(),
+						StartedAt:         started2,
+						CompletedAt:       completed2,
+						FileCount:         6,
+						ChecksumAlgorithm: checksumAlgo,
+						ChecksumHash:      checksum2,
 					},
 				},
 				page: &persistence.Page{
@@ -1021,23 +1087,27 @@ func TestListSIPs(t *testing.T) {
 			name: "Returns no results when no SIPs match CreatedAt range",
 			data: []*datatypes.SIP{
 				{
-					UUID:        sipUUID,
-					Name:        "Test SIP 1",
-					AIPID:       aipID,
-					Status:      enums.SIPStatusIngested,
-					StartedAt:   started,
-					CompletedAt: completed,
+					UUID:              sipUUID,
+					Name:              "Test SIP 1",
+					AIPID:             aipID,
+					Status:            enums.SIPStatusIngested,
+					StartedAt:         started,
+					CompletedAt:       completed,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum,
 				},
 				{
-					UUID:        sipUUID2,
-					Name:        "Test SIP 2",
-					AIPID:       aipID2,
-					Status:      enums.SIPStatusProcessing,
-					StartedAt:   started2,
-					CompletedAt: completed2,
+					UUID:              sipUUID2,
+					Name:              "Test SIP 2",
+					AIPID:             aipID2,
+					Status:            enums.SIPStatusProcessing,
+					StartedAt:         started2,
+					CompletedAt:       completed2,
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum2,
 				},
 			},
-			sipFilter: &persistence.SIPFilter{
+			filter: &persistence.SIPFilter{
 				CreatedAt: func(t *testing.T) *timerange.Range {
 					r, err := timerange.New(
 						time.Now().Add(time.Minute),
@@ -1075,6 +1145,8 @@ func TestListSIPs(t *testing.T) {
 						OIDCIss:   "https://example.com/oidc",
 						OIDCSub:   "1234567890",
 					},
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum,
 				},
 				{
 					UUID:        sipUUID2,
@@ -1091,9 +1163,11 @@ func TestListSIPs(t *testing.T) {
 						OIDCIss:   "https://example.com/oidc",
 						OIDCSub:   "otheruser",
 					},
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum2,
 				},
 			},
-			sipFilter: &persistence.SIPFilter{
+			filter: &persistence.SIPFilter{
 				UploaderID: new(uploaderID2),
 			},
 			want: results{
@@ -1115,6 +1189,8 @@ func TestListSIPs(t *testing.T) {
 							OIDCIss:   "https://example.com/oidc",
 							OIDCSub:   "otheruser",
 						},
+						ChecksumAlgorithm: checksumAlgo,
+						ChecksumHash:      checksum2,
 					},
 				},
 				page: &persistence.Page{
@@ -1140,6 +1216,8 @@ func TestListSIPs(t *testing.T) {
 						SIPSCount:  5,
 						CreatedAt:  time.Now(),
 					},
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum,
 				},
 				{
 					UUID:        sipUUID2,
@@ -1155,9 +1233,11 @@ func TestListSIPs(t *testing.T) {
 						SIPSCount:  10,
 						CreatedAt:  time.Now(),
 					},
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum2,
 				},
 			},
-			sipFilter: &persistence.SIPFilter{
+			filter: &persistence.SIPFilter{
 				BatchID: new(batchID2),
 			},
 			want: results{
@@ -1179,6 +1259,79 @@ func TestListSIPs(t *testing.T) {
 							SIPSCount:  10,
 							CreatedAt:  time.Now(),
 						},
+						ChecksumAlgorithm: checksumAlgo,
+						ChecksumHash:      checksum2,
+					},
+				},
+				page: &persistence.Page{
+					Limit: entfilter.DefaultPageSize,
+					Total: 1,
+				},
+			},
+		},
+		{
+			name: "Returns SIPs filtered by checksum",
+			data: []*datatypes.SIP{
+				{
+					UUID:        sipUUID,
+					Name:        "Test SIP 1",
+					AIPID:       aipID,
+					Status:      enums.SIPStatusIngested,
+					StartedAt:   started,
+					CompletedAt: completed,
+					Batch: &datatypes.Batch{
+						UUID:       batchID,
+						Identifier: "Test Batch 1",
+						Status:     enums.BatchStatusIngested,
+						SIPSCount:  5,
+						CreatedAt:  time.Now(),
+					},
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum,
+				},
+				{
+					UUID:        sipUUID2,
+					Name:        "Test SIP 2",
+					AIPID:       aipID2,
+					Status:      enums.SIPStatusProcessing,
+					StartedAt:   started2,
+					CompletedAt: completed2,
+					Batch: &datatypes.Batch{
+						UUID:       batchID2,
+						Identifier: "Test Batch 2",
+						Status:     enums.BatchStatusProcessing,
+						SIPSCount:  10,
+						CreatedAt:  time.Now(),
+					},
+					ChecksumAlgorithm: checksumAlgo,
+					ChecksumHash:      checksum2,
+				},
+			},
+			filter: &persistence.SIPFilter{
+				ChecksumAlgorithm: new(checksumAlgo),
+				ChecksumHash:      new(checksum2),
+			},
+			want: results{
+				data: []*datatypes.SIP{
+					{
+						ID:          2,
+						UUID:        sipUUID2,
+						Name:        "Test SIP 2",
+						AIPID:       aipID2,
+						Status:      enums.SIPStatusProcessing,
+						CreatedAt:   time.Now(),
+						StartedAt:   started2,
+						CompletedAt: completed2,
+						Batch: &datatypes.Batch{
+							ID:         2,
+							UUID:       batchID2,
+							Identifier: "Test Batch 2",
+							Status:     enums.BatchStatusProcessing,
+							SIPSCount:  10,
+							CreatedAt:  time.Now(),
+						},
+						ChecksumAlgorithm: checksumAlgo,
+						ChecksumHash:      checksum2,
 					},
 				},
 				page: &persistence.Page{
@@ -1205,7 +1358,9 @@ func TestListSIPs(t *testing.T) {
 						SetCreatedAt(time.Now()).
 						SetStartedAt(sip.StartedAt).
 						SetCompletedAt(sip.CompletedAt).
-						SetFileCount(sip.FileCount)
+						SetFileCount(sip.FileCount).
+						SetChecksumAlgorithm(sip.ChecksumAlgorithm).
+						SetChecksumHash(sip.ChecksumHash)
 
 					if sip.AIPID.Valid {
 						q.SetAipID(sip.AIPID.UUID)
@@ -1245,7 +1400,7 @@ func TestListSIPs(t *testing.T) {
 				}
 			}
 
-			got, pg, err := svc.ListSIPs(ctx, tt.sipFilter)
+			got, pg, err := svc.ListSIPs(ctx, tt.filter)
 			assert.NilError(t, err)
 
 			assert.DeepEqual(t, got, tt.want.data,

--- a/internal/persistence/ent/db/migrate/schema.go
+++ b/internal/persistence/ent/db/migrate/schema.go
@@ -78,6 +78,8 @@ var (
 		{Name: "failed_as", Type: field.TypeEnum, Nullable: true, Enums: []string{"SIP", "PIP"}},
 		{Name: "failed_key", Type: field.TypeString, Nullable: true, Size: 1024},
 		{Name: "file_count", Type: field.TypeInt32, Nullable: true},
+		{Name: "checksum_algorithm", Type: field.TypeString, Nullable: true},
+		{Name: "checksum_hash", Type: field.TypeString, Nullable: true},
 		{Name: "batch_id", Type: field.TypeInt, Nullable: true},
 		{Name: "uploader_id", Type: field.TypeInt, Nullable: true},
 	}
@@ -89,13 +91,13 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "sip_batch_sips",
-				Columns:    []*schema.Column{SipColumns[11]},
+				Columns:    []*schema.Column{SipColumns[13]},
 				RefColumns: []*schema.Column{BatchColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "sip_user_uploaded_sips",
-				Columns:    []*schema.Column{SipColumns[12]},
+				Columns:    []*schema.Column{SipColumns[14]},
 				RefColumns: []*schema.Column{UserColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -132,12 +134,17 @@ var (
 			{
 				Name:    "sip_uploader_id_idx",
 				Unique:  false,
-				Columns: []*schema.Column{SipColumns[12]},
+				Columns: []*schema.Column{SipColumns[14]},
 			},
 			{
 				Name:    "sip_batch_id_idx",
 				Unique:  false,
-				Columns: []*schema.Column{SipColumns[11]},
+				Columns: []*schema.Column{SipColumns[13]},
+			},
+			{
+				Name:    "sip_checksum_idx",
+				Unique:  false,
+				Columns: []*schema.Column{SipColumns[11], SipColumns[12]},
 			},
 		},
 	}

--- a/internal/persistence/ent/db/mutation.go
+++ b/internal/persistence/ent/db/mutation.go
@@ -979,31 +979,33 @@ func (m *BatchMutation) ResetEdge(name string) error {
 // SIPMutation represents an operation that mutates the SIP nodes in the graph.
 type SIPMutation struct {
 	config
-	op               Op
-	typ              string
-	id               *int
-	uuid             *uuid.UUID
-	name             *string
-	aip_id           *uuid.UUID
-	status           *enums.SIPStatus
-	created_at       *time.Time
-	started_at       *time.Time
-	completed_at     *time.Time
-	failed_as        *enums.SIPFailedAs
-	failed_key       *string
-	file_count       *int32
-	addfile_count    *int32
-	clearedFields    map[string]struct{}
-	workflows        map[int]struct{}
-	removedworkflows map[int]struct{}
-	clearedworkflows bool
-	uploader         *int
-	cleareduploader  bool
-	batch            *int
-	clearedbatch     bool
-	done             bool
-	oldValue         func(context.Context) (*SIP, error)
-	predicates       []predicate.SIP
+	op                 Op
+	typ                string
+	id                 *int
+	uuid               *uuid.UUID
+	name               *string
+	aip_id             *uuid.UUID
+	status             *enums.SIPStatus
+	created_at         *time.Time
+	started_at         *time.Time
+	completed_at       *time.Time
+	failed_as          *enums.SIPFailedAs
+	failed_key         *string
+	file_count         *int32
+	addfile_count      *int32
+	checksum_algorithm *string
+	checksum_hash      *string
+	clearedFields      map[string]struct{}
+	workflows          map[int]struct{}
+	removedworkflows   map[int]struct{}
+	clearedworkflows   bool
+	uploader           *int
+	cleareduploader    bool
+	batch              *int
+	clearedbatch       bool
+	done               bool
+	oldValue           func(context.Context) (*SIP, error)
+	predicates         []predicate.SIP
 }
 
 var _ ent.Mutation = (*SIPMutation)(nil)
@@ -1661,6 +1663,104 @@ func (m *SIPMutation) ResetFileCount() {
 	delete(m.clearedFields, sip.FieldFileCount)
 }
 
+// SetChecksumAlgorithm sets the "checksum_algorithm" field.
+func (m *SIPMutation) SetChecksumAlgorithm(s string) {
+	m.checksum_algorithm = &s
+}
+
+// ChecksumAlgorithm returns the value of the "checksum_algorithm" field in the mutation.
+func (m *SIPMutation) ChecksumAlgorithm() (r string, exists bool) {
+	v := m.checksum_algorithm
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldChecksumAlgorithm returns the old "checksum_algorithm" field's value of the SIP entity.
+// If the SIP object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SIPMutation) OldChecksumAlgorithm(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldChecksumAlgorithm is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldChecksumAlgorithm requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldChecksumAlgorithm: %w", err)
+	}
+	return oldValue.ChecksumAlgorithm, nil
+}
+
+// ClearChecksumAlgorithm clears the value of the "checksum_algorithm" field.
+func (m *SIPMutation) ClearChecksumAlgorithm() {
+	m.checksum_algorithm = nil
+	m.clearedFields[sip.FieldChecksumAlgorithm] = struct{}{}
+}
+
+// ChecksumAlgorithmCleared returns if the "checksum_algorithm" field was cleared in this mutation.
+func (m *SIPMutation) ChecksumAlgorithmCleared() bool {
+	_, ok := m.clearedFields[sip.FieldChecksumAlgorithm]
+	return ok
+}
+
+// ResetChecksumAlgorithm resets all changes to the "checksum_algorithm" field.
+func (m *SIPMutation) ResetChecksumAlgorithm() {
+	m.checksum_algorithm = nil
+	delete(m.clearedFields, sip.FieldChecksumAlgorithm)
+}
+
+// SetChecksumHash sets the "checksum_hash" field.
+func (m *SIPMutation) SetChecksumHash(s string) {
+	m.checksum_hash = &s
+}
+
+// ChecksumHash returns the value of the "checksum_hash" field in the mutation.
+func (m *SIPMutation) ChecksumHash() (r string, exists bool) {
+	v := m.checksum_hash
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldChecksumHash returns the old "checksum_hash" field's value of the SIP entity.
+// If the SIP object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SIPMutation) OldChecksumHash(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldChecksumHash is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldChecksumHash requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldChecksumHash: %w", err)
+	}
+	return oldValue.ChecksumHash, nil
+}
+
+// ClearChecksumHash clears the value of the "checksum_hash" field.
+func (m *SIPMutation) ClearChecksumHash() {
+	m.checksum_hash = nil
+	m.clearedFields[sip.FieldChecksumHash] = struct{}{}
+}
+
+// ChecksumHashCleared returns if the "checksum_hash" field was cleared in this mutation.
+func (m *SIPMutation) ChecksumHashCleared() bool {
+	_, ok := m.clearedFields[sip.FieldChecksumHash]
+	return ok
+}
+
+// ResetChecksumHash resets all changes to the "checksum_hash" field.
+func (m *SIPMutation) ResetChecksumHash() {
+	m.checksum_hash = nil
+	delete(m.clearedFields, sip.FieldChecksumHash)
+}
+
 // AddWorkflowIDs adds the "workflows" edge to the Workflow entity by ids.
 func (m *SIPMutation) AddWorkflowIDs(ids ...int) {
 	if m.workflows == nil {
@@ -1803,7 +1903,7 @@ func (m *SIPMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SIPMutation) Fields() []string {
-	fields := make([]string, 0, 12)
+	fields := make([]string, 0, 14)
 	if m.uuid != nil {
 		fields = append(fields, sip.FieldUUID)
 	}
@@ -1840,6 +1940,12 @@ func (m *SIPMutation) Fields() []string {
 	if m.file_count != nil {
 		fields = append(fields, sip.FieldFileCount)
 	}
+	if m.checksum_algorithm != nil {
+		fields = append(fields, sip.FieldChecksumAlgorithm)
+	}
+	if m.checksum_hash != nil {
+		fields = append(fields, sip.FieldChecksumHash)
+	}
 	return fields
 }
 
@@ -1872,6 +1978,10 @@ func (m *SIPMutation) Field(name string) (ent.Value, bool) {
 		return m.BatchID()
 	case sip.FieldFileCount:
 		return m.FileCount()
+	case sip.FieldChecksumAlgorithm:
+		return m.ChecksumAlgorithm()
+	case sip.FieldChecksumHash:
+		return m.ChecksumHash()
 	}
 	return nil, false
 }
@@ -1905,6 +2015,10 @@ func (m *SIPMutation) OldField(ctx context.Context, name string) (ent.Value, err
 		return m.OldBatchID(ctx)
 	case sip.FieldFileCount:
 		return m.OldFileCount(ctx)
+	case sip.FieldChecksumAlgorithm:
+		return m.OldChecksumAlgorithm(ctx)
+	case sip.FieldChecksumHash:
+		return m.OldChecksumHash(ctx)
 	}
 	return nil, fmt.Errorf("unknown SIP field %s", name)
 }
@@ -1998,6 +2112,20 @@ func (m *SIPMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetFileCount(v)
 		return nil
+	case sip.FieldChecksumAlgorithm:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetChecksumAlgorithm(v)
+		return nil
+	case sip.FieldChecksumHash:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetChecksumHash(v)
+		return nil
 	}
 	return fmt.Errorf("unknown SIP field %s", name)
 }
@@ -2067,6 +2195,12 @@ func (m *SIPMutation) ClearedFields() []string {
 	if m.FieldCleared(sip.FieldFileCount) {
 		fields = append(fields, sip.FieldFileCount)
 	}
+	if m.FieldCleared(sip.FieldChecksumAlgorithm) {
+		fields = append(fields, sip.FieldChecksumAlgorithm)
+	}
+	if m.FieldCleared(sip.FieldChecksumHash) {
+		fields = append(fields, sip.FieldChecksumHash)
+	}
 	return fields
 }
 
@@ -2104,6 +2238,12 @@ func (m *SIPMutation) ClearField(name string) error {
 		return nil
 	case sip.FieldFileCount:
 		m.ClearFileCount()
+		return nil
+	case sip.FieldChecksumAlgorithm:
+		m.ClearChecksumAlgorithm()
+		return nil
+	case sip.FieldChecksumHash:
+		m.ClearChecksumHash()
 		return nil
 	}
 	return fmt.Errorf("unknown SIP nullable field %s", name)
@@ -2148,6 +2288,12 @@ func (m *SIPMutation) ResetField(name string) error {
 		return nil
 	case sip.FieldFileCount:
 		m.ResetFileCount()
+		return nil
+	case sip.FieldChecksumAlgorithm:
+		m.ResetChecksumAlgorithm()
+		return nil
+	case sip.FieldChecksumHash:
+		m.ResetChecksumHash()
 		return nil
 	}
 	return fmt.Errorf("unknown SIP field %s", name)

--- a/internal/persistence/ent/db/sip.go
+++ b/internal/persistence/ent/db/sip.go
@@ -45,6 +45,10 @@ type SIP struct {
 	BatchID int `json:"batch_id,omitempty"`
 	// FileCount holds the value of the "file_count" field.
 	FileCount int32 `json:"file_count,omitempty"`
+	// ChecksumAlgorithm holds the value of the "checksum_algorithm" field.
+	ChecksumAlgorithm string `json:"checksum_algorithm,omitempty"`
+	// ChecksumHash holds the value of the "checksum_hash" field.
+	ChecksumHash string `json:"checksum_hash,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the SIPQuery when eager-loading is set.
 	Edges        SIPEdges `json:"edges"`
@@ -102,7 +106,7 @@ func (*SIP) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case sip.FieldID, sip.FieldUploaderID, sip.FieldBatchID, sip.FieldFileCount:
 			values[i] = new(sql.NullInt64)
-		case sip.FieldName, sip.FieldStatus, sip.FieldFailedAs, sip.FieldFailedKey:
+		case sip.FieldName, sip.FieldStatus, sip.FieldFailedAs, sip.FieldFailedKey, sip.FieldChecksumAlgorithm, sip.FieldChecksumHash:
 			values[i] = new(sql.NullString)
 		case sip.FieldCreatedAt, sip.FieldStartedAt, sip.FieldCompletedAt:
 			values[i] = new(sql.NullTime)
@@ -201,6 +205,18 @@ func (_m *SIP) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.FileCount = int32(value.Int64)
 			}
+		case sip.FieldChecksumAlgorithm:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field checksum_algorithm", values[i])
+			} else if value.Valid {
+				_m.ChecksumAlgorithm = value.String
+			}
+		case sip.FieldChecksumHash:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field checksum_hash", values[i])
+			} else if value.Valid {
+				_m.ChecksumHash = value.String
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -287,6 +303,12 @@ func (_m *SIP) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("file_count=")
 	builder.WriteString(fmt.Sprintf("%v", _m.FileCount))
+	builder.WriteString(", ")
+	builder.WriteString("checksum_algorithm=")
+	builder.WriteString(_m.ChecksumAlgorithm)
+	builder.WriteString(", ")
+	builder.WriteString("checksum_hash=")
+	builder.WriteString(_m.ChecksumHash)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/internal/persistence/ent/db/sip/sip.go
+++ b/internal/persistence/ent/db/sip/sip.go
@@ -40,6 +40,10 @@ const (
 	FieldBatchID = "batch_id"
 	// FieldFileCount holds the string denoting the file_count field in the database.
 	FieldFileCount = "file_count"
+	// FieldChecksumAlgorithm holds the string denoting the checksum_algorithm field in the database.
+	FieldChecksumAlgorithm = "checksum_algorithm"
+	// FieldChecksumHash holds the string denoting the checksum_hash field in the database.
+	FieldChecksumHash = "checksum_hash"
 	// EdgeWorkflows holds the string denoting the workflows edge name in mutations.
 	EdgeWorkflows = "workflows"
 	// EdgeUploader holds the string denoting the uploader edge name in mutations.
@@ -86,6 +90,8 @@ var Columns = []string{
 	FieldUploaderID,
 	FieldBatchID,
 	FieldFileCount,
+	FieldChecksumAlgorithm,
+	FieldChecksumHash,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -195,6 +201,16 @@ func ByBatchID(opts ...sql.OrderTermOption) OrderOption {
 // ByFileCount orders the results by the file_count field.
 func ByFileCount(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldFileCount, opts...).ToFunc()
+}
+
+// ByChecksumAlgorithm orders the results by the checksum_algorithm field.
+func ByChecksumAlgorithm(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldChecksumAlgorithm, opts...).ToFunc()
+}
+
+// ByChecksumHash orders the results by the checksum_hash field.
+func ByChecksumHash(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldChecksumHash, opts...).ToFunc()
 }
 
 // ByWorkflowsCount orders the results by workflows count.

--- a/internal/persistence/ent/db/sip/where.go
+++ b/internal/persistence/ent/db/sip/where.go
@@ -107,6 +107,16 @@ func FileCount(v int32) predicate.SIP {
 	return predicate.SIP(sql.FieldEQ(FieldFileCount, v))
 }
 
+// ChecksumAlgorithm applies equality check predicate on the "checksum_algorithm" field. It's identical to ChecksumAlgorithmEQ.
+func ChecksumAlgorithm(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldEQ(FieldChecksumAlgorithm, v))
+}
+
+// ChecksumHash applies equality check predicate on the "checksum_hash" field. It's identical to ChecksumHashEQ.
+func ChecksumHash(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldEQ(FieldChecksumHash, v))
+}
+
 // UUIDEQ applies the EQ predicate on the "uuid" field.
 func UUIDEQ(v uuid.UUID) predicate.SIP {
 	return predicate.SIP(sql.FieldEQ(FieldUUID, v))
@@ -655,6 +665,156 @@ func FileCountIsNil() predicate.SIP {
 // FileCountNotNil applies the NotNil predicate on the "file_count" field.
 func FileCountNotNil() predicate.SIP {
 	return predicate.SIP(sql.FieldNotNull(FieldFileCount))
+}
+
+// ChecksumAlgorithmEQ applies the EQ predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmEQ(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldEQ(FieldChecksumAlgorithm, v))
+}
+
+// ChecksumAlgorithmNEQ applies the NEQ predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmNEQ(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldNEQ(FieldChecksumAlgorithm, v))
+}
+
+// ChecksumAlgorithmIn applies the In predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmIn(vs ...string) predicate.SIP {
+	return predicate.SIP(sql.FieldIn(FieldChecksumAlgorithm, vs...))
+}
+
+// ChecksumAlgorithmNotIn applies the NotIn predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmNotIn(vs ...string) predicate.SIP {
+	return predicate.SIP(sql.FieldNotIn(FieldChecksumAlgorithm, vs...))
+}
+
+// ChecksumAlgorithmGT applies the GT predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmGT(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldGT(FieldChecksumAlgorithm, v))
+}
+
+// ChecksumAlgorithmGTE applies the GTE predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmGTE(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldGTE(FieldChecksumAlgorithm, v))
+}
+
+// ChecksumAlgorithmLT applies the LT predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmLT(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldLT(FieldChecksumAlgorithm, v))
+}
+
+// ChecksumAlgorithmLTE applies the LTE predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmLTE(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldLTE(FieldChecksumAlgorithm, v))
+}
+
+// ChecksumAlgorithmContains applies the Contains predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmContains(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldContains(FieldChecksumAlgorithm, v))
+}
+
+// ChecksumAlgorithmHasPrefix applies the HasPrefix predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmHasPrefix(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldHasPrefix(FieldChecksumAlgorithm, v))
+}
+
+// ChecksumAlgorithmHasSuffix applies the HasSuffix predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmHasSuffix(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldHasSuffix(FieldChecksumAlgorithm, v))
+}
+
+// ChecksumAlgorithmIsNil applies the IsNil predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmIsNil() predicate.SIP {
+	return predicate.SIP(sql.FieldIsNull(FieldChecksumAlgorithm))
+}
+
+// ChecksumAlgorithmNotNil applies the NotNil predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmNotNil() predicate.SIP {
+	return predicate.SIP(sql.FieldNotNull(FieldChecksumAlgorithm))
+}
+
+// ChecksumAlgorithmEqualFold applies the EqualFold predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmEqualFold(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldEqualFold(FieldChecksumAlgorithm, v))
+}
+
+// ChecksumAlgorithmContainsFold applies the ContainsFold predicate on the "checksum_algorithm" field.
+func ChecksumAlgorithmContainsFold(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldContainsFold(FieldChecksumAlgorithm, v))
+}
+
+// ChecksumHashEQ applies the EQ predicate on the "checksum_hash" field.
+func ChecksumHashEQ(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldEQ(FieldChecksumHash, v))
+}
+
+// ChecksumHashNEQ applies the NEQ predicate on the "checksum_hash" field.
+func ChecksumHashNEQ(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldNEQ(FieldChecksumHash, v))
+}
+
+// ChecksumHashIn applies the In predicate on the "checksum_hash" field.
+func ChecksumHashIn(vs ...string) predicate.SIP {
+	return predicate.SIP(sql.FieldIn(FieldChecksumHash, vs...))
+}
+
+// ChecksumHashNotIn applies the NotIn predicate on the "checksum_hash" field.
+func ChecksumHashNotIn(vs ...string) predicate.SIP {
+	return predicate.SIP(sql.FieldNotIn(FieldChecksumHash, vs...))
+}
+
+// ChecksumHashGT applies the GT predicate on the "checksum_hash" field.
+func ChecksumHashGT(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldGT(FieldChecksumHash, v))
+}
+
+// ChecksumHashGTE applies the GTE predicate on the "checksum_hash" field.
+func ChecksumHashGTE(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldGTE(FieldChecksumHash, v))
+}
+
+// ChecksumHashLT applies the LT predicate on the "checksum_hash" field.
+func ChecksumHashLT(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldLT(FieldChecksumHash, v))
+}
+
+// ChecksumHashLTE applies the LTE predicate on the "checksum_hash" field.
+func ChecksumHashLTE(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldLTE(FieldChecksumHash, v))
+}
+
+// ChecksumHashContains applies the Contains predicate on the "checksum_hash" field.
+func ChecksumHashContains(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldContains(FieldChecksumHash, v))
+}
+
+// ChecksumHashHasPrefix applies the HasPrefix predicate on the "checksum_hash" field.
+func ChecksumHashHasPrefix(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldHasPrefix(FieldChecksumHash, v))
+}
+
+// ChecksumHashHasSuffix applies the HasSuffix predicate on the "checksum_hash" field.
+func ChecksumHashHasSuffix(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldHasSuffix(FieldChecksumHash, v))
+}
+
+// ChecksumHashIsNil applies the IsNil predicate on the "checksum_hash" field.
+func ChecksumHashIsNil() predicate.SIP {
+	return predicate.SIP(sql.FieldIsNull(FieldChecksumHash))
+}
+
+// ChecksumHashNotNil applies the NotNil predicate on the "checksum_hash" field.
+func ChecksumHashNotNil() predicate.SIP {
+	return predicate.SIP(sql.FieldNotNull(FieldChecksumHash))
+}
+
+// ChecksumHashEqualFold applies the EqualFold predicate on the "checksum_hash" field.
+func ChecksumHashEqualFold(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldEqualFold(FieldChecksumHash, v))
+}
+
+// ChecksumHashContainsFold applies the ContainsFold predicate on the "checksum_hash" field.
+func ChecksumHashContainsFold(v string) predicate.SIP {
+	return predicate.SIP(sql.FieldContainsFold(FieldChecksumHash, v))
 }
 
 // HasWorkflows applies the HasEdge predicate on the "workflows" edge.

--- a/internal/persistence/ent/db/sip_create.go
+++ b/internal/persistence/ent/db/sip_create.go
@@ -171,6 +171,34 @@ func (_c *SIPCreate) SetNillableFileCount(v *int32) *SIPCreate {
 	return _c
 }
 
+// SetChecksumAlgorithm sets the "checksum_algorithm" field.
+func (_c *SIPCreate) SetChecksumAlgorithm(v string) *SIPCreate {
+	_c.mutation.SetChecksumAlgorithm(v)
+	return _c
+}
+
+// SetNillableChecksumAlgorithm sets the "checksum_algorithm" field if the given value is not nil.
+func (_c *SIPCreate) SetNillableChecksumAlgorithm(v *string) *SIPCreate {
+	if v != nil {
+		_c.SetChecksumAlgorithm(*v)
+	}
+	return _c
+}
+
+// SetChecksumHash sets the "checksum_hash" field.
+func (_c *SIPCreate) SetChecksumHash(v string) *SIPCreate {
+	_c.mutation.SetChecksumHash(v)
+	return _c
+}
+
+// SetNillableChecksumHash sets the "checksum_hash" field if the given value is not nil.
+func (_c *SIPCreate) SetNillableChecksumHash(v *string) *SIPCreate {
+	if v != nil {
+		_c.SetChecksumHash(*v)
+	}
+	return _c
+}
+
 // AddWorkflowIDs adds the "workflows" edge to the Workflow entity by IDs.
 func (_c *SIPCreate) AddWorkflowIDs(ids ...int) *SIPCreate {
 	_c.mutation.AddWorkflowIDs(ids...)
@@ -342,6 +370,14 @@ func (_c *SIPCreate) createSpec() (*SIP, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.FileCount(); ok {
 		_spec.SetField(sip.FieldFileCount, field.TypeInt32, value)
 		_node.FileCount = value
+	}
+	if value, ok := _c.mutation.ChecksumAlgorithm(); ok {
+		_spec.SetField(sip.FieldChecksumAlgorithm, field.TypeString, value)
+		_node.ChecksumAlgorithm = value
+	}
+	if value, ok := _c.mutation.ChecksumHash(); ok {
+		_spec.SetField(sip.FieldChecksumHash, field.TypeString, value)
+		_node.ChecksumHash = value
 	}
 	if nodes := _c.mutation.WorkflowsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -619,6 +655,42 @@ func (u *SIPUpsert) ClearFileCount() *SIPUpsert {
 	return u
 }
 
+// SetChecksumAlgorithm sets the "checksum_algorithm" field.
+func (u *SIPUpsert) SetChecksumAlgorithm(v string) *SIPUpsert {
+	u.Set(sip.FieldChecksumAlgorithm, v)
+	return u
+}
+
+// UpdateChecksumAlgorithm sets the "checksum_algorithm" field to the value that was provided on create.
+func (u *SIPUpsert) UpdateChecksumAlgorithm() *SIPUpsert {
+	u.SetExcluded(sip.FieldChecksumAlgorithm)
+	return u
+}
+
+// ClearChecksumAlgorithm clears the value of the "checksum_algorithm" field.
+func (u *SIPUpsert) ClearChecksumAlgorithm() *SIPUpsert {
+	u.SetNull(sip.FieldChecksumAlgorithm)
+	return u
+}
+
+// SetChecksumHash sets the "checksum_hash" field.
+func (u *SIPUpsert) SetChecksumHash(v string) *SIPUpsert {
+	u.Set(sip.FieldChecksumHash, v)
+	return u
+}
+
+// UpdateChecksumHash sets the "checksum_hash" field to the value that was provided on create.
+func (u *SIPUpsert) UpdateChecksumHash() *SIPUpsert {
+	u.SetExcluded(sip.FieldChecksumHash)
+	return u
+}
+
+// ClearChecksumHash clears the value of the "checksum_hash" field.
+func (u *SIPUpsert) ClearChecksumHash() *SIPUpsert {
+	u.SetNull(sip.FieldChecksumHash)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -867,6 +939,48 @@ func (u *SIPUpsertOne) UpdateFileCount() *SIPUpsertOne {
 func (u *SIPUpsertOne) ClearFileCount() *SIPUpsertOne {
 	return u.Update(func(s *SIPUpsert) {
 		s.ClearFileCount()
+	})
+}
+
+// SetChecksumAlgorithm sets the "checksum_algorithm" field.
+func (u *SIPUpsertOne) SetChecksumAlgorithm(v string) *SIPUpsertOne {
+	return u.Update(func(s *SIPUpsert) {
+		s.SetChecksumAlgorithm(v)
+	})
+}
+
+// UpdateChecksumAlgorithm sets the "checksum_algorithm" field to the value that was provided on create.
+func (u *SIPUpsertOne) UpdateChecksumAlgorithm() *SIPUpsertOne {
+	return u.Update(func(s *SIPUpsert) {
+		s.UpdateChecksumAlgorithm()
+	})
+}
+
+// ClearChecksumAlgorithm clears the value of the "checksum_algorithm" field.
+func (u *SIPUpsertOne) ClearChecksumAlgorithm() *SIPUpsertOne {
+	return u.Update(func(s *SIPUpsert) {
+		s.ClearChecksumAlgorithm()
+	})
+}
+
+// SetChecksumHash sets the "checksum_hash" field.
+func (u *SIPUpsertOne) SetChecksumHash(v string) *SIPUpsertOne {
+	return u.Update(func(s *SIPUpsert) {
+		s.SetChecksumHash(v)
+	})
+}
+
+// UpdateChecksumHash sets the "checksum_hash" field to the value that was provided on create.
+func (u *SIPUpsertOne) UpdateChecksumHash() *SIPUpsertOne {
+	return u.Update(func(s *SIPUpsert) {
+		s.UpdateChecksumHash()
+	})
+}
+
+// ClearChecksumHash clears the value of the "checksum_hash" field.
+func (u *SIPUpsertOne) ClearChecksumHash() *SIPUpsertOne {
+	return u.Update(func(s *SIPUpsert) {
+		s.ClearChecksumHash()
 	})
 }
 
@@ -1284,6 +1398,48 @@ func (u *SIPUpsertBulk) UpdateFileCount() *SIPUpsertBulk {
 func (u *SIPUpsertBulk) ClearFileCount() *SIPUpsertBulk {
 	return u.Update(func(s *SIPUpsert) {
 		s.ClearFileCount()
+	})
+}
+
+// SetChecksumAlgorithm sets the "checksum_algorithm" field.
+func (u *SIPUpsertBulk) SetChecksumAlgorithm(v string) *SIPUpsertBulk {
+	return u.Update(func(s *SIPUpsert) {
+		s.SetChecksumAlgorithm(v)
+	})
+}
+
+// UpdateChecksumAlgorithm sets the "checksum_algorithm" field to the value that was provided on create.
+func (u *SIPUpsertBulk) UpdateChecksumAlgorithm() *SIPUpsertBulk {
+	return u.Update(func(s *SIPUpsert) {
+		s.UpdateChecksumAlgorithm()
+	})
+}
+
+// ClearChecksumAlgorithm clears the value of the "checksum_algorithm" field.
+func (u *SIPUpsertBulk) ClearChecksumAlgorithm() *SIPUpsertBulk {
+	return u.Update(func(s *SIPUpsert) {
+		s.ClearChecksumAlgorithm()
+	})
+}
+
+// SetChecksumHash sets the "checksum_hash" field.
+func (u *SIPUpsertBulk) SetChecksumHash(v string) *SIPUpsertBulk {
+	return u.Update(func(s *SIPUpsert) {
+		s.SetChecksumHash(v)
+	})
+}
+
+// UpdateChecksumHash sets the "checksum_hash" field to the value that was provided on create.
+func (u *SIPUpsertBulk) UpdateChecksumHash() *SIPUpsertBulk {
+	return u.Update(func(s *SIPUpsert) {
+		s.UpdateChecksumHash()
+	})
+}
+
+// ClearChecksumHash clears the value of the "checksum_hash" field.
+func (u *SIPUpsertBulk) ClearChecksumHash() *SIPUpsertBulk {
+	return u.Update(func(s *SIPUpsert) {
+		s.ClearChecksumHash()
 	})
 }
 

--- a/internal/persistence/ent/db/sip_update.go
+++ b/internal/persistence/ent/db/sip_update.go
@@ -228,6 +228,46 @@ func (_u *SIPUpdate) ClearFileCount() *SIPUpdate {
 	return _u
 }
 
+// SetChecksumAlgorithm sets the "checksum_algorithm" field.
+func (_u *SIPUpdate) SetChecksumAlgorithm(v string) *SIPUpdate {
+	_u.mutation.SetChecksumAlgorithm(v)
+	return _u
+}
+
+// SetNillableChecksumAlgorithm sets the "checksum_algorithm" field if the given value is not nil.
+func (_u *SIPUpdate) SetNillableChecksumAlgorithm(v *string) *SIPUpdate {
+	if v != nil {
+		_u.SetChecksumAlgorithm(*v)
+	}
+	return _u
+}
+
+// ClearChecksumAlgorithm clears the value of the "checksum_algorithm" field.
+func (_u *SIPUpdate) ClearChecksumAlgorithm() *SIPUpdate {
+	_u.mutation.ClearChecksumAlgorithm()
+	return _u
+}
+
+// SetChecksumHash sets the "checksum_hash" field.
+func (_u *SIPUpdate) SetChecksumHash(v string) *SIPUpdate {
+	_u.mutation.SetChecksumHash(v)
+	return _u
+}
+
+// SetNillableChecksumHash sets the "checksum_hash" field if the given value is not nil.
+func (_u *SIPUpdate) SetNillableChecksumHash(v *string) *SIPUpdate {
+	if v != nil {
+		_u.SetChecksumHash(*v)
+	}
+	return _u
+}
+
+// ClearChecksumHash clears the value of the "checksum_hash" field.
+func (_u *SIPUpdate) ClearChecksumHash() *SIPUpdate {
+	_u.mutation.ClearChecksumHash()
+	return _u
+}
+
 // AddWorkflowIDs adds the "workflows" edge to the Workflow entity by IDs.
 func (_u *SIPUpdate) AddWorkflowIDs(ids ...int) *SIPUpdate {
 	_u.mutation.AddWorkflowIDs(ids...)
@@ -404,6 +444,18 @@ func (_u *SIPUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if _u.mutation.FileCountCleared() {
 		_spec.ClearField(sip.FieldFileCount, field.TypeInt32)
+	}
+	if value, ok := _u.mutation.ChecksumAlgorithm(); ok {
+		_spec.SetField(sip.FieldChecksumAlgorithm, field.TypeString, value)
+	}
+	if _u.mutation.ChecksumAlgorithmCleared() {
+		_spec.ClearField(sip.FieldChecksumAlgorithm, field.TypeString)
+	}
+	if value, ok := _u.mutation.ChecksumHash(); ok {
+		_spec.SetField(sip.FieldChecksumHash, field.TypeString, value)
+	}
+	if _u.mutation.ChecksumHashCleared() {
+		_spec.ClearField(sip.FieldChecksumHash, field.TypeString)
 	}
 	if _u.mutation.WorkflowsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -723,6 +775,46 @@ func (_u *SIPUpdateOne) ClearFileCount() *SIPUpdateOne {
 	return _u
 }
 
+// SetChecksumAlgorithm sets the "checksum_algorithm" field.
+func (_u *SIPUpdateOne) SetChecksumAlgorithm(v string) *SIPUpdateOne {
+	_u.mutation.SetChecksumAlgorithm(v)
+	return _u
+}
+
+// SetNillableChecksumAlgorithm sets the "checksum_algorithm" field if the given value is not nil.
+func (_u *SIPUpdateOne) SetNillableChecksumAlgorithm(v *string) *SIPUpdateOne {
+	if v != nil {
+		_u.SetChecksumAlgorithm(*v)
+	}
+	return _u
+}
+
+// ClearChecksumAlgorithm clears the value of the "checksum_algorithm" field.
+func (_u *SIPUpdateOne) ClearChecksumAlgorithm() *SIPUpdateOne {
+	_u.mutation.ClearChecksumAlgorithm()
+	return _u
+}
+
+// SetChecksumHash sets the "checksum_hash" field.
+func (_u *SIPUpdateOne) SetChecksumHash(v string) *SIPUpdateOne {
+	_u.mutation.SetChecksumHash(v)
+	return _u
+}
+
+// SetNillableChecksumHash sets the "checksum_hash" field if the given value is not nil.
+func (_u *SIPUpdateOne) SetNillableChecksumHash(v *string) *SIPUpdateOne {
+	if v != nil {
+		_u.SetChecksumHash(*v)
+	}
+	return _u
+}
+
+// ClearChecksumHash clears the value of the "checksum_hash" field.
+func (_u *SIPUpdateOne) ClearChecksumHash() *SIPUpdateOne {
+	_u.mutation.ClearChecksumHash()
+	return _u
+}
+
 // AddWorkflowIDs adds the "workflows" edge to the Workflow entity by IDs.
 func (_u *SIPUpdateOne) AddWorkflowIDs(ids ...int) *SIPUpdateOne {
 	_u.mutation.AddWorkflowIDs(ids...)
@@ -929,6 +1021,18 @@ func (_u *SIPUpdateOne) sqlSave(ctx context.Context) (_node *SIP, err error) {
 	}
 	if _u.mutation.FileCountCleared() {
 		_spec.ClearField(sip.FieldFileCount, field.TypeInt32)
+	}
+	if value, ok := _u.mutation.ChecksumAlgorithm(); ok {
+		_spec.SetField(sip.FieldChecksumAlgorithm, field.TypeString, value)
+	}
+	if _u.mutation.ChecksumAlgorithmCleared() {
+		_spec.ClearField(sip.FieldChecksumAlgorithm, field.TypeString)
+	}
+	if value, ok := _u.mutation.ChecksumHash(); ok {
+		_spec.SetField(sip.FieldChecksumHash, field.TypeString, value)
+	}
+	if _u.mutation.ChecksumHashCleared() {
+		_spec.ClearField(sip.FieldChecksumHash, field.TypeString)
 	}
 	if _u.mutation.WorkflowsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/persistence/ent/schema/sip.go
+++ b/internal/persistence/ent/schema/sip.go
@@ -64,6 +64,12 @@ func (SIP) Fields() []ent.Field {
 		field.Int32("file_count").
 			Optional().
 			NonNegative(),
+		field.String("checksum_algorithm").
+			Optional(),
+		// checksum_hash is the hash of a SIP archive (e.g. zip file) before it
+		// is extracted for processing.
+		field.String("checksum_hash").
+			Optional(),
 	}
 }
 
@@ -101,5 +107,7 @@ func (SIP) Indexes() []ent.Index {
 			StorageKey("sip_uploader_id_idx"),
 		index.Fields("batch_id").
 			StorageKey("sip_batch_id_idx"),
+		index.Fields("checksum_algorithm", "checksum_hash").
+			StorageKey("sip_checksum_idx"),
 	}
 }

--- a/internal/persistence/filter.go
+++ b/internal/persistence/filter.go
@@ -38,11 +38,13 @@ type SIPFilter struct {
 	// Name filters for SIPs whose names contain the given string.
 	Name *string
 
-	AIPID      *uuid.UUID
-	Status     *enums.SIPStatus
-	CreatedAt  *timerange.Range
-	UploaderID *uuid.UUID
-	BatchID    *uuid.UUID
+	AIPID             *uuid.UUID
+	Status            *enums.SIPStatus
+	CreatedAt         *timerange.Range
+	UploaderID        *uuid.UUID
+	BatchID           *uuid.UUID
+	ChecksumAlgorithm *string
+	ChecksumHash      *string
 
 	entfilter.Sort
 	Page

--- a/internal/workflow/activities/calc_file_checksum.go
+++ b/internal/workflow/activities/calc_file_checksum.go
@@ -1,0 +1,66 @@
+package activities
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
+)
+
+const CalcFileChecksumActivityName = "calc-file-checksum-activity"
+
+type (
+	CalcFileChecksumActivityParams struct {
+		Path string
+	}
+	CalcFileChecksumActivityResult struct {
+		Checksum datatypes.Checksum
+	}
+	CalcFileChecksumActivity struct{}
+)
+
+func NewCalcFileChecksumActivity() *CalcFileChecksumActivity {
+	return &CalcFileChecksumActivity{}
+}
+
+// Execute calculates the SHA-256 checksum of the file at params.Path.
+//
+// If params.Path is a directory, Execute returns an error.
+func (a *CalcFileChecksumActivity) Execute(
+	ctx context.Context,
+	params *CalcFileChecksumActivityParams,
+) (*CalcFileChecksumActivityResult, error) {
+	fi, err := os.Stat(params.Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("calculate file checksum: file not found: %s", params.Path)
+		}
+		return nil, fmt.Errorf("calculate file checksum: stat file: %v", err)
+	}
+
+	if fi.IsDir() {
+		return nil, fmt.Errorf("calculate file checksum: not a file: %s", params.Path)
+	}
+
+	f, err := os.Open(params.Path)
+	if err != nil {
+		return nil, fmt.Errorf("calculate file checksum: open file: %v", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, fmt.Errorf("calculate file checksum: compute hash: %v", err)
+	}
+
+	return &CalcFileChecksumActivityResult{
+		Checksum: datatypes.Checksum{
+			Algorithm: datatypes.ChecksumAlgoSHA256,
+			Hash:      hex.EncodeToString(h.Sum(nil)),
+		},
+	}, nil
+}

--- a/internal/workflow/activities/calc_file_checksum_test.go
+++ b/internal/workflow/activities/calc_file_checksum_test.go
@@ -1,0 +1,83 @@
+package activities_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
+	"github.com/artefactual-sdps/enduro/internal/workflow/activities"
+)
+
+func TestCalcFileChecksumActivity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		params  activities.CalcFileChecksumActivityParams
+		want    activities.CalcFileChecksumActivityResult
+		wantErr string
+	}{
+		{
+			name: "Calculates file checksum",
+			params: activities.CalcFileChecksumActivityParams{
+				Path: filepath.Join("..", "..", "testdata", "zipped_transfer", "small.zip"),
+			},
+			want: activities.CalcFileChecksumActivityResult{
+				Checksum: datatypes.Checksum{
+					Algorithm: datatypes.ChecksumAlgoSHA256,
+					Hash:      "3ee958afa3bacb8698d0b7a549a6192d2bdf9feb53b409941a00a9d69da2ae6c",
+				},
+			},
+		},
+		{
+			name: "Fails when file is not found",
+			params: activities.CalcFileChecksumActivityParams{
+				Path: filepath.Join("..", "..", "testdata", "zipped_transfer", "missing.zip"),
+			},
+			wantErr: "calculate file checksum: file not found",
+		},
+		{
+			name: "Fails when path is a directory",
+			params: activities.CalcFileChecksumActivityParams{
+				Path: filepath.Join("..", "..", "testdata", "zipped_transfer"),
+			},
+			wantErr: "calculate file checksum: not a file",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			env.RegisterActivityWithOptions(
+				activities.NewCalcFileChecksumActivity().Execute,
+				temporalsdk_activity.RegisterOptions{Name: activities.CalcFileChecksumActivityName},
+			)
+
+			future, err := env.ExecuteActivity(
+				activities.CalcFileChecksumActivityName,
+				&tt.params,
+			)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Errorf("error is nil, expecting: %q", tt.wantErr)
+				} else {
+					assert.ErrorContains(t, err, tt.wantErr)
+				}
+
+				return
+			}
+
+			assert.NilError(t, err)
+			var res activities.CalcFileChecksumActivityResult
+			future.Get(&res)
+			assert.DeepEqual(t, res, tt.want)
+		})
+	}
+}

--- a/internal/workflow/activities/check_duplicate_sip.go
+++ b/internal/workflow/activities/check_duplicate_sip.go
@@ -1,0 +1,42 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
+	"github.com/artefactual-sdps/enduro/internal/ingest"
+)
+
+const CheckDuplicateSIPActivityName = "check-duplicate-sip-activity"
+
+type (
+	CheckDuplicateSIPActivity struct {
+		ingestSvc ingest.Service
+	}
+	CheckDuplicateSIPActivityParams struct {
+		SIPID    uuid.UUID
+		Checksum datatypes.Checksum
+	}
+	CheckDuplicateSIPActivityResult struct {
+		Duplicate *datatypes.SIP
+	}
+)
+
+func NewCheckDuplicateSIPActivity(svc ingest.Service) *CheckDuplicateSIPActivity {
+	return &CheckDuplicateSIPActivity{ingestSvc: svc}
+}
+
+func (a *CheckDuplicateSIPActivity) Execute(
+	ctx context.Context,
+	params CheckDuplicateSIPActivityParams,
+) (*CheckDuplicateSIPActivityResult, error) {
+	duplicate, err := a.ingestSvc.FindDuplicateSIP(ctx, params.SIPID, params.Checksum)
+	if err != nil {
+		return nil, fmt.Errorf("check duplicate SIP: %w", err)
+	}
+
+	return &CheckDuplicateSIPActivityResult{Duplicate: duplicate}, nil
+}

--- a/internal/workflow/activities/check_duplicate_sip_test.go
+++ b/internal/workflow/activities/check_duplicate_sip_test.go
@@ -1,0 +1,146 @@
+package activities_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"go.artefactual.dev/tools/mockutil"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
+	"github.com/artefactual-sdps/enduro/internal/enums"
+	ingest_fake "github.com/artefactual-sdps/enduro/internal/ingest/fake"
+	"github.com/artefactual-sdps/enduro/internal/workflow/activities"
+)
+
+func TestCheckSIPChecksumActivity(t *testing.T) {
+	t.Parallel()
+
+	sipID := uuid.New()       // Current SIP ID.
+	duplicateID := uuid.New() // Duplicate SIP ID.
+	hash := "5d96420c54e8c2664a7142ed1d681db98861263a5c248077ba46423ad1f66d35"
+
+	type test struct {
+		name      string
+		params    activities.CheckDuplicateSIPActivityParams
+		mockCalls func(m *ingest_fake.MockServiceMockRecorder)
+		want      *activities.CheckDuplicateSIPActivityResult
+		wantErr   string
+	}
+	for _, tt := range []test{
+		{
+			name: "Checksum matches ingested SIP",
+			params: activities.CheckDuplicateSIPActivityParams{
+				SIPID: sipID,
+				Checksum: datatypes.Checksum{
+					Algorithm: datatypes.ChecksumAlgoSHA256,
+					Hash:      hash,
+				},
+			},
+			mockCalls: func(m *ingest_fake.MockServiceMockRecorder) {
+				m.FindDuplicateSIP(
+					mockutil.Context(),
+					sipID,
+					datatypes.Checksum{
+						Algorithm: datatypes.ChecksumAlgoSHA256,
+						Hash:      hash,
+					},
+				).Return(
+					&datatypes.SIP{
+						UUID:              duplicateID,
+						Status:            enums.SIPStatusIngested,
+						ChecksumAlgorithm: string(datatypes.ChecksumAlgoSHA256),
+						ChecksumHash:      hash,
+					},
+					nil,
+				)
+			},
+			want: &activities.CheckDuplicateSIPActivityResult{
+				Duplicate: &datatypes.SIP{
+					UUID:              duplicateID,
+					Status:            enums.SIPStatusIngested,
+					ChecksumAlgorithm: string(datatypes.ChecksumAlgoSHA256),
+					ChecksumHash:      hash,
+				},
+			},
+		},
+		{
+			name: "Checksum not found",
+			params: activities.CheckDuplicateSIPActivityParams{
+				SIPID: sipID,
+				Checksum: datatypes.Checksum{
+					Algorithm: datatypes.ChecksumAlgoSHA256,
+					Hash:      hash,
+				},
+			},
+			mockCalls: func(m *ingest_fake.MockServiceMockRecorder) {
+				m.FindDuplicateSIP(
+					mockutil.Context(),
+					sipID,
+					datatypes.Checksum{
+						Algorithm: datatypes.ChecksumAlgoSHA256,
+						Hash:      hash,
+					},
+				).Return(nil, nil)
+			},
+			want: &activities.CheckDuplicateSIPActivityResult{},
+		},
+		{
+			name: "Errors when ingest service returns an error",
+			params: activities.CheckDuplicateSIPActivityParams{
+				SIPID: sipID,
+				Checksum: datatypes.Checksum{
+					Algorithm: datatypes.ChecksumAlgoSHA256,
+					Hash:      hash,
+				},
+			},
+			mockCalls: func(m *ingest_fake.MockServiceMockRecorder) {
+				m.FindDuplicateSIP(
+					mockutil.Context(),
+					sipID,
+					datatypes.Checksum{
+						Algorithm: datatypes.ChecksumAlgoSHA256,
+						Hash:      hash,
+					},
+				).Return(nil, errors.New("an error occurred"))
+			},
+			wantErr: "check duplicate SIP: an error occurred",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockSvc := ingest_fake.NewMockService(ctrl)
+			tt.mockCalls(mockSvc.EXPECT())
+
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			env.RegisterActivityWithOptions(
+				activities.NewCheckDuplicateSIPActivity(mockSvc).Execute,
+				temporalsdk_activity.RegisterOptions{Name: activities.CheckDuplicateSIPActivityName},
+			)
+
+			enc, err := env.ExecuteActivity(
+				activities.CheckDuplicateSIPActivityName,
+				tt.params,
+			)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+
+			var got *activities.CheckDuplicateSIPActivityResult
+			err = enc.Get(&got)
+
+			assert.NilError(t, err)
+			assert.DeepEqual(t, tt.want, got)
+		})
+	}
+}

--- a/internal/workflow/local_activities.go
+++ b/internal/workflow/local_activities.go
@@ -30,14 +30,16 @@ func createSIPLocalActivity(
 }
 
 type updateSIPLocalActivityParams struct {
-	UUID        uuid.UUID
-	Name        string
-	AIPUUID     string
-	CompletedAt time.Time
-	Status      enums.SIPStatus
-	FailedAs    enums.SIPFailedAs
-	FailedKey   string
-	FileCount   int32
+	UUID         uuid.UUID
+	Name         string
+	AIPUUID      string
+	CompletedAt  time.Time
+	Status       enums.SIPStatus
+	FailedAs     enums.SIPFailedAs
+	FailedKey    string
+	FileCount    int32
+	ChecksumAlgo datatypes.ChecksumAlgo
+	ChecksumHash string
 }
 
 type updateSIPLocalActivityResult struct{}
@@ -87,6 +89,14 @@ func updateSIPLocalActivity(
 
 			if params.FileCount > 0 {
 				s.FileCount = params.FileCount
+			}
+
+			if params.ChecksumAlgo != "" {
+				s.ChecksumAlgorithm = string(params.ChecksumAlgo)
+			}
+
+			if params.ChecksumHash != "" {
+				s.ChecksumHash = params.ChecksumHash
 			}
 
 			return s, nil

--- a/internal/workflow/local_activities_test.go
+++ b/internal/workflow/local_activities_test.go
@@ -210,6 +210,7 @@ func TestUpdateSIPLocalActivity(t *testing.T) {
 	completedAt := time.Now()
 	failedKey := "failed-key"
 	filecount := int32(42)
+	hash := "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 
 	for _, tt := range []struct {
 		name      string
@@ -220,14 +221,16 @@ func TestUpdateSIPLocalActivity(t *testing.T) {
 		{
 			name: "Updates a SIP",
 			params: &updateSIPLocalActivityParams{
-				UUID:        sipUUID,
-				Name:        name,
-				Status:      enums.SIPStatusIngested,
-				CompletedAt: completedAt,
-				AIPUUID:     aipUUID.String(),
-				FailedAs:    enums.SIPFailedAsSIP,
-				FailedKey:   failedKey,
-				FileCount:   filecount,
+				UUID:         sipUUID,
+				Name:         name,
+				Status:       enums.SIPStatusIngested,
+				CompletedAt:  completedAt,
+				AIPUUID:      aipUUID.String(),
+				FailedAs:     enums.SIPFailedAsSIP,
+				FailedKey:    failedKey,
+				FileCount:    filecount,
+				ChecksumAlgo: datatypes.ChecksumAlgoSHA256,
+				ChecksumHash: hash,
 			},
 			mockCalls: func(ctx context.Context, svc *ingest_fake.MockService) {
 				svc.EXPECT().
@@ -239,13 +242,15 @@ func TestUpdateSIPLocalActivity(t *testing.T) {
 							func(updater persistence.SIPUpdater) error {
 								s, err := updater(&datatypes.SIP{})
 								assert.NilError(t, err)
-								assert.DeepEqual(t, s.Name, name)
-								assert.DeepEqual(t, s.Status, enums.SIPStatusIngested)
-								assert.DeepEqual(t, s.CompletedAt, completedAt)
-								assert.DeepEqual(t, s.FileCount, filecount)
-								assert.DeepEqual(t, s.AIPID, uuid.NullUUID{Valid: true, UUID: aipUUID})
-								assert.DeepEqual(t, s.FailedAs, enums.SIPFailedAsSIP)
-								assert.DeepEqual(t, s.FailedKey, failedKey)
+								assert.Equal(t, s.Name, name)
+								assert.Equal(t, s.Status, enums.SIPStatusIngested)
+								assert.Equal(t, s.CompletedAt, completedAt)
+								assert.Equal(t, s.FileCount, filecount)
+								assert.Equal(t, s.AIPID, uuid.NullUUID{Valid: true, UUID: aipUUID})
+								assert.Equal(t, s.FailedAs, enums.SIPFailedAsSIP)
+								assert.Equal(t, s.FailedKey, failedKey)
+								assert.Equal(t, s.ChecksumAlgorithm, string(datatypes.ChecksumAlgoSHA256))
+								assert.Equal(t, s.ChecksumHash, hash)
 								return nil
 							},
 						),

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -411,6 +411,21 @@ func (w *ProcessingWorkflow) SessionHandler(
 		}
 	}
 
+	// Calculate the SIP checksum if the SIP is not a directory.
+	if !state.sip.isDir {
+		if err := w.calcSIPChecksum(sessCtx, state); err != nil {
+			return err
+		}
+
+		// If duplicate SIPs are not allowed, check if a SIP with the same
+		// checksum has already been ingested or is being processed.
+		if !w.cfg.Ingest.AllowDuplicates {
+			if err := w.checkForDuplicateSIP(sessCtx, state); err != nil {
+				return err
+			}
+		}
+	}
+
 	// Extract the transfer if it's not a directory and a preprocessing child
 	// workflow is not doing the extraction.
 	cfg := w.cfg.ChildWorkflows.ByType(childwf.WorkflowTypePreprocessing)
@@ -1767,4 +1782,149 @@ func (w *ProcessingWorkflow) countSIPFIles(
 	state.sip.fileCount = result.Count
 
 	return nil
+}
+
+func (w *ProcessingWorkflow) calcSIPChecksum(
+	sessCtx temporalsdk_workflow.Context,
+	state *workflowState,
+) (err error) {
+	id, err := w.createTask(
+		sessCtx,
+		&datatypes.Task{
+			Name:         "Calculate SIP checksum",
+			Status:       enums.TaskStatusInProgress,
+			WorkflowUUID: state.workflowUUID,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("calculate SIP checksum: create task: %v", err)
+	}
+
+	// Set the default (successful) task completion values.
+	task := datatypes.Task{ID: id, Status: enums.TaskStatusDone}
+
+	// Complete the task when calcSIPChecksum() returns.
+	defer func() {
+		if e := w.completeTask(sessCtx, task); e != nil {
+			err = errors.Join(
+				err,
+				fmt.Errorf("calculate SIP checksum: complete task: %v", e),
+			)
+		}
+	}()
+
+	var result activities.CalcFileChecksumActivityResult
+	opts := withActivityOptsForLocalAction(sessCtx)
+	err = temporalsdk_workflow.ExecuteActivity(
+		opts,
+		activities.CalcFileChecksumActivityName,
+		&activities.CalcFileChecksumActivityParams{
+			Path: state.sip.path,
+		},
+	).Get(opts, &result)
+	if err != nil {
+		task.SystemError(
+			"Calculating SIP checksum failed.",
+			"An error has occurred while calculating the SIP checksum. Please try again, or ask a system administrator to investigate.",
+		)
+		state.status = enums.WorkflowStatusError
+		return err
+	}
+
+	state.sip.checksum = result.Checksum
+	task.Note = fmt.Sprintf("SIP checksum calculated: %s", state.sip.checksum.Hash)
+
+	// Persist the SIP checksum.
+	opts = withLocalActivityOpts(sessCtx)
+	err = temporalsdk_workflow.ExecuteLocalActivity(
+		opts,
+		updateSIPLocalActivity,
+		w.ingestsvc,
+		&updateSIPLocalActivityParams{
+			UUID:         state.sip.uuid,
+			ChecksumAlgo: state.sip.checksum.Algorithm,
+			ChecksumHash: state.sip.checksum.Hash,
+		},
+	).Get(opts, nil)
+	if err != nil {
+		task.SystemError(
+			"Saving SIP checksum failed.",
+			"An error has occurred while saving the SIP checksum. Please try again, or ask a system administrator to investigate.",
+		)
+		state.status = enums.WorkflowStatusError
+		return fmt.Errorf("save SIP checksum: %v", err)
+	}
+
+	return nil
+}
+
+func (w *ProcessingWorkflow) checkForDuplicateSIP(
+	ctx temporalsdk_workflow.Context,
+	state *workflowState,
+) error {
+	id, err := w.createTask(
+		ctx,
+		&datatypes.Task{
+			Name:         "Check if SIP has already been ingested",
+			Status:       enums.TaskStatusInProgress,
+			WorkflowUUID: state.workflowUUID,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("duplicate SIP check: create task: %v", err)
+	}
+
+	// Set the default (successful) task completion values.
+	task := datatypes.Task{
+		ID:     id,
+		Status: enums.TaskStatusDone,
+		Note:   "SIP has not been previously ingested",
+	}
+
+	// Search the database for any ingested or processing SIPs with the same
+	// checksum.
+	var duplicateResult activities.CheckDuplicateSIPActivityResult
+	opts := withActivityOptsForLocalAction(ctx)
+	err = temporalsdk_workflow.ExecuteActivity(
+		opts,
+		activities.CheckDuplicateSIPActivityName,
+		activities.CheckDuplicateSIPActivityParams{
+			SIPID:    state.sip.uuid,
+			Checksum: state.sip.checksum,
+		},
+	).Get(opts, &duplicateResult)
+	if err != nil {
+		task.SystemError(
+			"Duplicate SIP check has failed.",
+			"An error has occurred while checking for duplicate SIPs. Please try again, or ask a system administrator to investigate.",
+		)
+		state.status = enums.WorkflowStatusError
+	}
+
+	// If the SIP is a duplicate, halt the workflow with a content failure.
+	if err == nil && duplicateResult.Duplicate != nil {
+		task.Failed(
+			"SIP has already been ingested.",
+			fmt.Sprintf(
+				"A previously ingested SIP (UUID: %s) has the same checksum as the current SIP. Please ensure you have submitted the correct SIP and that it has not been previously submitted.",
+				duplicateResult.Duplicate.UUID,
+			),
+		)
+		state.status = enums.WorkflowStatusFailed
+		err = fmt.Errorf(
+			"duplicate SIP check: SIP %s is a duplicate of %s (status: %s)",
+			state.sip.uuid,
+			duplicateResult.Duplicate.UUID,
+			duplicateResult.Duplicate.Status,
+		)
+	}
+
+	if e := w.completeTask(ctx, task); e != nil {
+		return errors.Join(
+			err,
+			fmt.Errorf("duplicate SIP check: complete task: %v", e),
+		)
+	}
+
+	return err
 }

--- a/internal/workflow/processing_expectations_test.go
+++ b/internal/workflow/processing_expectations_test.go
@@ -42,10 +42,14 @@ const (
 	deleteSIPTaskID     = 106
 	valBagTaskID        = 107
 	CountSIPFilesTaskID = 108
-	sipName             = "name.zip"
-	key                 = "transfer.zip"
-	watcherName         = "watcher"
-	fileCount           = 5
+	calcChecksumTaskID  = 109
+	duplicateSIPTaskID  = 110
+
+	sipName     = "name.zip"
+	key         = "transfer.zip"
+	watcherName = "watcher"
+	fileCount   = 5
+	sipChecksum = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 )
 
 var (
@@ -255,6 +259,46 @@ var expectations = map[string]expectationFunc{
 				DestinationPath: params.downloadDestPath,
 			},
 		).Return(&activities.DownloadActivityResult{Path: params.downloadPath}, nil)
+	},
+	"calcFileChecksum": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			activities.CalcFileChecksumActivityName,
+			sessionCtx,
+			&activities.CalcFileChecksumActivityParams{Path: params.downloadPath},
+		).Return(
+			&activities.CalcFileChecksumActivityResult{
+				Checksum: datatypes.Checksum{
+					Algorithm: datatypes.ChecksumAlgoSHA256,
+					Hash:      "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+				},
+			},
+			nil,
+		)
+	},
+	"saveChecksum": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			updateSIPLocalActivity,
+			ctx,
+			s.workflow.ingestsvc,
+			&updateSIPLocalActivityParams{
+				UUID:         sipUUID,
+				ChecksumAlgo: datatypes.ChecksumAlgoSHA256,
+				ChecksumHash: sipChecksum,
+			},
+		).Return(nil, nil)
+	},
+	"checkDuplicateSIP": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			activities.CheckDuplicateSIPActivityName,
+			sessionCtx,
+			activities.CheckDuplicateSIPActivityParams{
+				SIPID: sipUUID,
+				Checksum: datatypes.Checksum{
+					Algorithm: datatypes.ChecksumAlgoSHA256,
+					Hash:      "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+				},
+			},
+		).Return(&activities.CheckDuplicateSIPActivityResult{}, nil)
 	},
 	"getSIPExtension": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
 		s.env.OnActivity(
@@ -521,7 +565,7 @@ func cleanupExpectations(s *ProcessingWorkflowTestSuite, params expectationParam
 	expectations["completeWorkflow"](s, params)
 }
 
-func CountSIPFilesExpectations(s *ProcessingWorkflowTestSuite, params expectationParams) {
+func countSIPFilesExpectations(s *ProcessingWorkflowTestSuite, params expectationParams) {
 	params.updateTaskParams(CountSIPFilesTaskID, enums.TaskStatusInProgress, "Count SIP Files", "")
 	expectations["createTask"](s, params)
 	expectations["countSIPFiles"](s, params)
@@ -530,6 +574,43 @@ func CountSIPFilesExpectations(s *ProcessingWorkflowTestSuite, params expectatio
 		enums.TaskStatusDone,
 		"",
 		fmt.Sprintf("SIP contains %d files", fileCount),
+	)
+	expectations["completeTask"](s, params)
+}
+
+func calcChecksumExpectations(s *ProcessingWorkflowTestSuite, params expectationParams) {
+	params.updateTaskParams(
+		calcChecksumTaskID,
+		enums.TaskStatusInProgress,
+		"Calculate SIP checksum",
+		"",
+	)
+	expectations["createTask"](s, params)
+	expectations["calcFileChecksum"](s, params)
+	params.updateTaskParams(
+		calcChecksumTaskID,
+		enums.TaskStatusDone,
+		"",
+		"SIP checksum calculated: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+	)
+	expectations["completeTask"](s, params)
+	expectations["saveChecksum"](s, params)
+}
+
+func checkDuplicateSIPExpectations(s *ProcessingWorkflowTestSuite, params expectationParams) {
+	params.updateTaskParams(
+		duplicateSIPTaskID,
+		enums.TaskStatusInProgress,
+		"Check if SIP has already been ingested",
+		"",
+	)
+	expectations["createTask"](s, params)
+	expectations["checkDuplicateSIP"](s, params)
+	params.updateTaskParams(
+		duplicateSIPTaskID,
+		enums.TaskStatusDone,
+		"",
+		"SIP has not been previously ingested",
 	)
 	expectations["completeTask"](s, params)
 }

--- a/internal/workflow/processing_setup_test.go
+++ b/internal/workflow/processing_setup_test.go
@@ -109,6 +109,14 @@ func (s *ProcessingWorkflowTestSuite) SetupWorkflowTest(
 		temporalsdk_activity.RegisterOptions{Name: activities.GetSIPExtensionActivityName},
 	)
 	s.env.RegisterActivityWithOptions(
+		activities.NewCalcFileChecksumActivity().Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.CalcFileChecksumActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
+		activities.NewCheckDuplicateSIPActivity(ingestsvc).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.CheckDuplicateSIPActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
 		archiveextract.New(cfg.ExtractActivity).Execute,
 		temporalsdk_activity.RegisterOptions{Name: archiveextract.Name},
 	)

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/a3m"
 	"github.com/artefactual-sdps/enduro/internal/am"
 	"github.com/artefactual-sdps/enduro/internal/config"
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
 	"github.com/artefactual-sdps/enduro/internal/enums"
 	"github.com/artefactual-sdps/enduro/internal/ingest"
 	"github.com/artefactual-sdps/enduro/internal/premis"
@@ -63,9 +64,11 @@ func (s *ProcessingWorkflowTestSuite) TestConfirmation() {
 	params := defaultParams()
 	params.workflowType = enums.WorkflowTypeCreateAndReviewAip
 	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
-	CountSIPFilesExpectations(s, params)
+	countSIPFilesExpectations(s, params)
 	expectations["saveFileCount"](s, params)
 	reviewA3mExpectations(s, params)
 	params.updateTaskParams(reviewAIPTaskID, enums.TaskStatusDone, "", "Reviewed and accepted")
@@ -120,9 +123,11 @@ func (s *ProcessingWorkflowTestSuite) TestRejection() {
 	params := defaultParams()
 	params.workflowType = enums.WorkflowTypeCreateAndReviewAip
 	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
-	CountSIPFilesExpectations(s, params)
+	countSIPFilesExpectations(s, params)
 	expectations["saveFileCount"](s, params)
 	reviewA3mExpectations(s, params)
 	params.updateTaskParams(reviewAIPTaskID, enums.TaskStatusDone, "", "Reviewed and rejected")
@@ -160,9 +165,11 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 
 	params := defaultParams()
 	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
-	CountSIPFilesExpectations(s, params)
+	countSIPFilesExpectations(s, params)
 	expectations["saveFileCount"](s, params)
 	autoApproveA3mExpectations(s, params)
 	params.retentionPeriod = -1 * time.Second
@@ -196,10 +203,12 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 
 	params := defaultParams()
 	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
 	expectations["createBag"](s, params)
-	CountSIPFilesExpectations(s, params)
+	countSIPFilesExpectations(s, params)
 	expectations["saveFileCount"](s, params)
 	params.updateTaskParams(valPREMISTaskID, enums.TaskStatusInProgress, "Validate PREMIS", "")
 	expectations["createTask"](s, params)
@@ -328,6 +337,8 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	params.downloadPath = prepDownloadPath + "/" + key
 	params.extractPath = prepExtractPath
 	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 	preprocessingMetadata := childwf.CustomMetadata{
 		"external_id": json.RawMessage(`"12345"`),
 		"flags":       json.RawMessage(`{"validated":true}`),
@@ -389,7 +400,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	expectations["validateBag"](s, params)
 	params.updateTaskParams(valBagTaskID, enums.TaskStatusDone, "", "Bag successfully validated")
 	expectations["completeTask"](s, params)
-	CountSIPFilesExpectations(s, params)
+	countSIPFilesExpectations(s, params)
 	expectations["saveFileCount"](s, params)
 	autoApproveA3mExpectations(s, params)
 
@@ -513,6 +524,8 @@ func (s *ProcessingWorkflowTestSuite) TestPreprocessingDecisionFlow() {
 	params.downloadPath = prepDownloadPath + "/" + key
 	params.extractPath = prepExtractPath
 	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 
 	params.updateTaskParams(
 		preprocessingDecisionTaskID,
@@ -560,7 +573,7 @@ func (s *ProcessingWorkflowTestSuite) TestPreprocessingDecisionFlow() {
 	expectations["validateBag"](s, params)
 	params.updateTaskParams(valBagTaskID, enums.TaskStatusDone, "", "Bag successfully validated")
 	expectations["completeTask"](s, params)
-	CountSIPFilesExpectations(s, params)
+	countSIPFilesExpectations(s, params)
 	s.env.OnActivity(
 		updateSIPLocalActivity,
 		ctx,
@@ -612,6 +625,8 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 	params.downloadDestPath = prepSharedPath
 	params.downloadPath = prepDownloadPath + "/" + key
 	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 
 	// Fail the workflow on preprocessing.
 	s.env.OnWorkflow(
@@ -666,6 +681,8 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPA3m() {
 
 	params := defaultParams()
 	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	params.sipType = enums.SIPTypeBagIt
 	expectations["classifySIP"](s, params)
@@ -674,7 +691,7 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPA3m() {
 	expectations["validateBag"](s, params)
 	params.updateTaskParams(valBagTaskID, enums.TaskStatusDone, "", "Bag successfully validated")
 	expectations["completeTask"](s, params)
-	CountSIPFilesExpectations(s, params)
+	countSIPFilesExpectations(s, params)
 	expectations["saveFileCount"](s, params)
 	expectations["bundle"](s, params)
 	params.updateTaskParams(valPREMISTaskID, enums.TaskStatusInProgress, "Validate PREMIS", "")
@@ -733,9 +750,11 @@ func (s *ProcessingWorkflowTestSuite) TestFailedPIPAM() {
 
 	params := defaultParams()
 	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
-	CountSIPFilesExpectations(s, params)
+	countSIPFilesExpectations(s, params)
 	expectations["saveFileCount"](s, params)
 	expectations["createBag"](s, params)
 	expectations["zipArchive"](s, params)
@@ -792,9 +811,11 @@ func (s *ProcessingWorkflowTestSuite) TestInternalUpload() {
 
 	params.updateTaskParams(copySIPTaskID, enums.TaskStatusDone, "", "SIP successfully copied")
 	expectations["completeTask"](s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
-	CountSIPFilesExpectations(s, params)
+	countSIPFilesExpectations(s, params)
 	expectations["saveFileCount"](s, params)
 	autoApproveA3mExpectations(s, params)
 
@@ -850,6 +871,7 @@ func (s *ProcessingWorkflowTestSuite) TestInternalUploadError() {
 
 	downloadDir := filepath.Join(prepSharedPath, sipUUID.String())
 	params := defaultParams()
+	params.downloadPath = filepath.Join(downloadDir, key)
 	expectations["setStatusInProgress"](s, params)
 	expectations["createWorkflow"](s, params)
 	params.updateTaskParams(copySIPTaskID, enums.TaskStatusInProgress, "Copy SIP to workspace", "")
@@ -862,16 +884,18 @@ func (s *ProcessingWorkflowTestSuite) TestInternalUploadError() {
 			Key:     key,
 			DirPath: downloadDir,
 		},
-	).Return(&bucketdownload.Result{FilePath: downloadDir + "/" + key}, nil)
+	).Return(&bucketdownload.Result{FilePath: params.downloadPath}, nil)
 
 	params.updateTaskParams(copySIPTaskID, enums.TaskStatusDone, "", "SIP successfully copied")
 	expectations["completeTask"](s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 
 	// Fail the workflow on extraction.
 	s.env.OnActivity(
 		archiveextract.Name,
 		sessionCtx,
-		&archiveextract.Params{SourcePath: downloadDir + "/" + key},
+		&archiveextract.Params{SourcePath: params.downloadPath},
 	).Return(nil, errors.New("extract error"))
 	s.env.OnActivity(
 		bucketcopy.Name,
@@ -930,10 +954,12 @@ func (s *ProcessingWorkflowTestSuite) TestSIPSourceUpload() {
 
 	params.updateTaskParams(copySIPTaskID, enums.TaskStatusDone, "", "SIP successfully copied")
 	expectations["completeTask"](s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 	expectations["getSIPExtension"](s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
-	CountSIPFilesExpectations(s, params)
+	countSIPFilesExpectations(s, params)
 	expectations["saveFileCount"](s, params)
 	autoApproveA3mExpectations(s, params)
 
@@ -981,9 +1007,11 @@ func (s *ProcessingWorkflowTestSuite) TestSIPDeletionError() {
 
 	params := defaultParams()
 	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
-	CountSIPFilesExpectations(s, params)
+	countSIPFilesExpectations(s, params)
 	expectations["saveFileCount"](s, params)
 	autoApproveA3mExpectations(s, params)
 	expectations["removePaths"](s, params)
@@ -1037,9 +1065,11 @@ func (s *ProcessingWorkflowTestSuite) TestBatchSignalDoNotContinue() {
 
 	params := defaultParams()
 	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+	checkDuplicateSIPExpectations(s, params)
 	expectations["archiveExtract"](s, params)
 	expectations["classifySIP"](s, params)
-	CountSIPFilesExpectations(s, params)
+	countSIPFilesExpectations(s, params)
 	expectations["saveFileCount"](s, params)
 	expectations["bundle"](s, params)
 
@@ -1085,5 +1115,179 @@ func (s *ProcessingWorkflowTestSuite) TestBatchSignalDoNotContinue() {
 		SIPUUID:         sipUUID,
 		SIPName:         sipName,
 		BatchUUID:       batchUUID,
+	}, nil, true)
+}
+
+// TestDuplicateSIP tests:
+// - Archivematica as preservation system.
+// - The "create AIP" workflow type.
+// - Content error due to SIP being a duplicate.
+// - Move to failed SIP.
+// - Watched bucket download.
+func (s *ProcessingWorkflowTestSuite) TestDuplicateSIP() {
+	duplicateSIPID := uuid.New()
+	s.SetupWorkflowTest(config.Configuration{
+		AM:           am.Config{ZipPIP: true},
+		Preservation: pres.Config{TaskQueue: temporal.AmWorkerTaskQueue},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: amssLocationID}},
+	}, nil)
+
+	params := defaultParams()
+	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+
+	params.updateTaskParams(
+		duplicateSIPTaskID,
+		enums.TaskStatusInProgress,
+		"Check if SIP has already been ingested",
+		"",
+	)
+	expectations["createTask"](s, params)
+
+	// Fail the workflow on duplicate SIP.
+	s.env.OnActivity(
+		activities.CheckDuplicateSIPActivityName,
+		sessionCtx,
+		activities.CheckDuplicateSIPActivityParams{
+			SIPID: sipUUID,
+			Checksum: datatypes.Checksum{
+				Algorithm: datatypes.ChecksumAlgoSHA256,
+				Hash:      "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+			},
+		},
+	).Return(
+		&activities.CheckDuplicateSIPActivityResult{
+			Duplicate: &datatypes.SIP{
+				UUID:   duplicateSIPID,
+				Name:   "existing_sip.zip",
+				Status: enums.SIPStatusIngested,
+			},
+		},
+		nil,
+	)
+
+	params.updateTaskParams(
+		duplicateSIPTaskID,
+		enums.TaskStatusFailed,
+		"",
+		fmt.Sprintf(
+			"Content error: SIP has already been ingested.\n\nA previously ingested SIP (UUID: %s) has the same checksum as the current SIP. Please ensure you have submitted the correct SIP and that it has not been previously submitted.",
+			duplicateSIPID,
+		),
+	)
+	expectations["completeTask"](s, params)
+
+	params.sipStatus = enums.SIPStatusFailed
+	params.failedAs = enums.SIPFailedAsSIP
+	params.failedKey = failedSIPKey
+	params.removePaths = []string{tempPath}
+	expectations["uploadToFailed"](s, params)
+	expectations["removePaths"](s, params)
+	expectations["updateSIPFailed"](s, params)
+	expectations["completeWorkflow"](s, params)
+
+	s.ExecuteAndValidateWorkflow(&ingest.ProcessingWorkflowRequest{
+		Key:         key,
+		WatcherName: watcherName,
+		Type:        enums.WorkflowTypeCreateAip,
+		SIPUUID:     sipUUID,
+		SIPName:     sipName,
+	}, nil, true)
+}
+
+// TestAllowDuplicateSIP tests:
+// - a3m as preservation system.
+// - The "create AIP" workflow type.
+// - Don't check for duplicate SIPs (config override).
+// - Watched bucket download.
+// - Watched bucket negative retention period.
+func (s *ProcessingWorkflowTestSuite) TestAllowDuplicateSIP() {
+	s.SetupWorkflowTest(config.Configuration{
+		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
+		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
+		Ingest: ingest.Config{
+			AllowDuplicates: true,
+			Storage:         ingest.StorageConfig{DefaultPermanentLocationID: locationID},
+		},
+	}, nil)
+
+	params := defaultParams()
+	downloadExpectations(s, params)
+	calcChecksumExpectations(s, params)
+	expectations["archiveExtract"](s, params)
+	expectations["classifySIP"](s, params)
+	countSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
+	autoApproveA3mExpectations(s, params)
+	params.retentionPeriod = -1 * time.Second
+	cleanupExpectations(s, params)
+
+	s.ExecuteAndValidateWorkflow(&ingest.ProcessingWorkflowRequest{
+		Key:             key,
+		WatcherName:     watcherName,
+		RetentionPeriod: params.retentionPeriod,
+		Type:            enums.WorkflowTypeCreateAip,
+		SIPUUID:         sipUUID,
+		SIPName:         sipName,
+	}, &ingest.ProcessingWorkflowResult{}, false)
+}
+
+// TestCalculateSIPChecksumSysError tests:
+// - Archivematica as preservation system.
+// - The "create AIP" workflow type.
+// - System error calculating checksum.
+// - Move to failed SIP.
+// - Watched bucket download.
+func (s *ProcessingWorkflowTestSuite) TestCalculateSIPChecksumSysError() {
+	s.SetupWorkflowTest(config.Configuration{
+		AM:           am.Config{ZipPIP: true},
+		Preservation: pres.Config{TaskQueue: temporal.AmWorkerTaskQueue},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: amssLocationID}},
+	}, nil)
+
+	params := defaultParams()
+	downloadExpectations(s, params)
+
+	params.updateTaskParams(
+		calcChecksumTaskID,
+		enums.TaskStatusInProgress,
+		"Calculate SIP checksum",
+		"",
+	)
+	expectations["createTask"](s, params)
+
+	// Return error from CalcFileChecksumActivity.
+	s.env.OnActivity(
+		activities.CalcFileChecksumActivityName,
+		sessionCtx,
+		&activities.CalcFileChecksumActivityParams{Path: params.downloadPath},
+	).Return(
+		nil,
+		errors.New("checksum error"),
+	)
+
+	params.updateTaskParams(
+		calcChecksumTaskID,
+		enums.TaskStatusError,
+		"",
+		"System error: Calculating SIP checksum failed.\n\nAn error has occurred while calculating the SIP checksum. Please try again, or ask a system administrator to investigate.",
+	)
+	expectations["completeTask"](s, params)
+
+	params.sipStatus = enums.SIPStatusError
+	params.failedAs = enums.SIPFailedAsSIP
+	params.failedKey = failedSIPKey
+	params.removePaths = []string{tempPath}
+	expectations["uploadToFailed"](s, params)
+	expectations["removePaths"](s, params)
+	expectations["updateSIPFailed"](s, params)
+	expectations["completeWorkflow"](s, params)
+
+	s.ExecuteAndValidateWorkflow(&ingest.ProcessingWorkflowRequest{
+		Key:         key,
+		WatcherName: watcherName,
+		Type:        enums.WorkflowTypeCreateAip,
+		SIPUUID:     sipUUID,
+		SIPName:     sipName,
 	}, nil, true)
 }

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -7,6 +7,7 @@ import (
 	temporalsdk_log "go.temporal.io/sdk/log"
 	temporalsdk_workflow "go.temporal.io/sdk/workflow"
 
+	"github.com/artefactual-sdps/enduro/internal/datatypes"
 	"github.com/artefactual-sdps/enduro/internal/enums"
 	"github.com/artefactual-sdps/enduro/internal/ingest"
 	"github.com/artefactual-sdps/enduro/pkg/childwf"
@@ -116,6 +117,9 @@ type sipInfo struct {
 	// fileCount is the number of preservation files in the SIP. It is populated
 	// by the CountSIPFilesActivity after preprocessing.
 	fileCount int32
+
+	// checksum is the SIP checksum calculated by CalcSIPChecksumActivity.
+	checksum datatypes.Checksum
 }
 
 // aipInfo represents the AIP.


### PR DESCRIPTION
Fixes #1617.

Check that the checksum of a newly submitted SIP does doesn't match a previously ingested SIP to prevent duplicate submissions.  A previously submitted SIP that has failed or has been cancelled may be resubmitted successfully, but if a duplicate SIP has a status of pending, queued, processing, or validated it will trigger the duplicate SIP error.

SIPs that are submitted as a directory will not be checked for duplicate contents.

The duplicate checker can be disabled by setting the `ingest.allowDuplicates` configuration to `true`.