### PR TITLE
Pass user email to child workflows

### DIFF
--- a/internal/ingest/goa.go
+++ b/internal/ingest/goa.go
@@ -94,6 +94,7 @@ func (svc *ingestImpl) AddSip(ctx context.Context, payload *goaingest.AddSipPayl
 
 	// Initialize the processing workflow.
 	req := ProcessingWorkflowRequest{
+		User:            childWorkflowUserFromClaims(claims),
 		SIPUUID:         s.UUID,
 		SIPSourceID:     sourceID,
 		SIPName:         s.Name,

--- a/internal/ingest/goa_batch.go
+++ b/internal/ingest/goa_batch.go
@@ -64,6 +64,7 @@ func (svc *ingestImpl) AddBatch(
 	}
 
 	req := BatchWorkflowRequest{
+		User:            childWorkflowUserFromClaims(claims),
 		Batch:           *b,
 		SIPSourceID:     sourceID,
 		Keys:            payload.Keys,

--- a/internal/ingest/goa_batch_test.go
+++ b/internal/ingest/goa_batch_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/persistence"
 	persistence_fake "github.com/artefactual-sdps/enduro/internal/persistence/fake"
 	"github.com/artefactual-sdps/enduro/internal/timerange"
+	"github.com/artefactual-sdps/enduro/pkg/childwf"
 )
 
 func TestAddBatch(t *testing.T) {
@@ -185,6 +186,7 @@ func TestAddBatch(t *testing.T) {
 					},
 					ingest.BatchWorkflowName,
 					&ingest.BatchWorkflowRequest{
+						User:        &childwf.User{Email: "nobody@example.com"},
 						Batch:       *batchWithUploader,
 						SIPSourceID: sourceID,
 						Keys:        keys,

--- a/internal/ingest/goa_test.go
+++ b/internal/ingest/goa_test.go
@@ -785,6 +785,7 @@ func TestAddSIP(t *testing.T) {
 					},
 					ingest.ProcessingWorkflowName,
 					&ingest.ProcessingWorkflowRequest{
+						User:        &childwf.User{Email: "nobody@example.com"},
 						SIPUUID:     sipUUID,
 						SIPSourceID: sourceID,
 						SIPName:     key,

--- a/internal/ingest/upload.go
+++ b/internal/ingest/upload.go
@@ -132,6 +132,7 @@ func (svc *ingestImpl) initSIP(
 	}
 
 	req := ProcessingWorkflowRequest{
+		User:            childWorkflowUserFromClaims(claims),
 		SIPUUID:         id,
 		SIPName:         name,
 		Type:            wType,

--- a/internal/ingest/upload_test.go
+++ b/internal/ingest/upload_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/artefactual-sdps/enduro/internal/enums"
 	"github.com/artefactual-sdps/enduro/internal/ingest"
 	persistence_fake "github.com/artefactual-sdps/enduro/internal/persistence/fake"
+	"github.com/artefactual-sdps/enduro/pkg/childwf"
 )
 
 const txtMultipartBody = `Content-Type: multipart/form-data; boundary="foobar"
@@ -218,6 +219,7 @@ func TestUpload(t *testing.T) {
 					},
 					ingest.ProcessingWorkflowName,
 					&ingest.ProcessingWorkflowRequest{
+						User:      &childwf.User{Email: "nobody@example.com"},
 						SIPUUID:   uuid0,
 						SIPName:   "first.zip",
 						Type:      enums.WorkflowTypeCreateAip,

--- a/internal/ingest/workflows.go
+++ b/internal/ingest/workflows.go
@@ -9,6 +9,7 @@ import (
 	temporalsdk_api_enums "go.temporal.io/api/enums/v1"
 	temporalsdk_client "go.temporal.io/sdk/client"
 
+	"github.com/artefactual-sdps/enduro/internal/api/auth"
 	"github.com/artefactual-sdps/enduro/internal/datatypes"
 	"github.com/artefactual-sdps/enduro/internal/enums"
 	"github.com/artefactual-sdps/enduro/pkg/childwf"
@@ -49,6 +50,10 @@ type (
 	}
 
 	BatchWorkflowRequest struct {
+		// User contains non-sensitive information about the user who initiated
+		// the workflow, when available.
+		User *childwf.User
+
 		// Batch contains the Batch details.
 		Batch datatypes.Batch
 
@@ -64,6 +69,10 @@ type (
 	}
 
 	ProcessingWorkflowRequest struct {
+		// User contains non-sensitive information about the user who initiated
+		// the workflow, when available.
+		User *childwf.User
+
 		// SIPUUID is the unique identifier of the SIP.
 		SIPUUID uuid.UUID
 
@@ -153,4 +162,12 @@ func InitProcessingWorkflow(
 
 func BatchWorkflowID(batchID uuid.UUID) string {
 	return fmt.Sprintf("%s-%s", BatchWorkflowName, batchID)
+}
+
+func childWorkflowUserFromClaims(claims *auth.Claims) *childwf.User {
+	if claims == nil || claims.Email == "" {
+		return nil
+	}
+
+	return &childwf.User{Email: claims.Email}
 }

--- a/internal/ingest/workflows_test.go
+++ b/internal/ingest/workflows_test.go
@@ -1,0 +1,44 @@
+package ingest
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/enduro/internal/api/auth"
+	"github.com/artefactual-sdps/enduro/pkg/childwf"
+)
+
+func TestChildWorkflowUserFromClaims(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name   string
+		claims *auth.Claims
+		want   *childwf.User
+	}{
+		{
+			name: "Returns nil without claims",
+		},
+		{
+			name:   "Returns nil without email",
+			claims: &auth.Claims{Iss: "issuer", Sub: "subject"},
+		},
+		{
+			name: "Returns email only",
+			claims: &auth.Claims{
+				Email: "nobody@example.com",
+				Name:  "Test User",
+				Iss:   "issuer",
+				Sub:   "subject",
+			},
+			want: &childwf.User{Email: "nobody@example.com"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.DeepEqual(t, childWorkflowUserFromClaims(tt.claims), tt.want)
+		})
+	}
+}

--- a/internal/workflow/batch.go
+++ b/internal/workflow/batch.go
@@ -246,6 +246,7 @@ func (w *BatchWorkflow) startSIPWorkflow(
 		processingCtx,
 		ingest.ProcessingWorkflowName,
 		&ingest.ProcessingWorkflowRequest{
+			User:            state.user,
 			SIPUUID:         sipUUID,
 			SIPName:         key,
 			Key:             key,

--- a/internal/workflow/batch_state.go
+++ b/internal/workflow/batch_state.go
@@ -19,6 +19,10 @@ type batchWorkflowState struct {
 	// batch represents the batch being processed.
 	batch datatypes.Batch
 
+	// user contains non-sensitive information about the user who initiated the
+	// batch, when available.
+	user *childwf.User
+
 	// sipDetails contains details for each SIP in the batch.
 	sipDetails []*sipDetails
 
@@ -51,12 +55,14 @@ func newBatchWorkflowState(ctx temporalsdk_workflow.Context, req *ingest.BatchWo
 	return &batchWorkflowState{
 		logger:     temporalsdk_workflow.GetLogger(ctx),
 		batch:      req.Batch,
+		user:       req.User,
 		sipDetails: make([]*sipDetails, len(req.Keys)),
 	}
 }
 
 func (s *batchWorkflowState) PostbatchParams() *childwf.PostbatchParams {
 	return &childwf.PostbatchParams{
+		User: s.user,
 		Batch: &childwf.PostbatchBatch{
 			UUID:       s.batch.UUID,
 			Identifier: s.batch.Identifier,

--- a/internal/workflow/batch_test.go
+++ b/internal/workflow/batch_test.go
@@ -155,7 +155,9 @@ func TestBatchWorkflow(t *testing.T) {
 // - Wait for all child workflows to complete.
 // - Update batch status (ingested).
 // - Run postbatch child workflow.
+// - Propagate user context to child workflows.
 func (s *BatchWorkflowTestSuite) TestBatch() {
+	user := &childwf.User{Email: "nobody@example.com"}
 	cfg := config.Configuration{
 		ChildWorkflows: config.ChildWorkflowConfigs{
 			{
@@ -277,6 +279,7 @@ func (s *BatchWorkflowTestSuite) TestBatch() {
 		postBatchChildWorkflow,
 		internalCtx,
 		&childwf.PostbatchParams{
+			User: user,
 			Batch: &childwf.PostbatchBatch{
 				UUID:       batchUUID,
 				Identifier: batchIdentifier,
@@ -326,6 +329,7 @@ func (s *BatchWorkflowTestSuite) TestBatch() {
 
 	s.ExecuteAndValidateWorkflow(
 		&ingest.BatchWorkflowRequest{
+			User: user,
 			Batch: datatypes.Batch{
 				UUID:       batchUUID,
 				Identifier: batchIdentifier,
@@ -338,6 +342,7 @@ func (s *BatchWorkflowTestSuite) TestBatch() {
 		},
 		[]ingest.ProcessingWorkflowRequest{
 			{
+				User:            user,
 				SIPUUID:         batchSIP1UUID,
 				SIPName:         batchSIP1Key,
 				Key:             batchSIP1Key,
@@ -347,6 +352,7 @@ func (s *BatchWorkflowTestSuite) TestBatch() {
 				BatchUUID:       batchUUID,
 			},
 			{
+				User:            user,
 				SIPUUID:         batchSIP2UUID,
 				SIPName:         batchSIP2Key,
 				Key:             batchSIP2Key,

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -1120,6 +1120,7 @@ func (w *ProcessingWorkflow) preprocessing(ctx temporalsdk_workflow.Context, sta
 		preCtx,
 		cfg.WorkflowName,
 		childwf.PreprocessingParams{
+			User:         state.req.User,
 			RelativePath: relPath,
 			SIPID:        state.sip.uuid,
 			BatchID:      state.req.BatchUUID,
@@ -1387,6 +1388,7 @@ func (w *ProcessingWorkflow) poststorage(ctx temporalsdk_workflow.Context, state
 		ctx,
 		cfg.WorkflowName,
 		childwf.PostStorageParams{
+			User:           state.req.User,
 			AIPUUID:        state.aip.id,
 			CustomMetadata: state.customMetadata,
 		},

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -306,10 +306,12 @@ func (s *ProcessingWorkflowTestSuite) TestAMWorkflow() {
 // - preprocessing child workflow.
 // - custom metadata from preprocessing to poststorage.
 // - poststorage child workflows.
+// - user context propagation to child workflows.
 // - Bag validation.
 // - Watched bucket download.
 // - Watched bucket custom retention period.
 func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
+	user := &childwf.User{Email: "nobody@example.com"}
 	s.SetupWorkflowTest(config.Configuration{
 		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
 		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
@@ -352,6 +354,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 		"preprocessing",
 		internalCtx,
 		&childwf.PreprocessingParams{
+			User:         user,
 			RelativePath: strings.TrimPrefix(prepDownloadPath+"/"+key, prepSharedPath),
 			SIPID:        sipUUID,
 			SIPName:      sipName,
@@ -408,6 +411,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 		"poststorage",
 		internalCtx,
 		&childwf.PostStorageParams{
+			User:           user,
 			AIPUUID:        aipUUID.String(),
 			CustomMetadata: preprocessingMetadata,
 		},
@@ -452,6 +456,7 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 	cleanupExpectations(s, params)
 
 	s.ExecuteAndValidateWorkflow(&ingest.ProcessingWorkflowRequest{
+		User:            user,
 		Key:             key,
 		WatcherName:     watcherName,
 		RetentionPeriod: params.retentionPeriod,

--- a/pkg/childwf/childwf.go
+++ b/pkg/childwf/childwf.go
@@ -18,3 +18,8 @@ const (
 
 // CustomMetadata is opaque JSON metadata carried between child workflows.
 type CustomMetadata map[string]json.RawMessage
+
+// User carries non-sensitive user information to child workflows.
+type User struct {
+	Email string
+}

--- a/pkg/childwf/postbatch.go
+++ b/pkg/childwf/postbatch.go
@@ -3,6 +3,10 @@ package childwf
 import "github.com/google/uuid"
 
 type PostbatchParams struct {
+	// User contains non-sensitive information about the user who initiated the
+	// workflow, when available.
+	User *User
+
 	// Batch represents data general to the whole batch.
 	Batch *PostbatchBatch
 

--- a/pkg/childwf/poststorage.go
+++ b/pkg/childwf/poststorage.go
@@ -3,6 +3,10 @@ package childwf
 import "time"
 
 type PostStorageParams struct {
+	// User contains non-sensitive information about the user who initiated the
+	// workflow, when available.
+	User *User
+
 	AIPUUID string
 
 	// CustomMetadata is opaque metadata returned by earlier child workflows.

--- a/pkg/childwf/preprocessing.go
+++ b/pkg/childwf/preprocessing.go
@@ -7,6 +7,10 @@ import (
 )
 
 type PreprocessingParams struct {
+	// User contains non-sensitive information about the user who initiated the
+	// workflow, when available.
+	User *User
+
 	// Relative path to the shared path.
 	RelativePath string
 


### PR DESCRIPTION
Add a user value with only email to child workflow request types. Populate it from auth claims when authentication is enabled and users start ingest from the API upload or a SIP source.

Refs #1666.