### PR TITLE
Document, fix and enable filesystem watchers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,8 @@ RUN ["mkdir", "-m", "700", "-p", \
     "/home/enduro/internal-storage/ingest", \
     "/home/enduro/internal-storage/storage", \
     "/home/enduro/internal-storage/sip-source", \
+    "/home/enduro/internal-storage/watched", \
+    "/home/enduro/internal-storage/watched-complete", \
     "/home/enduro/internal-storage/perma-aips"]
 
 FROM base AS enduro

--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -256,6 +256,14 @@ func main() {
 			activities.NewDownloadActivity(tp.Tracer(activities.DownloadActivityName), wsvc).Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.DownloadActivityName},
 		)
+		w.RegisterActivityWithOptions(
+			activities.NewDeleteOriginalActivity(wsvc).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			activities.NewDisposeOriginalActivity(wsvc).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.DisposeOriginalActivityName},
+		)
 		// TODO: At some point there may be multiple SIP sources, this activity should
 		// work similar to the watched bucket download activity and use the source ID
 		// to determine which bucket to use. Alternatively, we could register multiple
@@ -265,8 +273,16 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: activities.DownloadFromSIPSourceActivityName},
 		)
 		w.RegisterActivityWithOptions(
+			bucketdelete.New(sipSource.Bucket).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalFromSIPSourceActivityName},
+		)
+		w.RegisterActivityWithOptions(
 			bucketdownload.New(internalStorage).Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.DownloadFromInternalBucketActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			bucketdelete.New(internalStorage).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalFromInternalBucketActivityName},
 		)
 		w.RegisterActivityWithOptions(
 			activities.NewGetSIPExtensionActivity().Execute,

--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -247,6 +247,14 @@ func main() {
 			activities.NewDownloadActivity(tp.Tracer(activities.DownloadActivityName), wsvc).Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.DownloadActivityName},
 		)
+		w.RegisterActivityWithOptions(
+			activities.NewDeleteOriginalActivity(wsvc).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			activities.NewDisposeOriginalActivity(wsvc).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.DisposeOriginalActivityName},
+		)
 		// TODO: At some point there may be multiple SIP sources, this activity should
 		// work similar to the watched bucket download activity and use the source ID
 		// to determine which bucket to use. Alternatively, we could register multiple
@@ -256,8 +264,16 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: activities.DownloadFromSIPSourceActivityName},
 		)
 		w.RegisterActivityWithOptions(
+			bucketdelete.New(sipSource.Bucket).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalFromSIPSourceActivityName},
+		)
+		w.RegisterActivityWithOptions(
 			bucketdownload.New(internalStorage).Execute,
 			temporalsdk_activity.RegisterOptions{Name: activities.DownloadFromInternalBucketActivityName},
+		)
+		w.RegisterActivityWithOptions(
+			bucketdelete.New(internalStorage).Execute,
+			temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalFromInternalBucketActivityName},
 		)
 		w.RegisterActivityWithOptions(
 			activities.NewGetSIPExtensionActivity().Execute,

--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -16,7 +16,6 @@ import (
 
 	"ariga.io/sqlcomment"
 	"entgo.io/ent/dialect/sql"
-	"github.com/artefactual-sdps/temporal-activities/bucketdelete"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/jonboulle/clockwork"
@@ -515,26 +514,6 @@ func main() {
 				wsvc,
 			).Execute,
 			temporalsdk_workflow.RegisterOptions{Name: ingest.ProcessingWorkflowName},
-		)
-		w.RegisterActivityWithOptions(
-			activities.NewDeleteOriginalActivity(wsvc).Execute,
-			temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalActivityName},
-		)
-		// TODO: At some point there may be multiple SIP sources, this activity should
-		// work similar to the watched bucket delete original activity and use the
-		// source ID to determine which bucket to use. Alternatively, we could register
-		// multiple copies of this activity, one per source.
-		w.RegisterActivityWithOptions(
-			bucketdelete.New(sipSource.Bucket).Execute,
-			temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalFromSIPSourceActivityName},
-		)
-		w.RegisterActivityWithOptions(
-			bucketdelete.New(internalStorage).Execute,
-			temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalFromInternalBucketActivityName},
-		)
-		w.RegisterActivityWithOptions(
-			activities.NewDisposeOriginalActivity(wsvc).Execute,
-			temporalsdk_activity.RegisterOptions{Name: activities.DisposeOriginalActivityName},
 		)
 
 		// Ingest batch workflow and activities.

--- a/docs/src/admin-manual/configuration.md
+++ b/docs/src/admin-manual/configuration.md
@@ -480,28 +480,82 @@ xsdPath = "/home/enduro/premis.xsd"
 ### Watched location configuration
 
 These configuration settings, when enabled, allow Enduro to initiate SIP ingest
-from a watched location. The current Redis-backed object-store watcher consumes
-the MinIO Redis notification event format. This watcher is still available for
-existing deployments with MinIO-compatible event publishers, but the development
-environment no longer deploys MinIO and the default configuration leaves this
-section commented out. Enduro does not currently support Azure Blob Storage or
-generic S3-compatible buckets as watched locations.
+from a watched location. Enduro supports two watched-location implementations:
 
-Once this section is enabled, the chosen watched location must publish an event
-to Enduro's message queue (in this case, [Redis], listening for events in the
-queue defined by the `redisList` parameter below) any time a new zipped package
-is added to the watched location. Enduro's internal watcher will watch for new
-deposit events at the configured `redisAddress` and queue, and will trigger the
-ingest workflow when it detects a SIP deposit in the configured watched
-location. For more information on ingests from a watched location, see:
+* Filesystem watchers monitor a local directory for new files or directories.
+  They do not use a message queue.
+* Legacy object-store watchers consume MinIO Redis notification events. This
+  path is still available for deployments with MinIO-compatible event
+  publishers.
+
+For filesystem watchers, make the deposit appear at its final name only after it
+is complete. The watcher reacts to top-level create or rename events; it does
+not wait for a file copy or directory tree copy to become stable. Copy or build
+the package in a staging location outside the watched path, then move or rename
+the completed file or directory into the watched path. If staging inside the
+watched path is required, configure `ignore` to match the temporary name, then
+rename the completed deposit to an unignored final name. The process running the
+watcher must be able to read the watched path and must have permission to delete
+or move deposits if retention or `completedDir` cleanup is enabled.
+
+For legacy object-store watchers, the watched location must publish an event to
+Enduro's message queue ([Redis], listening for events in the queue defined by
+the `redisList` parameter below) any time a new zipped package is added.
+Enduro's internal watcher will trigger the ingest workflow when it detects a SIP
+deposit in the configured watched location. Enduro does not currently support
+Azure Blob Storage or generic S3-compatible buckets as event-driven watched
+locations. For more information on ingests from a watched location, see:
 
 * [Initiate ingest via a watched location upload][watched-location]
 
-At this time, [Redis] is the only supported messaging queue - as such, the
-`redisAddress` and `redisList` fields are required.
+#### Filesystem watcher
 
-All other default parameters are MinIO bucket access settings and might not be
-needed for other watched location types.
+Use a repeated `[[watcher.filesystem]]` table for each filesystem watched
+location.
+
+**Example configuration**:
+
+```toml
+[[watcher.filesystem]]
+name = "filesystem-dropbox"
+path = "/home/enduro/watched"
+ignore = "^\\."
+inotify = false
+pollInterval = "200ms"
+retentionPeriod = "-1s"
+completedDir = "/home/enduro/watched-complete"
+workflowType = "create aip"
+```
+
+* `name`: Defines a name to be used internally for the watched location.
+  This must be unique across all configured watchers.
+* `path`: Filesystem directory that Enduro watches for new deposits. The
+  directory must exist before Enduro starts.
+* `ignore`: Optional regular expression matched against the base name of a
+  created file or directory. Matching deposits are ignored. Use this when an
+  incomplete deposit must be staged inside the watched path under a temporary
+  name before being renamed to its final name.
+* `inotify`: Set to `true` to prefer filesystem event notifications on
+  platforms where they are available. The default `false` uses polling.
+* `pollInterval`: Time between filesystem polls when polling is used. The
+  default is `200ms`; use a string format compatible with [ParseDuration].
+* `retentionPeriod`: Duration to retain the original SIP before deleting it
+  after a successful ingest. Set to a negative value to disable automatic
+  deletion. Set to `"0"` to delete immediately. Use a string format compatible
+  with [ParseDuration].
+* `completedDir`: Directory where Enduro moves the original SIP after a
+  successful ingest. This setting can only be used when `retentionPeriod` is
+  negative.
+* `workflowType`: Specifies the name of the Enduro workflow type to be run when
+  SIPs are deposited in the watched location. Currently the only supported
+  values are "create aip" and "create and review aip". The latter review
+  workflow also only works if [a3m] is the configured [preservation engine].
+
+#### Legacy MinIO Redis watcher
+
+At this time, [Redis] is the only supported messaging queue for legacy
+object-store watchers, so `redisAddress` and `redisList` are required.
+All other default parameters are MinIO bucket access settings.
 
 **Example configuration**:
 

--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -283,6 +283,8 @@ folders used by different local workflows:
 - `ingest`: internal storage for the ingest domain.
 - `storage`: internal storage for the storage domain.
 - `sip-source`: filesystem-backed SIP source.
+- `watched`: filesystem watched location.
+- `watched-complete`: successfully ingested watched-location SIPs.
 - `perma-aips`: local permanent AIP storage.
 
 Use the `enduro` pod as an access point for copying, listing, and removing files
@@ -305,6 +307,38 @@ kubectl -n "$NAMESPACE" cp -c "$CONTAINER" ./sip.zip \
   "$POD:$INTERNAL_STORAGE/sip-source/sip.zip"
 ```
 
+Copy a single local file into the filesystem watched location under an ignored
+temporary name, then rename it when the copy is complete. The default watcher
+configuration ignores names ending in `.tmp`, so the watcher will not process
+the file until it has its final name:
+
+```bash
+kubectl -n "$NAMESPACE" cp -c "$CONTAINER" ./sip.zip \
+  "$POD:$INTERNAL_STORAGE/watched/sip.zip.tmp"
+
+kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
+  mv "$INTERNAL_STORAGE/watched/sip.zip.tmp" \
+    "$INTERNAL_STORAGE/watched/sip.zip"
+```
+
+Copy a full local directory ("./example-sip") into the filesystem watched
+location under an ignored temporary directory, then rename it when the copy is
+complete. Copy the SIP contents into the temporary directory so the final
+renamed directory is the SIP root:
+
+```bash
+kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
+  mkdir -p "$INTERNAL_STORAGE/watched/example-sip.tmp"
+
+tar -C ./example-sip -cf - . | \
+  kubectl -n "$NAMESPACE" exec -i "$POD" -c "$CONTAINER" -- \
+    tar -C "$INTERNAL_STORAGE/watched/example-sip.tmp" -xf -
+
+kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
+  mv "$INTERNAL_STORAGE/watched/example-sip.tmp" \
+    "$INTERNAL_STORAGE/watched/example-sip"
+```
+
 Copy the contents of a local directory into one of the internal folders without
 creating an extra parent directory in the volume:
 
@@ -322,6 +356,12 @@ kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
 
 kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
   ls -la "$INTERNAL_STORAGE/sip-source"
+
+kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
+  ls -la "$INTERNAL_STORAGE/watched"
+
+kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
+  ls -la "$INTERNAL_STORAGE/watched-complete"
 
 kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
   ls -la "$INTERNAL_STORAGE/perma-aips"
@@ -345,7 +385,16 @@ kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
   rm -f "$INTERNAL_STORAGE/sip-source/sip.zip"
 
 kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
-  rm -rf "$INTERNAL_STORAGE/sip-source/example-transfer"
+  rm -rf "$INTERNAL_STORAGE/sip-source/example-sip"
+```
+
+Clean the watcher completed directory. This removes every completed SIP from
+`watched-complete` while keeping the directory itself:
+
+```bash
+kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
+  find "$INTERNAL_STORAGE/watched-complete" -mindepth 1 -maxdepth 1 \
+    -exec rm -rf {} +
 ```
 
 [administrator configuration]: ../admin-manual/configuration.md

--- a/docs/src/user-manual/ingest/submitting-content.md
+++ b/docs/src/user-manual/ingest/submitting-content.md
@@ -175,26 +175,29 @@ The deposit or upload process will depend on the source location used.
 It is also possible to configure Enduro to use a watched location for ingest.
 The [watched location configuration] must be done by a system administrator.
 
-Once configured, any time a new zipped package is added to the location,
-Enduro's [messaging queue][mq] will see it and automatically initiate an ingest
-workflow.
+Once configured, any time a new package is added to the location, Enduro will
+automatically initiate an ingest workflow. Filesystem watched locations can
+detect files or directories that are moved into the watched path. The watcher
+reacts when the top-level file or directory appears; it does not wait for
+contents that are still being copied. Stage the SIP elsewhere, then move or
+rename the completed archive or full directory into the watched location.
 
-The legacy object-store watcher currently consumes MinIO Redis notification
-events. Existing deployments can continue using it with MinIO-compatible event
-publishers. Azure Blob Storage and generic S3-compatible buckets are not
-supported as watched locations; use direct upload or SIP source locations for
-those sources.
+The legacy object-store watcher consumes MinIO Redis notification events for
+zipped packages. Existing deployments can continue using it with
+MinIO-compatible event publishers. Azure Blob Storage and generic S3-compatible
+buckets are not supported as watched locations; use direct upload or SIP source
+locations for those sources.
 
 !!! note
 
-    Packages **must** be zipped to be properly ingested into Enduro.
+    Legacy object-store watched-location packages **must** be zipped. Filesystem
+    watched locations may submit either a SIP archive file or a directory.
 
 [a3m]: https://github.com/artefactual-labs/a3m
 [Archivematica]: https://archivematica.org
 [BagIt]: https://tools.ietf.org/html/rfc8493
 [SIP source configuration]: ../../admin-manual/configuration.md#sip-source-location-configuration
 [watched location configuration]: ../../admin-manual/configuration.md#watched-location-configuration
-[mq]: ../components.md#messaging-queue
 [source location]: ../glossary.md#source-location
 [Unzipped and zipped bags]: https://www.archivematica.org/docs/latest/user-manual/transfer/bags/#bags
 [configure a SIP upload size limit]: ../../admin-manual/configuration.md#user-interface-sip-upload-filesize-limit

--- a/enduro.toml
+++ b/enduro.toml
@@ -157,6 +157,34 @@ fileMode = "0o600"
 enabled = true
 xsdPath = "/home/enduro/premis.xsd"
 
+# Filesystem watched locations ingest SIPs automatically when completed files
+# or directories are moved into the watched path.
+[[watcher.filesystem]]
+name = "filesystem-watched-location"
+path = "/home/enduro/internal-storage/watched"
+# ignore is an optional regular expression matched against the deposited file
+# or directory name. Dot-prefixed names and temporary staging names ending in
+# ".tmp" are ignored.
+ignore = "(^\\.)|(\\.tmp$)"
+# Set inotify to true to prefer filesystem event notifications where
+# available. When false, Enduro uses polling.
+inotify = false
+pollInterval = "200ms"
+# retentionPeriod is the duration to retain SIPs before they are deleted after
+# a successful ingest. Set to a negative value to disable automatic deletion.
+# Set to "0" (default) to delete SIPs immediately after they have been
+# ingested. It must be a string format compatible with
+# https://pkg.go.dev/time#ParseDuration.
+retentionPeriod = "-1s"
+# completedDir moves successfully ingested SIPs instead of deleting them.
+# It can only be used when retentionPeriod is negative.
+completedDir = "/home/enduro/internal-storage/watched-complete"
+# workflowType is the processing workflow type related to this watcher.
+# Available workflow types are "create aip" and "create and review aip",
+# the later only works properly when the preservation system is "a3m".
+# Default: "create aip".
+workflowType = "create aip"
+
 # The legacy watched-location watcher consumes MinIO Redis notification events.
 # The development environment no longer deploys MinIO, so the example remains
 # here only as a reference for compatible deployments.

--- a/hack/kube/base/enduro.yaml
+++ b/hack/kube/base/enduro.yaml
@@ -28,6 +28,8 @@ spec:
                 /home/enduro/internal-storage/ingest \
                 /home/enduro/internal-storage/storage \
                 /home/enduro/internal-storage/sip-source \
+                /home/enduro/internal-storage/watched \
+                /home/enduro/internal-storage/watched-complete \
                 /home/enduro/internal-storage/perma-aips
               chown -R 1000:1000 /home/enduro/internal-storage
           volumeMounts:

--- a/hack/kube/overlays/dev-a3m/enduro-a3m.yaml
+++ b/hack/kube/overlays/dev-a3m/enduro-a3m.yaml
@@ -29,6 +29,8 @@ spec:
                 /home/enduro/internal-storage/ingest \
                 /home/enduro/internal-storage/storage \
                 /home/enduro/internal-storage/sip-source \
+                /home/enduro/internal-storage/watched \
+                /home/enduro/internal-storage/watched-complete \
                 /home/enduro/internal-storage/perma-aips
               chown -R 1000:1000 /home/enduro/internal-storage
           volumeMounts:

--- a/hack/kube/overlays/dev-am/enduro-am.yaml
+++ b/hack/kube/overlays/dev-am/enduro-am.yaml
@@ -29,6 +29,8 @@ spec:
                 /home/enduro/internal-storage/ingest \
                 /home/enduro/internal-storage/storage \
                 /home/enduro/internal-storage/sip-source \
+                /home/enduro/internal-storage/watched \
+                /home/enduro/internal-storage/watched-complete \
                 /home/enduro/internal-storage/perma-aips
               chown -R 1000:1000 /home/enduro/internal-storage
           volumeMounts:

--- a/internal/watcher/filesystem.go
+++ b/internal/watcher/filesystem.go
@@ -177,12 +177,10 @@ func (w *filesystemWatcher) Dispose(key string) error {
 	return fsutil.Move(src, dst)
 }
 
-// Download recursively copies the contents of key to dest. Key may be the name
-// of a directory or file.
+// Download copies key to dest. Key may be the name of a directory or file.
 func (w *filesystemWatcher) Download(ctx context.Context, dest, key string) error {
 	src := filepath.Clean(filepath.Join(w.path, key))
-	dest = filepath.Clean(filepath.Join(dest, key))
-	if err := cp.Copy(src, dest); err != nil {
+	if err := cp.Copy(src, filepath.Clean(dest)); err != nil {
 		return fmt.Errorf("filesystem watcher: download: %v", err)
 	}
 

--- a/internal/watcher/filesystem_test.go
+++ b/internal/watcher/filesystem_test.go
@@ -163,6 +163,35 @@ func TestFileSystemWatcher(t *testing.T) {
 		)))
 	})
 
+	t.Run("Download copies a file to the destination path", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+
+		src := fs.NewDir(t, "enduro-test-fswatcher",
+			fs.WithFile("sip.zip", "A test file."),
+		)
+		dest := fs.NewDir(t, "enduro-test-fswatcher")
+
+		w, err := watcher.NewFilesystemWatcher(ctx, &watcher.FilesystemConfig{
+			Name: "filesystem",
+			Path: src.Path(),
+		})
+		assert.NilError(t, err)
+
+		destPath := filepath.Join(dest.Path(), "sip.zip")
+		err = w.Download(context.Background(), destPath, "sip.zip")
+		assert.NilError(t, err)
+
+		info, err := os.Stat(destPath)
+		assert.NilError(t, err)
+		assert.Assert(t, !info.IsDir())
+
+		got, err := os.ReadFile(destPath)
+		assert.NilError(t, err)
+		assert.Equal(t, string(got), "A test file.")
+	})
+
 	t.Run("Download copies a directory", func(t *testing.T) {
 		t.Parallel()
 
@@ -183,7 +212,7 @@ func TestFileSystemWatcher(t *testing.T) {
 		})
 		assert.NilError(t, err)
 
-		err = w.Download(context.Background(), dest.Path(), "transfer")
+		err = w.Download(context.Background(), filepath.Join(dest.Path(), "transfer"), "transfer")
 		assert.NilError(t, err)
 		assert.Assert(t, fs.Equal(dest.Path(), fs.Expected(t, fs.WithMode(0o700),
 			fs.WithDir("transfer", fs.WithMode(0o755),

--- a/internal/watcher/filesystem_test.go
+++ b/internal/watcher/filesystem_test.go
@@ -138,11 +138,13 @@ func TestFileSystemWatcher(t *testing.T) {
 		assert.Assert(t, fs.Equal(w.Path(), fs.Expected(t)))
 	})
 
-	t.Run("Dispose moves transfer to CompletedDir", func(t *testing.T) {
+	t.Run("Dispose moves SIP to CompletedDir", func(t *testing.T) {
 		t.Parallel()
 
 		src := fs.NewDir(t, "enduro-test-fswatcher",
-			fs.WithDir("transfer", fs.WithFile("test.txt", "A test file.")),
+			fs.WithDir("example-sip",
+				fs.WithDir("objects", fs.WithFile("test.txt", "A test file.")),
+			),
 		)
 		dest := fs.NewDir(t, "enduro-test-fswatcher")
 
@@ -156,10 +158,21 @@ func TestFileSystemWatcher(t *testing.T) {
 		})
 		assert.NilError(t, err)
 
-		err = w.Dispose("transfer")
+		srcPath := filepath.Join(w.Path(), "example-sip")
+		info, err := os.Stat(srcPath)
 		assert.NilError(t, err)
+		assert.Assert(t, info.IsDir())
+
+		err = w.Dispose("example-sip")
+		assert.NilError(t, err)
+
+		_, err = os.Stat(srcPath)
+		assert.Assert(t, os.IsNotExist(err))
+
 		assert.Assert(t, fs.Equal(dest.Path(), fs.Expected(t,
-			fs.WithDir("transfer", fs.WithFile("test.txt", "A test file.")),
+			fs.WithDir("example-sip",
+				fs.WithDir("objects", fs.WithFile("test.txt", "A test file.")),
+			),
 		)))
 	})
 
@@ -198,7 +211,7 @@ func TestFileSystemWatcher(t *testing.T) {
 		ctx := t.Context()
 
 		src := fs.NewDir(t, "enduro-test-fswatcher",
-			fs.WithDir("transfer",
+			fs.WithDir("example-sip",
 				fs.WithFile("test.txt", "A test file."),
 				fs.WithFile("test2", "Another test file."),
 			),
@@ -212,10 +225,10 @@ func TestFileSystemWatcher(t *testing.T) {
 		})
 		assert.NilError(t, err)
 
-		err = w.Download(context.Background(), filepath.Join(dest.Path(), "transfer"), "transfer")
+		err = w.Download(context.Background(), filepath.Join(dest.Path(), "example-sip"), "example-sip")
 		assert.NilError(t, err)
 		assert.Assert(t, fs.Equal(dest.Path(), fs.Expected(t, fs.WithMode(0o700),
-			fs.WithDir("transfer", fs.WithMode(0o755),
+			fs.WithDir("example-sip", fs.WithMode(0o755),
 				fs.WithFile("test.txt", "A test file.", fs.WithMode(0o644)),
 				fs.WithFile("test2", "Another test file.", fs.WithMode(0o644)),
 			),

--- a/internal/workflow/delete_original.go
+++ b/internal/workflow/delete_original.go
@@ -46,7 +46,7 @@ func (w *ProcessingWorkflow) deleteOriginalSIP(ctx temporalsdk_workflow.Context,
 	}
 
 	// Delete the original SIP based on its origin.
-	activityOpts := withActivityOptsForRequestOnQueue(ctx, w.cfg.Temporal.TaskQueue)
+	activityOpts := withActivityOptsForRequest(ctx)
 	if state.req.WatcherName != "" {
 		err = temporalsdk_workflow.ExecuteActivity(
 			activityOpts,

--- a/internal/workflow/policies.go
+++ b/internal/workflow/policies.go
@@ -42,25 +42,6 @@ func withActivityOptsForRequest(ctx temporalsdk_workflow.Context) temporalsdk_wo
 	})
 }
 
-// withActivityOptsForRequestOnQueue returns activity options for short-lived
-// requests but forces execution on a specific task queue.
-func withActivityOptsForRequestOnQueue(
-	ctx temporalsdk_workflow.Context,
-	taskQueue string,
-) temporalsdk_workflow.Context {
-	return temporalsdk_workflow.WithActivityOptions(ctx, temporalsdk_workflow.ActivityOptions{
-		StartToCloseTimeout:    time.Second * 10,
-		ScheduleToCloseTimeout: time.Minute * 5,
-		TaskQueue:              taskQueue,
-		RetryPolicy: &temporalsdk_temporal.RetryPolicy{
-			InitialInterval:    time.Second,
-			BackoffCoefficient: 2,
-			MaximumInterval:    time.Minute,
-			MaximumAttempts:    20,
-		},
-	})
-}
-
 // withActivityOptsForLocalAction returns a workflow context with activity
 // options suited for local activities like disk operations that should not
 // require a retry policy attached.

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -297,25 +297,6 @@ func (w *ProcessingWorkflow) Execute(
 		return &ingest.ProcessingWorkflowResult{}, nil
 	}
 
-	// Schedule deletion or disposal of the original SIP.
-	if req.RetentionPeriod >= 0 {
-		if err := w.deleteOriginalSIP(ctx, state); err != nil {
-			state.logger.Error("Failed to delete original SIP", "err", err.Error())
-		}
-	} else if req.CompletedDir != "" {
-		activityOpts := withActivityOptsForLocalAction(ctx)
-		err := temporalsdk_workflow.ExecuteActivity(
-			activityOpts,
-			activities.DisposeOriginalActivityName,
-			req.WatcherName,
-			req.CompletedDir,
-			req.Key,
-		).Get(activityOpts, nil)
-		if err != nil {
-			state.logger.Error("Failed to dispose original SIP", "err", err.Error())
-		}
-	}
-
 	state.logger.Info(
 		"Workflow completed successfully!",
 		"SIPUUID", state.sip.uuid,
@@ -579,6 +560,26 @@ func (w *ProcessingWorkflow) SessionHandler(
 
 	// Set status to done so it's considered in the session cleanup.
 	state.status = enums.WorkflowStatusDone
+
+	// Original SIP cleanup for filesystem-backed inputs must run in the
+	// session so it executes on the worker with access to the local path.
+	if state.req.RetentionPeriod >= 0 {
+		if err := w.deleteOriginalSIP(sessCtx, state); err != nil {
+			state.logger.Error("Failed to delete original SIP", "err", err.Error())
+		}
+	} else if state.req.CompletedDir != "" {
+		activityOpts := withActivityOptsForLocalAction(sessCtx)
+		err := temporalsdk_workflow.ExecuteActivity(
+			activityOpts,
+			activities.DisposeOriginalActivityName,
+			state.req.WatcherName,
+			state.req.CompletedDir,
+			state.req.Key,
+		).Get(activityOpts, nil)
+		if err != nil {
+			state.logger.Error("Failed to dispose original SIP", "err", err.Error())
+		}
+	}
 
 	return nil
 }

--- a/internal/workflow/processing_expectations_test.go
+++ b/internal/workflow/processing_expectations_test.go
@@ -45,11 +45,12 @@ const (
 	calcChecksumTaskID  = 109
 	duplicateSIPTaskID  = 110
 
-	sipName     = "name.zip"
-	key         = "transfer.zip"
-	watcherName = "watcher"
-	fileCount   = 5
-	sipChecksum = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+	sipName      = "name.zip"
+	key          = "transfer.zip"
+	watcherName  = "watcher"
+	fileCount    = 5
+	sipChecksum  = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+	completedDir = "/home/enduro/watched-complete"
 )
 
 var (
@@ -118,6 +119,9 @@ type expectationParams struct {
 
 	// Retention period for original SIP deletion.
 	retentionPeriod time.Duration
+
+	// Completed directory for original SIP disposal.
+	completedDir string
 }
 
 // defaultParams returns a new expectationParams instance with sensible defaults.
@@ -381,6 +385,15 @@ var expectations = map[string]expectationFunc{
 			key,
 		).Return(nil, nil)
 	},
+	"disposeOriginal": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
+		s.env.OnActivity(
+			activities.DisposeOriginalActivityName,
+			sessionCtx,
+			watcherName,
+			params.completedDir,
+			key,
+		).Return(nil, nil)
+	},
 	"validateBag": func(s *ProcessingWorkflowTestSuite, params expectationParams) {
 		s.env.OnActivity(
 			bagvalidate.Name,
@@ -560,6 +573,8 @@ func cleanupExpectations(s *ProcessingWorkflowTestSuite, params expectationParam
 		expectations["deleteOriginal"](s, params)
 		params.updateTaskParams(deleteSIPTaskID, enums.TaskStatusDone, "", "SIP successfully deleted")
 		expectations["completeTask"](s, params)
+	} else if params.completedDir != "" {
+		expectations["disposeOriginal"](s, params)
 	}
 	expectations["updateSIPIngested"](s, params)
 	expectations["completeWorkflow"](s, params)

--- a/internal/workflow/processing_setup_test.go
+++ b/internal/workflow/processing_setup_test.go
@@ -153,6 +153,10 @@ func (s *ProcessingWorkflowTestSuite) SetupWorkflowTest(
 		temporalsdk_activity.RegisterOptions{Name: activities.DeleteOriginalActivityName},
 	)
 	s.env.RegisterActivityWithOptions(
+		activities.NewDisposeOriginalActivity(wsvc).Execute,
+		temporalsdk_activity.RegisterOptions{Name: activities.DisposeOriginalActivityName},
+	)
+	s.env.RegisterActivityWithOptions(
 		archivezip.New().Execute,
 		temporalsdk_activity.RegisterOptions{Name: archivezip.Name},
 	)

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -185,6 +185,50 @@ func (s *ProcessingWorkflowTestSuite) TestAutoApprovedAIP() {
 	}, &ingest.ProcessingWorkflowResult{}, false)
 }
 
+// TestFilesystemWatcherDispose tests:
+// - a3m as preservation system.
+// - The "create AIP" workflow type.
+// - Filesystem watcher directory SIP download.
+// - Filesystem watcher completedDir disposal.
+func (s *ProcessingWorkflowTestSuite) TestFilesystemWatcherDispose() {
+	s.SetupWorkflowTest(config.Configuration{
+		A3m:          a3m.Config{ShareDir: s.CreateTransferDir()},
+		Preservation: pres.Config{TaskQueue: temporal.A3mWorkerTaskQueue},
+		Ingest:       ingest.Config{Storage: ingest.StorageConfig{DefaultPermanentLocationID: locationID}},
+	}, nil)
+
+	params := defaultParams()
+	params.downloadPath = filepath.Join(tempPath, "example-sip")
+	params.extractPath = params.downloadPath
+
+	expectations["createSIP"](s, params)
+	expectations["setStatusInProgress"](s, params)
+	expectations["createWorkflow"](s, params)
+	params.updateTaskParams(copySIPTaskID, enums.TaskStatusInProgress, "Copy SIP to workspace", "")
+	expectations["createTask"](s, params)
+	expectations["download"](s, params)
+	params.updateTaskParams(copySIPTaskID, enums.TaskStatusDone, "", "SIP successfully copied")
+	expectations["completeTask"](s, params)
+	expectations["classifySIP"](s, params)
+	countSIPFilesExpectations(s, params)
+	expectations["saveFileCount"](s, params)
+	autoApproveA3mExpectations(s, params)
+	params.retentionPeriod = -1 * time.Second
+	params.completedDir = completedDir
+	cleanupExpectations(s, params)
+
+	s.ExecuteAndValidateWorkflow(&ingest.ProcessingWorkflowRequest{
+		Key:             key,
+		WatcherName:     watcherName,
+		RetentionPeriod: params.retentionPeriod,
+		CompletedDir:    params.completedDir,
+		IsDir:           true,
+		Type:            enums.WorkflowTypeCreateAip,
+		SIPUUID:         sipUUID,
+		SIPName:         sipName,
+	}, &ingest.ProcessingWorkflowResult{}, false)
+}
+
 // TestAMWorkflow tests:
 // - Archivematica as preservation system.
 // - The "create AIP" workflow type.


### PR DESCRIPTION
**Document filesystem watchers and enable one in dev**

Document filesystem watcher settings and behaviour. Configure a
filesystem watched location in the dev environment. Create the watched
and completed directories in the Docker image and Kubernetes manifests.

**Fix filesystem watcher SIP downloads**

Make filesystem watcher downloads write to the destination path set
by the activity, where the key is already appended to the destination.

**Run SIP cleanup on preservation workers**

Move original SIP deletion and completed directory disposal into the
preservation session so filesystem-backed sources are handled by the
worker that has access to their local paths.

Register the cleanup activities on the AM and A3M preservation workers,
and remove the redundant registrations from the main Enduro workflow
worker. Update workflow and filesystem watcher tests to cover
completed directory disposal for SIPs.

Refs #1660.