### PR TITLE
Use `bucket.Attributes` to check if AIP exists

### DIFF
--- a/internal/storage/download_aip.go
+++ b/internal/storage/download_aip.go
@@ -28,19 +28,24 @@ func (s *serviceImpl) DownloadAipRequest(
 		return nil, goastorage.MakeNotValid(errors.New("AIP is not available for download"))
 	}
 
-	// Check if the failed AIP exists in the location bucket.
-	reader, err := s.AipReader(ctx, aip)
+	bucket, err := s.openAIPBucket(ctx, aip)
+	if err != nil {
+		s.logger.Error(fmt.Errorf("open AIP bucket: %v", err), "AIP UUID", aip.UUID)
+		return nil, goastorage.MakeInternalError(errors.New("error opening AIP storage location"))
+	}
+	defer bucket.Close()
+
+	_, err = bucket.Attributes(ctx, aip.UUID.String())
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			return nil, &goastorage.AIPNotFound{
 				UUID:    aip.UUID,
-				Message: "AIP file not found in the location bucket",
+				Message: "AIP not found",
 			}
 		} else {
-			return nil, goastorage.MakeInternalError(errors.New("error checking AIP file"))
+			return nil, goastorage.MakeInternalError(errors.New("error getting AIP attributes"))
 		}
 	}
-	reader.Close()
 
 	// Request a ticket.
 	ticket, err := s.ticketProvider.Request(ctx, nil)
@@ -97,7 +102,7 @@ func (s *serviceImpl) DownloadAip(
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			return nil, nil, &goastorage.AIPNotFound{
 				UUID:    aip.UUID,
-				Message: "AIP file not found in the location bucket",
+				Message: "AIP not found",
 			}
 		} else {
 			return nil, nil, goastorage.MakeInternalError(errors.New("error reading AIP file"))

--- a/internal/storage/service.go
+++ b/internal/storage/service.go
@@ -353,65 +353,42 @@ func (s *serviceImpl) UpdateAipLocationID(ctx context.Context, aipID, locationID
 	return nil
 }
 
-// aipLocation returns the bucket and the key of the given AIP.
-func (s *serviceImpl) aipLocation(ctx context.Context, a *goastorage.AIP) (Location, string, error) {
-	// AIP is still in the internal processing bucket.
-	if a.LocationUUID == nil || *a.LocationUUID == uuid.Nil {
-		return s.internal, a.ObjectKey.String(), nil
-	}
-
-	location, err := s.Location(ctx, *a.LocationUUID)
-	if err != nil {
-		return nil, "", err
-	}
-	return location, a.UUID.String(), nil
-}
-
 func (s *serviceImpl) DeleteAip(ctx context.Context, aipID uuid.UUID) error {
 	aip, err := s.ReadAip(ctx, aipID)
 	if err != nil {
 		return err
 	}
 
-	location, key, err := s.aipLocation(ctx, aip)
+	bucket, err := s.openAIPBucket(ctx, aip)
 	if err != nil {
-		return err
-	}
-
-	bucket, err := s.openBucket(ctx, location)
-	if err != nil {
-		return err
-	}
-
-	// If the location is the internal processing location, use the AIP prefix.
-	if location.UUID() == uuid.Nil {
-		bucket = blob.PrefixedBucket(bucket, AIPPrefix)
+		return fmt.Errorf("open AIP bucket: %v", err)
 	}
 	defer bucket.Close()
 
-	return bucket.Delete(ctx, key)
+	err = bucket.Delete(ctx, aip.UUID.String())
+	if err != nil {
+		return fmt.Errorf("delete AIP: %v", err)
+	}
+
+	return nil
 }
 
+// AipReader returns a blob.Reader for the AIP content.
+//
+// If the AIP is stored in the Archivematica Storage Service, reader does not
+// support ranged reads, and the AIP will be immediately downloaded. For other
+// storage types, the reader supports range reads and the AIP contents are
+// streamed from the source on read.
 func (s *serviceImpl) AipReader(ctx context.Context, a *goastorage.AIP) (*blob.Reader, error) {
-	location, key, err := s.aipLocation(ctx, a)
+	bucket, err := s.openAIPBucket(ctx, a)
 	if err != nil {
-		return nil, err
-	}
-
-	bucket, err := s.openBucket(ctx, location)
-	if err != nil {
-		return nil, err
-	}
-
-	// If the location is the internal processing location, use the AIP prefix.
-	if location.UUID() == uuid.Nil {
-		bucket = blob.PrefixedBucket(bucket, AIPPrefix)
+		return nil, fmt.Errorf("open AIP bucket: %w", err)
 	}
 	defer bucket.Close()
 
-	reader, err := bucket.NewReader(ctx, key, nil)
+	reader, err := bucket.NewReader(ctx, a.UUID.String(), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("new AIP reader: %w", err)
 	}
 
 	return reader, nil
@@ -433,12 +410,40 @@ func (s *serviceImpl) openBucket(ctx context.Context, location Location) (*blob.
 		return loc.OpenBucket(ctx)
 	}
 
-	config, ok := loc.config.Value.(*types.AMSSConfig)
-	if !ok {
-		return loc.OpenBucket(ctx)
+	if cfg, ok := loc.config.Value.(*types.AMSSConfig); ok {
+		return cfg.OpenBucketWithHTTPClient(ctx, s.amssHTTPClient)
 	}
 
-	return config.OpenBucketWithHTTPClient(ctx, s.amssHTTPClient)
+	return loc.OpenBucket(ctx)
+}
+
+// openAIPBucket returns the bucket where an AIP is stored.
+func (s *serviceImpl) openAIPBucket(ctx context.Context, aip *goastorage.AIP) (*blob.Bucket, error) {
+	if aip == nil {
+		return nil, errors.New("AIP is nil")
+	}
+
+	var locID uuid.UUID
+	if aip.LocationUUID != nil {
+		locID = *aip.LocationUUID
+	}
+
+	loc, err := s.Location(ctx, locID)
+	if err != nil {
+		return nil, fmt.Errorf("get AIP location: %w", err)
+	}
+
+	bucket, err := s.openBucket(ctx, loc)
+	if err != nil {
+		return nil, fmt.Errorf("open bucket: %w", err)
+	}
+
+	// If the location is the internal processing location, use the AIP prefix.
+	if loc.UUID() == uuid.Nil {
+		bucket = blob.PrefixedBucket(bucket, AIPPrefix)
+	}
+
+	return bucket, nil
 }
 
 func (s *serviceImpl) ListAipWorkflows(

--- a/internal/storage/service_test.go
+++ b/internal/storage/service_test.go
@@ -673,7 +673,7 @@ func TestServiceDeleteAip(t *testing.T) {
 
 		err := svc.DeleteAip(ctx, aipID)
 		assert.Error(t, err, fmt.Sprintf(
-			"blob (key %q) (code=NotFound): remove %s/%s: no such file or directory",
+			"delete AIP: blob (key %q) (code=NotFound): remove %s/%s: no such file or directory",
 			aipID.String(), td.Path(), aipID.String(),
 		))
 	})
@@ -837,7 +837,7 @@ func TestAipReader(t *testing.T) {
 			LocationUUID: &locationID,
 		})
 		assert.Error(t, err, fmt.Sprintf(
-			"blob (key %q) (code=NotFound): blob not found",
+			"new AIP reader: blob (key %q) (code=NotFound): blob not found",
 			aipID.String(),
 		))
 	})

--- a/internal/storage/ssblob/ssblob.go
+++ b/internal/storage/ssblob/ssblob.go
@@ -129,7 +129,36 @@ func (b *bucket) ErrorAs(err error, i any) bool {
 }
 
 func (b *bucket) Attributes(ctx context.Context, key string) (*driver.Attributes, error) {
-	return nil, errNotImplemented
+	id, err := uuid.Parse(key)
+	if err != nil {
+		return nil, err
+	}
+
+	pkg, err := b.client.Packages().Get(ctx, id)
+	if err != nil {
+		if apiErr := apiError(err); apiErr != nil {
+			return nil, apiErr
+		}
+		return nil, err
+	}
+
+	if pkg.GetStatus() == nil || *pkg.GetStatus() == "DELETED" {
+		return nil, &APIError{
+			Status: "Not Found",
+			Code:   http.StatusNotFound,
+			Cause:  errors.New("resource deleted"),
+		}
+	}
+
+	drv := &driver.Attributes{
+		ContentDisposition: "attachment",
+		ContentType:        "application/octet-stream",
+	}
+	if pkg.GetSize() != nil {
+		drv.Size = *pkg.GetSize()
+	}
+
+	return drv, nil
 }
 
 func (b *bucket) ListPaged(ctx context.Context, opts *driver.ListOptions) (*driver.ListPage, error) {

--- a/internal/storage/ssblob/ssblob_test.go
+++ b/internal/storage/ssblob/ssblob_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.artefactual.dev/ssclient"
 	"gocloud.dev/blob"
 	"gocloud.dev/gcerrors"
@@ -155,10 +156,6 @@ func TestBucket(t *testing.T) {
 
 		ctx := context.Background()
 
-		attrs, err := b.Attributes(ctx, "2db707f3-3cd2-44b7-9012-9b68eb10d207")
-		assert.Assert(t, attrs == nil)
-		assert.Equal(t, gcerrors.Code(err), gcerrors.Unimplemented)
-
 		objs, nextPageToken, err := b.ListPage(ctx, nil, 10, nil)
 		assert.Assert(t, objs == nil)
 		assert.Assert(t, nextPageToken == nil)
@@ -261,5 +258,83 @@ func TestBucket(t *testing.T) {
 		})
 		assert.ErrorContains(t, err, "net/url: invalid control character in URL")
 		assert.Assert(t, b == nil)
+	})
+
+	t.Run("Returns blob attributes", func(t *testing.T) {
+		t.Parallel()
+
+		aipID := "2db707f3-3cd2-44b7-9012-9b68eb10d207"
+
+		b := setUpTest(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.URL.Path, fmt.Sprintf("/api/v2/file/%s/", aipID))
+
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Content-Disposition", "inline")
+			w.WriteHeader(http.StatusAccepted)
+			_, err := w.Write([]byte(`{
+"package_type": "AIP",
+"size": 12345,
+"status": "UPLOADED",
+"uuid": "` + aipID + `"
+}`))
+			assert.NilError(t, err)
+		}, nil)
+
+		attrs, err := b.Attributes(context.Background(), aipID)
+		assert.NilError(t, err)
+		assert.DeepEqual(t,
+			attrs,
+			&blob.Attributes{
+				ContentDisposition: "attachment",
+				ContentType:        "application/octet-stream",
+				Size:               12345,
+			},
+			cmpopts.IgnoreUnexported(blob.Attributes{}),
+		)
+	})
+
+	t.Run("bucket.Attributes returns not found when file deleted", func(t *testing.T) {
+		t.Parallel()
+
+		b := setUpTest(t, func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "AIP not found.", http.StatusNotFound)
+		}, nil)
+
+		attrs, err := b.Attributes(context.Background(), "2db707f3-3cd2-44b7-9012-9b68eb10d207")
+		assert.Equal(t, gcerrors.Code(err), gcerrors.NotFound)
+		assert.Assert(t, attrs == nil)
+
+		apiErr := &ssblob.APIError{}
+		assert.Equal(t, b.ErrorAs(err, &apiErr), true)
+		assert.Equal(t, apiErr.Code, http.StatusNotFound)
+	})
+
+	t.Run("Returns blob attributes", func(t *testing.T) {
+		t.Parallel()
+
+		aipID := "2db707f3-3cd2-44b7-9012-9b68eb10d207"
+
+		b := setUpTest(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.URL.Path, fmt.Sprintf("/api/v2/file/%s/", aipID))
+
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Content-Disposition", "inline")
+			w.WriteHeader(http.StatusAccepted)
+			_, err := w.Write([]byte(`{
+"package_type": "AIP",
+"size": 12345,
+"status": "DELETED",
+"uuid": "` + aipID + `"
+}`))
+			assert.NilError(t, err)
+		}, nil)
+
+		_, err := b.Attributes(context.Background(), aipID)
+
+		var apiErr *ssblob.APIError
+		assert.Assert(t, errors.As(err, &apiErr))
+		assert.Equal(t, apiErr.Code, http.StatusNotFound)
+		assert.Equal(t, apiErr.Error(), "Not Found")
+		assert.Equal(t, apiErr.Cause.Error(), "resource deleted")
 	})
 }


### PR DESCRIPTION
Call `bucket.Attributes()` to check if an AIP exists instead of trying to open a blob reader to avoid downloading the entire AIP.

When using `ssblob` as the `blob.Bucket` implementation to open a reader on an AIP file, it immediately downloads the entire file via the HTTP connection. Because `DownloadAipRequest()` was opening a blob reader to confirm if the AIP file existed, the entire AIP was being downloaded when the AIP was stored in the AMSS, which caused the request to time out.

- Implement the `ssblob.Attributes()` method using the AMSS `GET api/v2/file/{UUID}` endpoint
- Return a "Not Found" error from `ssblob.Attributes()` if the AIP doesn't exist in the AMSS database, or if the AIP has been deleted
- Call `bucket.Attributes()` in the storage service `DownloadAipRequest()` method to check if the AIP exists
- Add the storage service `openAIPbucket()` helper method reduce repetition and complexity in the code that opens the bucket where an AIP is stored.
- Remove the `aipLocation()` method because it was only called once, in the `openAIPbucket()` method and wasn't doing that much any more