### PR TITLE
Add SeaweedFS object store for dev

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -14,13 +14,23 @@ if os.path.exists(dotenv_path):
   dotenv(fn=dotenv_path)
 
 # Get preservation system (default: 'am')
-PRES_SYS = os.environ.get('ENDURO_PRES_SYSTEM', 'am')
+PRES_SYS = os.environ.get("ENDURO_PRES_SYSTEM", "am")
 if PRES_SYS not in ("a3m", "am"):
   fail("Invalid ENDURO_PRES_SYSTEM: {pres_sys}.".format(pres_sys=PRES_SYS))
+
+OBJECT_STORE = os.environ.get("OBJECT_STORE", "filesystem")
+if OBJECT_STORE not in ("filesystem", "seaweedfs"):
+  fail("Invalid OBJECT_STORE: {object_store}.".format(object_store=OBJECT_STORE))
 
 true = ("true", "1", "yes", "t", "y")
 LOCAL_A3M = os.environ.get("LOCAL_A3M", "").lower() in true
 DASHBOARD_DEV = os.environ.get("DASHBOARD_DEV", "").lower() in true
+
+LOCATION_JOB_PATH = "hack/kube/overlays/dev-{pres_sys}/mysql-create-{pres_sys}-location-job.yaml".format(
+  pres_sys=PRES_SYS,
+)
+if PRES_SYS == "a3m" and OBJECT_STORE == "seaweedfs":
+  LOCATION_JOB_PATH = "hack/kube/overlays/dev-a3m-seaweedfs/mysql-create-a3m-location-job.yaml"
 
 def add_enduro_config_secret(yaml):
   config_path = "enduro.toml"
@@ -82,6 +92,8 @@ docker_build(
 KUBE_OVERLAY = 'hack/kube/overlays/dev-a3m'
 if PRES_SYS == 'am':
   KUBE_OVERLAY = 'hack/kube/overlays/dev-am'
+if OBJECT_STORE == "seaweedfs":
+  KUBE_OVERLAY = "{overlay}-seaweedfs".format(overlay=KUBE_OVERLAY)
 
 # Load Kustomize YAML
 yaml = kustomize(KUBE_OVERLAY)
@@ -127,12 +139,16 @@ if os.environ.get('TRIGGER_MODE_AUTO', '').lower() in true:
   trigger_mode = TRIGGER_MODE_AUTO
 
 # Enduro resources
+enduro_resource_deps = ["temporal-schema-1-2-0-1"]
+if OBJECT_STORE == "seaweedfs":
+  enduro_resource_deps.append("seaweedfs")
+
 k8s_resource(
   "enduro",
   labels=["Enduro"],
   port_forwards=["9000:9000", "9002:9002"],
   trigger_mode=trigger_mode,
-  resource_deps=["temporal-schema-1-2-0-1"],
+  resource_deps=enduro_resource_deps,
 )
 k8s_resource(
   "enduro-dashboard",
@@ -152,14 +168,14 @@ if PRES_SYS == 'am':
     "enduro-am",
     labels=["Enduro"],
     trigger_mode=trigger_mode,
-    resource_deps=["temporal-schema-1-2-0-1", "ambox"],
+    resource_deps=enduro_resource_deps + ["ambox"],
   )
 else:
   k8s_resource(
     "enduro-a3m",
     labels=["Enduro"],
     trigger_mode=trigger_mode,
-    resource_deps=["temporal-schema-1-2-0-1"],
+    resource_deps=enduro_resource_deps,
   )
 
 # Temporal resources
@@ -208,6 +224,12 @@ k8s_resource(
 k8s_resource("keycloak", labels=["Others"], port_forwards="7470")
 k8s_resource("mysql", labels=["Others"], port_forwards="3306")
 k8s_resource("redis", labels=["Others"])
+if OBJECT_STORE == "seaweedfs":
+  k8s_resource(
+    "seaweedfs",
+    labels=["Others"],
+    port_forwards=["23646:23646"],
+  )
 
 # Tools
 if PRES_SYS == 'am':
@@ -255,9 +277,10 @@ cmd_button(
     kubectl wait --for=condition=complete --timeout=120s job --all; \
     kubectl rollout restart deployment enduro; \
     kubectl rollout restart {kind} enduro-{pres_sys}; \
-    kubectl create -f hack/kube/overlays/dev-{pres_sys}/mysql-create-{pres_sys}-location-job.yaml;".format(
+    kubectl create -f {location_job_path};".format(
       pres_sys=PRES_SYS,
       kind="statefulset" if PRES_SYS == "a3m" else "deployment",
+      location_job_path=LOCATION_JOB_PATH,
     ),
   ],
   location="nav",

--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -122,12 +122,16 @@ documentation to know more about it.
 
 The main local services are available from the host:
 
-| Service       | URL                     | Username    | Password       |
-| ------------- | ----------------------- | ----------- | -------------- |
-| Dashboard     | <http://localhost:8080> | `admin`     | `admin123`     |
-| Temporal UI   | <http://localhost:7440> | `admin`     | `admin123`     |
-| Grafana       | <http://localhost:7490> | `admin`     | `admin123`     |
-| Keycloak      | <http://localhost:7470> | `keycloak`  | `keycloak123`  |
+| Service       | URL                      | Username    | Password       |
+| ------------- | ------------------------ | ----------- | -------------- |
+| Dashboard     | <http://localhost:8080>  | `admin`     | `admin123`     |
+| Temporal UI   | <http://localhost:7440>  | `admin`     | `admin123`     |
+| Grafana       | <http://localhost:7490>  | `admin`     | `admin123`     |
+| Keycloak      | <http://localhost:7470>  | `keycloak`  | `keycloak123`  |
+| SeaweedFS     | <http://localhost:23646> | `admin`     | `admin123`     |
+
+The SeaweedFS Admin UI is available only with
+[`OBJECT_STORE=seaweedfs`](#object_store).
 
 ## Submit your first SIP
 
@@ -195,6 +199,7 @@ located in the root of the project. Example:
 TRIGGER_MODE_AUTO=true
 ENDURO_PRES_SYSTEM=a3m
 LOCAL_A3M=true
+OBJECT_STORE=seaweedfs
 DASHBOARD_DEV=true
 CHILD_WORKFLOW_PATHS='../preprocessing-acme:../acme-enduro-workflows'
 MOUNT_PREPROCESSING_VOLUME=true
@@ -221,6 +226,44 @@ but it has seen little adoption and is largely unmaintained. Check the
 
 Build and use a local version of a3m. Requires to have the `a3m` repository
 cloned as a sibling of this repository folder.
+
+### OBJECT_STORE
+
+Determines the object store used by the local development environment. Allowed
+values are `filesystem` and `seaweedfs`; it defaults to `filesystem`.
+
+With the default `filesystem` mode, Tilt uses the shared `internal-storage` PVC
+for Enduro's internal ingest bucket, storage bucket, SIP source bucket, and a3m
+permanent AIP location.
+
+With `OBJECT_STORE=seaweedfs`, Tilt deploys SeaweedFS and overrides Enduro's
+configured internal buckets to use its S3-compatible endpoint:
+`http://seaweedfs.enduro-sdps:8333`. This endpoint is exposed only inside the
+Kubernetes cluster. Tilt port-forwards the SeaweedFS Admin UI locally for bucket
+management:
+
+- Admin UI: `http://localhost:23646`
+
+The Admin UI uses SeaweedFS' built-in local authentication:
+
+- Username: `admin`
+- Password: `admin123`
+
+The S3 development credentials are:
+
+- Access key: `enduro`
+- Secret key: `enduro123`
+
+SeaweedFS starts with these buckets:
+
+- `ingest`: internal storage for the ingest domain.
+- `storage`: internal storage for the storage domain and a3m AIP staging.
+- `sip-source`: SIP source bucket.
+- `perma-aips`: a3m permanent AIP storage.
+
+The `internal-storage` PVC is still created in SeaweedFS mode because the
+filesystem watched location continues to use it. Only the configured bucket
+locations listed above move to SeaweedFS.
 
 ### DASHBOARD_DEV
 
@@ -271,13 +314,14 @@ make upload-sip LOCAL_PATH=/path/to/sip.zip
 Also in the Tilt UI header, click the trash button to flush the existing data.
 This will recreate the Enduro MySQL databases, and restart the required
 resources. It does not recreate the Temporal databases or clean the
-internal-storage volume; data in those locations remains after the flush.
+internal-storage volume or SeaweedFS PVC; data in those locations remains after
+the flush.
 
 ## Interact with the internal-storage volume
 
 The local development environment mounts the shared internal-storage PVC in the
-`enduro` pod at `/home/enduro/internal-storage`. The volume contains internal
-folders used by different local workflows:
+`enduro` pod at `/home/enduro/internal-storage`. In `OBJECT_STORE=filesystem`
+mode, the volume contains internal folders used by different local workflows:
 
 - `ingest`: internal storage for the ingest domain.
 - `storage`: internal storage for the storage domain.
@@ -286,9 +330,15 @@ folders used by different local workflows:
 - `watched-complete`: successfully ingested watched-location SIPs.
 - `perma-aips`: local permanent AIP storage.
 
-Use the `enduro` pod as an access point for copying, listing, and removing files
-in any of those folders. Declare the following variables related to the Enduro
-Kubernetes pod in the same BASH script as the subsequent `kubectl` commands:
+In `OBJECT_STORE=seaweedfs` mode, the `ingest`, `storage`, `sip-source`, and
+`perma-aips` locations are configured as SeaweedFS S3 buckets instead. Use the
+SeaweedFS S3 endpoint for those buckets. The `watched` and `watched-complete`
+folders continue to use the internal-storage PVC.
+
+For filesystem-backed locations, use the `enduro` pod as an access point for
+copying, listing, and removing files in those folders. Declare the following
+variables related to the Enduro Kubernetes pod in the same BASH script as the
+subsequent `kubectl` commands:
 
 ```bash
 NAMESPACE=enduro-sdps

--- a/hack/kube/components/seaweedfs/kustomization.yaml
+++ b/hack/kube/components/seaweedfs/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: enduro-sdps
+resources:
+  - seaweedfs.yaml

--- a/hack/kube/components/seaweedfs/seaweedfs.yaml
+++ b/hack/kube/components/seaweedfs/seaweedfs.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: seaweedfs-secret
+type: Opaque
+stringData:
+  access_key_id: enduro
+  secret_access_key: enduro123
+  admin_user: admin
+  admin_password: admin123
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seaweedfs-enduro-env
+data:
+  ENDURO_INTERNALSTORAGE_URL: s3://ingest?region=us-east-1&endpoint=http://seaweedfs.enduro-sdps:8333&use_path_style=true&disable_https=true&awssdk=v2
+  ENDURO_STORAGE_INTERNAL_URL: s3://storage?region=us-east-1&endpoint=http://seaweedfs.enduro-sdps:8333&use_path_style=true&disable_https=true&awssdk=v2
+  ENDURO_A3M_AIPSTAGING_URL: s3://storage?region=us-east-1&endpoint=http://seaweedfs.enduro-sdps:8333&use_path_style=true&disable_https=true&awssdk=v2
+  ENDURO_SIPSOURCE_BUCKET_URL: s3://sip-source?region=us-east-1&endpoint=http://seaweedfs.enduro-sdps:8333&use_path_style=true&disable_https=true&awssdk=v2
+  ENDURO_SIPSOURCE_NAME: SeaweedFS SIP Source
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: seaweedfs-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seaweedfs
+  labels:
+    app: seaweedfs
+spec:
+  selector:
+    matchLabels:
+      app: seaweedfs
+  template:
+    metadata:
+      labels:
+        app: seaweedfs
+    spec:
+      containers:
+        - name: seaweedfs
+          image: chrislusf/seaweedfs:4.38
+          imagePullPolicy: IfNotPresent
+          command:
+            - weed
+          args:
+            - mini
+            - -dir=/data
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: secret_access_key
+            - name: WEED_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: admin_user
+            - name: WEED_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: admin_password
+            - name: S3_BUCKET
+              value: ingest,storage,sip-source,perma-aips
+          ports:
+            - name: admin-ui
+              containerPort: 23646
+            - name: s3
+              containerPort: 8333
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources: {}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: seaweedfs-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: seaweedfs
+  labels:
+    app: seaweedfs
+spec:
+  selector:
+    app: seaweedfs
+  ports:
+    - name: admin-ui
+      port: 23646
+    - name: s3
+      port: 8333

--- a/hack/kube/overlays/dev-a3m-seaweedfs/enduro-a3m-seaweedfs-patch.yaml
+++ b/hack/kube/overlays/dev-a3m-seaweedfs/enduro-a3m-seaweedfs-patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enduro-a3m
+spec:
+  template:
+    spec:
+      containers:
+        - name: enduro-a3m-worker
+          envFrom:
+            - configMapRef:
+                name: seaweedfs-enduro-env
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: secret_access_key

--- a/hack/kube/overlays/dev-a3m-seaweedfs/enduro-seaweedfs-patch.yaml
+++ b/hack/kube/overlays/dev-a3m-seaweedfs/enduro-seaweedfs-patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: enduro
+spec:
+  template:
+    spec:
+      containers:
+        - name: enduro
+          envFrom:
+            - configMapRef:
+                name: seaweedfs-enduro-env
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: secret_access_key
+            - name: ENDURO_INGEST_STORAGE_DEFAULTPERMANENTLOCATIONID
+              value: "0cb26a7e-593a-4725-a97e-0b0780783692"

--- a/hack/kube/overlays/dev-a3m-seaweedfs/kustomization.yaml
+++ b/hack/kube/overlays/dev-a3m-seaweedfs/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: enduro-sdps
+resources:
+  - ../dev-a3m
+  - ../../components/seaweedfs
+patches:
+  - path: enduro-seaweedfs-patch.yaml
+    target:
+      kind: Deployment
+      name: enduro
+  - path: enduro-a3m-seaweedfs-patch.yaml
+    target:
+      kind: StatefulSet
+      name: enduro-a3m
+  - path: mysql-create-a3m-location-job.yaml
+    target:
+      kind: Job
+      name: mysql-create-a3m-location

--- a/hack/kube/overlays/dev-a3m-seaweedfs/mysql-create-a3m-location-job.yaml
+++ b/hack/kube/overlays/dev-a3m-seaweedfs/mysql-create-a3m-location-job.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mysql-create-a3m-location
+spec:
+  backoffLimit: 100
+  template:
+    spec:
+      serviceAccountName: sdps
+      restartPolicy: OnFailure
+      containers:
+        - name: create-a3m-location
+          image: mysql:8.4.8
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: user
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-secret
+                  key: password
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: secret_access_key
+          command:
+            - sh
+            - -c
+            - >
+              LOC='{"s3":{"bucket":"perma-aips","region":"us-east-1","endpoint":"http://seaweedfs.enduro-sdps:8333","path_style":true,"key":"'$AWS_ACCESS_KEY_ID'","secret":"'$AWS_SECRET_ACCESS_KEY'"}}' &&
+              mysql -h mysql.enduro-sdps -u $MYSQL_USER -p$MYSQL_PASSWORD --execute "
+                INSERT IGNORE INTO enduro_storage.location (name, description, source, purpose, uuid, created_at, config)
+                VALUES ('perma-aips-seaweedfs', '', 's3', 'aip_store', '0cb26a7e-593a-4725-a97e-0b0780783692', NOW(), '$LOC');
+              " && echo "Location created"

--- a/hack/kube/overlays/dev-am-seaweedfs/enduro-am-seaweedfs-patch.yaml
+++ b/hack/kube/overlays/dev-am-seaweedfs/enduro-am-seaweedfs-patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: enduro-am
+spec:
+  template:
+    spec:
+      containers:
+        - name: enduro-am-worker
+          envFrom:
+            - configMapRef:
+                name: seaweedfs-enduro-env
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: secret_access_key

--- a/hack/kube/overlays/dev-am-seaweedfs/enduro-seaweedfs-patch.yaml
+++ b/hack/kube/overlays/dev-am-seaweedfs/enduro-seaweedfs-patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: enduro
+spec:
+  template:
+    spec:
+      containers:
+        - name: enduro
+          envFrom:
+            - configMapRef:
+                name: seaweedfs-enduro-env
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: seaweedfs-secret
+                  key: secret_access_key

--- a/hack/kube/overlays/dev-am-seaweedfs/kustomization.yaml
+++ b/hack/kube/overlays/dev-am-seaweedfs/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: enduro-sdps
+resources:
+  - ../dev-am
+  - ../../components/seaweedfs
+patches:
+  - path: enduro-seaweedfs-patch.yaml
+    target:
+      kind: Deployment
+      name: enduro
+  - path: enduro-am-seaweedfs-patch.yaml
+    target:
+      kind: Deployment
+      name: enduro-am


### PR DESCRIPTION
Add an optional `OBJECT_STORE=seaweedfs` mode for Tilt that renders SeaweedFS dev overlays while keeping filesystem storage as the default.

Provide SeaweedFS manifests with S3 buckets, dev credentials, persistent storage, and the Admin UI. Wire Enduro and the active worker to use the SeaweedFS S3 endpoint in that mode.

Refs #1660.