### PR TITLE
Bump Go version from 1.26.4 to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/artefactual-sdps/enduro
 
-go 1.26.4
+go 1.26.5
 
 require (
 	ariga.io/atlas v0.37.0

--- a/hack/pulumi/azure-storage/go.mod
+++ b/hack/pulumi/azure-storage/go.mod
@@ -1,6 +1,6 @@
 module enduro-dev-azure-storage
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/pulumi/pulumi-azure-native-sdk/resources/v2 v2.90.0

--- a/hack/pulumi/go.mod
+++ b/hack/pulumi/go.mod
@@ -1,6 +1,6 @@
 module enduro
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0


### PR DESCRIPTION
Upgrade Go version to 1.26.5 to mitigate security vulnerability https://pkg.go.dev/vuln/GO-2026-5856