### PR TITLE
Use parent namespace for child workflows

### DIFF
--- a/docs/src/admin-manual/configuration.md
+++ b/docs/src/admin-manual/configuration.md
@@ -123,22 +123,20 @@ and communicate with Temporal.
 
 ```toml
 [temporal]
-namespace = "default"
 address = "temporal.enduro-sdps:7233"
+namespace = "default"
 taskQueue = "global"
 ```
 
-* `namespace`: An internal namespace label for the Temporal workflows. This only
-  needs to be changed if you expect to be running multiple different workflows
-  running at once, so they don't clash.
 * `address`: Tells Enduro where to find Temporal - address and port connection
   information.
+* `namespace`: The Temporal namespace in which Enduro workflows run. Custom
+  child workflows inherit this namespace. Workers that execute custom child
+  workflows must connect to the same namespace.
 * `taskQueue`: In Temporal, a [Task Queue] is a lightweight, dynamically
   allocated queue that one or more workers can poll for tasks. Temporal supports
   many kinds of parallelization for a distributed application architecture, and
-  and task queues can be namespaced to support such a set-up. At present
-  however, Enduro will only support the default `global` value for the general
-  ingest workflow queue.
+  and task queues can be namespaced to support such a set-up.
 
 ### Internal API
 
@@ -1440,9 +1438,13 @@ A child workflow is a concept borrowed from Enduro's [workflow engine],
 Enduro to keep custom activities with organization specific business rules or
 policy requirements separated from the underlying general Enduro code.
 
-All child workflow configurations share four common settings: `type`,
-`namespace`, `taskQueue`, and `workflowName`.  An example configuration for the
-poststorage child workflow is shown below.
+Enduro schedules custom child workflows in the same Temporal namespace as their
+parent workflows, as configured by `[temporal].namespace`. Workers that execute
+these child workflows must connect to the same namespace.
+
+All child workflow configurations share three common settings: `type`,
+`taskQueue`, and `workflowName`.  An example configuration for the poststorage
+child workflow is shown below.
 
 !!! note
 
@@ -1455,26 +1457,20 @@ poststorage child workflow is shown below.
 ```toml
 [[childWorkflows]]
 type = "poststorage"
-namespace = "default"
-taskQueue = "poststorage"
-workflowName = "poststrage"
+taskQueue = "custom-queue"
+workflowName = "custom-poststorage-workflow"
 ```
 
 * `type`: The type of child workflow. Type is used to load the correct child
   workflow configuration in Enduro so only one child workflow of each type may
   be configured for any instance of Enduro. If multiple child workflows have
   the same type, an error will be thrown when the configuration is validated.
-* `namespace`: An internal namespace label for the Temporal workflows. This only
-  needs to be changed if you expect to be running multiple different workflows
-  at once, so they don't clash.
 * `taskQueue`: In Temporal, a [Task Queue] is a lightweight, dynamically
-  allocated queue that one or more workers can poll for tasks. Temporal supports
-  many kinds of parallelization for a distributed application architecture, and
-  and task queues can be namespaced to support such a set-up. The value of
-  `poststorage` here differentiates it from the general `global` task queue
-  used by Enduro, and ensures that Enduro looks for child workflow tasks in a
-  dedicated queue.
-* `workflowName`: The name of the configured [child workflow] in Temporal.
+  allocated queue that one or more workers can poll for tasks. The example
+  value `custom-queue` differentiates this queue from Enduro's general `global`
+  queue. The custom workers must poll the configured queue.
+* `workflowName`: The name of the configured [child workflow] in Temporal. It
+  must exactly match the custom workers registration.
 
 All `[[childWorkflows]]` configuration sections are commented out at Enduro
 installation, disabling the child workflows. Uncomment the relevant
@@ -1500,9 +1496,8 @@ to the common child workflow settings: `extract` and `sharedPath`.
 ```toml
 [[childWorkflows]]
 type = "preprocessing"
-namespace = "default"
-taskQueue = "preprocessing"
-workflowName = "preprocessing"
+taskQueue = "custom-queue"
+workflowName = "custom-preprocessing-workflow"
 extract = true
 sharedPath = "/home/enduro/preprocessing"
 ```
@@ -1540,9 +1535,8 @@ archival management system), AIP encryption or replication, and more.
 ```toml
 [[childWorkflows]]
 type = "poststorage"
-namespace = "default"
-taskQueue = "poststorage"
-workflowName = "poststorage"
+taskQueue = "custom-queue"
+workflowName = "custom-poststorage-workflow"
 ```
 
 #### Postbatch child workflow
@@ -1557,9 +1551,8 @@ that collates SIP and AIP data for all of the SIPs in a batch.
 ```toml
 [[childWorkflows]]
 type = "postbatch"
-namespace = "default"
-taskQueue = "postbatch"
-workflowName = "postbatch"
+taskQueue = "custom-queue"
+workflowName = "custom-postbatch-workflow"
 ```
 
 [a3m]: https://github.com/artefactual-labs/a3m

--- a/enduro.toml
+++ b/enduro.toml
@@ -18,8 +18,8 @@ debugListen = "127.0.0.1:9001"
 verbosity = 2
 
 [temporal]
-namespace = "default"
 address = "temporal-frontend.enduro-sdps:7233"
+namespace = "default"
 taskQueue = "global"
 
 [internalapi]
@@ -350,7 +350,6 @@ url = "file:///home/enduro/internal-storage/sip-source?metadata=skip"
 # Uncomment to activate. All fields except "extract" are required.
 # [[childWorkflows]]
 # type = "preprocessing"
-# namespace = "default"
 # taskQueue = "preprocessing"
 # workflowName = "preprocessing"
 
@@ -369,7 +368,6 @@ url = "file:///home/enduro/internal-storage/sip-source?metadata=skip"
 # Uncomment to activate. All fields are required.
 # [[childWorkflows]]
 # type = "poststorage"
-# namespace = "default"
 # taskQueue = "poststorage"
 # workflowName = "poststorage"
 
@@ -377,7 +375,6 @@ url = "file:///home/enduro/internal-storage/sip-source?metadata=skip"
 # AIPs. Uncomment to activate. All fields are required.
 # [[childWorkflows]]
 # type = "postbatch"
-# namespace = "default"
 # taskQueue = "postbatch"
 # workflowName = "postbatch"
 

--- a/internal/about/goa_test.go
+++ b/internal/about/goa_test.go
@@ -139,7 +139,6 @@ func TestAbout(t *testing.T) {
 				ChildWorkflows: childwf.Configs{
 					{
 						Type:         enums.ChildWorkflowTypePreprocessing,
-						Namespace:    "default",
 						TaskQueue:    "preprocessing",
 						WorkflowName: "preprocessing",
 						Extract:      true,
@@ -147,7 +146,6 @@ func TestAbout(t *testing.T) {
 					},
 					{
 						Type:         enums.ChildWorkflowTypePoststorage,
-						Namespace:    "default",
 						TaskQueue:    "poststorage",
 						WorkflowName: "poststorage",
 					},

--- a/internal/childwf/childwf.go
+++ b/internal/childwf/childwf.go
@@ -13,9 +13,6 @@ type Config struct {
 	// Type of the child workflow.
 	Type enums.ChildWorkflowType
 
-	// Namespace is the Temporal namespace of the child workflow.
-	Namespace string
-
 	// TaskQueue is the Temporal task queue to use for child workflow tasks.
 	TaskQueue string
 
@@ -45,9 +42,6 @@ func (c Config) missingFields() error {
 
 	if c.Type == "" {
 		missing = append(missing, "type")
-	}
-	if c.Namespace == "" {
-		missing = append(missing, "namespace")
 	}
 	if c.TaskQueue == "" {
 		missing = append(missing, "taskQueue")

--- a/internal/childwf/childwf_test.go
+++ b/internal/childwf/childwf_test.go
@@ -19,7 +19,6 @@ func TestConfig_Validate(t *testing.T) {
 			name: "Valid config",
 			config: childwf.Config{
 				Type:         enums.ChildWorkflowTypePreprocessing,
-				Namespace:    "default",
 				TaskQueue:    "preprocessing",
 				WorkflowName: "preprocessing",
 				SharedPath:   "/home/enduro/shared",
@@ -30,13 +29,12 @@ func TestConfig_Validate(t *testing.T) {
 			config: childwf.Config{
 				Type: enums.ChildWorkflowTypePreprocessing,
 			},
-			wantErr: `missing required value(s): namespace, taskQueue, workflowName, sharedPath`,
+			wantErr: `missing required value(s): taskQueue, workflowName, sharedPath`,
 		},
 		{
 			name: "Errors on invalid type",
 			config: childwf.Config{
 				Type:         "invalid_type",
-				Namespace:    "default",
 				TaskQueue:    "taskqueue",
 				WorkflowName: "workflowname",
 			},
@@ -60,14 +58,12 @@ func TestConfigs_ByType(t *testing.T) {
 	configs := childwf.Configs{
 		{
 			Type:         enums.ChildWorkflowTypePreprocessing,
-			Namespace:    "default",
 			TaskQueue:    "preprocessing",
 			WorkflowName: "preprocessing",
 			SharedPath:   "/home/enduro/shared",
 		},
 		{
 			Type:         enums.ChildWorkflowTypePoststorage,
-			Namespace:    "default",
 			TaskQueue:    "poststorage",
 			WorkflowName: "poststorage",
 		},
@@ -76,7 +72,6 @@ func TestConfigs_ByType(t *testing.T) {
 	cfg := configs.ByType(enums.ChildWorkflowTypePreprocessing)
 	assert.DeepEqual(t, cfg, &childwf.Config{
 		Type:         enums.ChildWorkflowTypePreprocessing,
-		Namespace:    "default",
 		TaskQueue:    "preprocessing",
 		WorkflowName: "preprocessing",
 		SharedPath:   "/home/enduro/shared",
@@ -100,14 +95,12 @@ func TestConfigs_Validate(t *testing.T) {
 			configs: childwf.Configs{
 				{
 					Type:         enums.ChildWorkflowTypePreprocessing,
-					Namespace:    "default",
 					TaskQueue:    "preprocessing",
 					WorkflowName: "preprocessing",
 					SharedPath:   "/home/enduro/shared",
 				},
 				{
 					Type:         enums.ChildWorkflowTypePoststorage,
-					Namespace:    "default",
 					TaskQueue:    "poststorage",
 					WorkflowName: "poststorage",
 					SharedPath:   "/home/enduro/shared",
@@ -119,14 +112,12 @@ func TestConfigs_Validate(t *testing.T) {
 			configs: childwf.Configs{
 				{
 					Type:         enums.ChildWorkflowTypePreprocessing,
-					Namespace:    "default",
 					TaskQueue:    "preprocessing",
 					WorkflowName: "preprocessing",
 					SharedPath:   "/home/enduro/shared",
 				},
 				{
 					Type:         enums.ChildWorkflowTypePreprocessing,
-					Namespace:    "default",
 					TaskQueue:    "preprocessing-2",
 					WorkflowName: "preprocessing-2",
 					SharedPath:   "/home/enduro/shared-2",
@@ -139,12 +130,10 @@ func TestConfigs_Validate(t *testing.T) {
 			configs: childwf.Configs{
 				{
 					Type:         enums.ChildWorkflowTypePreprocessing,
-					Namespace:    "default",
 					TaskQueue:    "preprocessing",
 					WorkflowName: "preprocessing",
 				},
 				{
-					Namespace:    "default",
 					TaskQueue:    "poststorage",
 					WorkflowName: "poststorage",
 				},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -72,14 +72,12 @@ retryBackoffCoefficient = 1.5
 
 [[childWorkflows]]
 type = "preprocessing"
-namespace = "default"
 taskQueue = "preprocessing"
 workflowName = "preprocessing"
 sharedPath = "/home/enduro/shared"
 
 [[childWorkflows]]
 type = "poststorage"
-namespace = "default"
 taskQueue = "poststorage"
 workflowName = "poststorage"
 `
@@ -144,14 +142,12 @@ func TestConfigRead(t *testing.T) {
 				ChildWorkflows: childwf.Configs{
 					{
 						Type:         "preprocessing",
-						Namespace:    "default",
 						TaskQueue:    "preprocessing",
 						WorkflowName: "preprocessing",
 						SharedPath:   "/home/enduro/shared",
 					},
 					{
 						Type:         "poststorage",
-						Namespace:    "default",
 						TaskQueue:    "poststorage",
 						WorkflowName: "poststorage",
 					},

--- a/internal/workflow/batch.go
+++ b/internal/workflow/batch.go
@@ -237,7 +237,6 @@ func (w *BatchWorkflow) startSIPWorkflow(
 	// Start processing workflow for the SIP, keeping track of the workflow future and execution.
 	var we temporalsdk_workflow.Execution
 	processingCtx := temporalsdk_workflow.WithChildOptions(ctx, temporalsdk_workflow.ChildWorkflowOptions{
-		Namespace:         w.cfg.Temporal.Namespace,
 		TaskQueue:         w.cfg.Temporal.TaskQueue,
 		WorkflowID:        fmt.Sprintf("%s-%s", ingest.ProcessingWorkflowName, sipUUID.String()),
 		ParentClosePolicy: temporalapi_enums.PARENT_CLOSE_POLICY_TERMINATE,
@@ -361,7 +360,6 @@ func (w *BatchWorkflow) postbatchWorkflow(
 	childCtx := temporalsdk_workflow.WithChildOptions(
 		ctx,
 		temporalsdk_workflow.ChildWorkflowOptions{
-			Namespace:         cfg.Namespace,
 			TaskQueue:         cfg.TaskQueue,
 			WorkflowID:        fmt.Sprintf("%s-%s", cfg.WorkflowName, state.batch.UUID.String()),
 			ParentClosePolicy: temporalapi_enums.PARENT_CLOSE_POLICY_TERMINATE,

--- a/internal/workflow/batch_test.go
+++ b/internal/workflow/batch_test.go
@@ -163,7 +163,6 @@ func (s *BatchWorkflowTestSuite) TestBatch() {
 		ChildWorkflows: childwf.Configs{
 			{
 				Type:         enums.ChildWorkflowTypePostbatch,
-				Namespace:    "default",
 				TaskQueue:    "postbatch",
 				WorkflowName: "postbatch",
 			},

--- a/internal/workflow/processing.go
+++ b/internal/workflow/processing.go
@@ -1112,7 +1112,6 @@ func (w *ProcessingWorkflow) preprocessing(ctx temporalsdk_workflow.Context, sta
 	}
 
 	preCtx := temporalsdk_workflow.WithChildOptions(ctx, temporalsdk_workflow.ChildWorkflowOptions{
-		Namespace:         cfg.Namespace,
 		TaskQueue:         cfg.TaskQueue,
 		WorkflowID:        fmt.Sprintf("%s-%s", cfg.WorkflowName, state.sip.uuid.String()),
 		ParentClosePolicy: temporalapi_enums.PARENT_CLOSE_POLICY_TERMINATE,
@@ -1377,7 +1376,6 @@ func (w *ProcessingWorkflow) poststorage(ctx temporalsdk_workflow.Context, state
 	ctx = temporalsdk_workflow.WithChildOptions(
 		ctx,
 		temporalsdk_workflow.ChildWorkflowOptions{
-			Namespace:         cfg.Namespace,
 			TaskQueue:         cfg.TaskQueue,
 			WorkflowID:        fmt.Sprintf("%s-%s", cfg.WorkflowName, state.aip.id),
 			ParentClosePolicy: temporalapi_enums.PARENT_CLOSE_POLICY_TERMINATE,

--- a/internal/workflow/processing_test.go
+++ b/internal/workflow/processing_test.go
@@ -364,7 +364,6 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 		ChildWorkflows: childwf.Configs{
 			{
 				Type:         enums.ChildWorkflowTypePreprocessing,
-				Namespace:    "default",
 				TaskQueue:    "preprocessing",
 				WorkflowName: "preprocessing",
 				Extract:      true,
@@ -372,7 +371,6 @@ func (s *ProcessingWorkflowTestSuite) TestChildWorkflows() {
 			},
 			{
 				Type:         enums.ChildWorkflowTypePoststorage,
-				Namespace:    "default",
 				TaskQueue:    "poststorage",
 				WorkflowName: "poststorage",
 			},
@@ -533,7 +531,6 @@ func (s *ProcessingWorkflowTestSuite) TestPreprocessingDecisionFlow() {
 		ChildWorkflows: childwf.Configs{
 			{
 				Type:         enums.ChildWorkflowTypePreprocessing,
-				Namespace:    "default",
 				TaskQueue:    "preprocessing",
 				WorkflowName: "preprocessing",
 				Extract:      true,
@@ -662,7 +659,6 @@ func (s *ProcessingWorkflowTestSuite) TestFailedSIP() {
 		ChildWorkflows: childwf.Configs{
 			{
 				Type:         enums.ChildWorkflowTypePreprocessing,
-				Namespace:    "default",
 				TaskQueue:    "preprocessing",
 				WorkflowName: "preprocessing",
 				Extract:      true,


### PR DESCRIPTION
Remove the per child namespace setting so Enduro child workflows inherit their parent's namespace. Custom workers must connect to that namespace. Task queues remain independently configurable.

Temporal Server 1.30.1 deprecated cross-namespace Workflow commands and disabled them by default:
https://github.com/temporalio/temporal/releases/tag/v1.30.1

Go SDK 1.42.0 deprecated `ChildWorkflowOptions.Namespace`: https://github.com/temporalio/sdk-go/releases/tag/v1.42.0

Temporal's direction for cross-namespace coordination is Nexus: https://docs.temporal.io/nexus