### PR TITLE
Replace debug with log format

### DIFF
--- a/cmd/enduro-a3m-worker/main.go
+++ b/cmd/enduro-a3m-worker/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	logger := log.New(os.Stderr,
 		log.WithName(appName),
-		log.WithDebug(cfg.Debug),
+		log.WithFormat(cfg.LogFormat.LoggerFormat()),
 		log.WithLevel(cfg.Verbosity),
 	)
 	defer log.Sync(logger)

--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	logger := log.New(os.Stderr,
 		log.WithName(appName),
-		log.WithDebug(cfg.Debug),
+		log.WithFormat(cfg.LogFormat.LoggerFormat()),
 		log.WithLevel(cfg.Verbosity),
 	)
 	defer log.Sync(logger)

--- a/cmd/enduro/main.go
+++ b/cmd/enduro/main.go
@@ -85,7 +85,7 @@ func main() {
 
 	logger := log.New(os.Stderr,
 		log.WithName(appName),
-		log.WithDebug(cfg.Debug),
+		log.WithFormat(cfg.LogFormat.LoggerFormat()),
 		log.WithLevel(cfg.Verbosity),
 	)
 	defer log.Sync(logger)

--- a/docs/src/admin-manual/configuration.md
+++ b/docs/src/admin-manual/configuration.md
@@ -70,7 +70,7 @@ packages in the `internal` directory have configurable settings found here.
     CSV configuration file listing an allowed list of file-formats in a SIP when
     used for ingest validation.
 
-### Debug mode for development
+### Application logging
 
 The application log captures a record of discrete Enduro events to aid in
 diagnosing system errors and bugs. These settings control the format and
@@ -88,16 +88,14 @@ increase during development.
 **Example configuration**:
 
 ```toml
-debug = true
+logFormat = "text"
 debugListen = "127.0.0.1:9001"
 verbosity = 2
 ```
 
-* `debug`: Enables or disables debug mode. Accepted values are `true` or
-  `false`. When set to true, Enduro will log to the console using a
-  human-readable text output, and key elements are colorized (e.g. using red to
-  make ERROR more visible, etc). When set to false, logs are captured in JSON
-  format to support machine parsing and analysis.
+* `logFormat`: Controls the application log format. Accepted values are `text`
+  and `json`. The `text` format is human-readable and colorizes key elements,
+  while `json` supports machine parsing and analysis. The default is `json`.
 * `debugListen`: the IP and port to use if configuring an observability server.
 * `verbosity`: Sets the verbosity of the log output. Note that errors are
   **always** logged - this setting will control the verbosity of other log

--- a/docs/src/admin-manual/iac.md
+++ b/docs/src/admin-manual/iac.md
@@ -22,8 +22,6 @@ TOML format:
 [api]
 # TCP address for the server to listen on, in the form "host:port".
 listen = "0.0.0.0:9000"
-# Enable debug mode.
-debug = false
 # Allowed CORS origin URL.
 corsOrigin = "http://localhost"
 

--- a/docs/src/dev-manual/logging.md
+++ b/docs/src/dev-manual/logging.md
@@ -18,7 +18,8 @@ There are two configuration attributes that affect the application logger:
 # structured logs.
 logFormat = "text"
 
-# Show log messages up to V-level 2.
+# Show log messages up to verbosity level 2, where level 0 is the most
+# important and higher levels are less important.
 verbosity = 2
 ```
 

--- a/docs/src/dev-manual/logging.md
+++ b/docs/src/dev-manual/logging.md
@@ -14,14 +14,12 @@ design.
 There are two configuration attributes that affect the application logger:
 
 ```toml
-# When enabled, logs with V-levels greater than zero are shown (debug-y logs).
-# When disabled, only logs with V-level 0 are shown.
-# Note: v-level verbosity cannot be arbitrarily chosen, but can supported later.
-verbose = true
+# Use human-readable, colorized text logs. Use "json" for machine-readable
+# structured logs.
+logFormat = "text"
 
-# Use the color-enabled logging encoder.
-# Do not use in production, it disables JSON-encoded structured logging.
-debug = true
+# Show log messages up to V-level 2.
+verbosity = 2
 ```
 
 ## Usage

--- a/enduro.toml
+++ b/enduro.toml
@@ -11,7 +11,7 @@
 #                                                                       #
 #########################################################################
 
-debug = true
+logFormat = "text"
 debugListen = "127.0.0.1:9001"
 # verbosity supports values from 0-128, with 0 as least verbose and 128
 # capturing all possible log events.

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.artefactual.dev/amclient v0.4.1-0.20240705155055-0c5abef5207c
 	go.artefactual.dev/ssclient v0.11.0
-	go.artefactual.dev/tools v0.25.1
+	go.artefactual.dev/tools v0.26.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.63.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
@@ -212,6 +212,7 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1042,8 +1042,8 @@ go.artefactual.dev/amclient v0.4.1-0.20240705155055-0c5abef5207c h1:kMgKuV9yx0LT
 go.artefactual.dev/amclient v0.4.1-0.20240705155055-0c5abef5207c/go.mod h1:oAOlZHC78IWjWDCqRM1/8K1x/WYmRUL3peujKCdoXaA=
 go.artefactual.dev/ssclient v0.11.0 h1:mRjB8J0IQ+gjg6ICtZxJm+whG56tvIyxT+x4bO6CQGc=
 go.artefactual.dev/ssclient v0.11.0/go.mod h1:0tO5nOwQ8naw+GcPBi2A7lXzPt4HUn7MPXqQwi7H3jY=
-go.artefactual.dev/tools v0.25.1 h1:kpnaIyv+60ip0IdaY4V1S6B6A+NQzVOHS+CGubp/kWw=
-go.artefactual.dev/tools v0.25.1/go.mod h1:tW9DHZzeQO6H3Fjp0NCaRPqzGNLsDpDWELR4rssyels=
+go.artefactual.dev/tools v0.26.0 h1:OQR88tp4Sqw2ngID9F2mftRN7mgbIRRd97y2K9O919I=
+go.artefactual.dev/tools v0.26.0/go.mod h1:e6i94cr2i2ZI5fEc82WASYE3TXiJB/kM7Pi2e9vEni8=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 	"go.artefactual.dev/tools/bucket"
+	"go.artefactual.dev/tools/log"
 
 	"github.com/artefactual-sdps/enduro/internal/a3m"
 	"github.com/artefactual-sdps/enduro/internal/am"
@@ -47,16 +48,39 @@ type ConfigurationValidator interface {
 	Validate() error
 }
 
+type LogFormat string
+
+const (
+	LogFormatJSON LogFormat = "json"
+	LogFormatText LogFormat = "text"
+)
+
+func (f LogFormat) Validate() error {
+	switch f {
+	case LogFormatJSON, LogFormatText:
+		return nil
+	default:
+		return fmt.Errorf("LogFormat: unsupported value %q (use %q or %q)", f, LogFormatJSON, LogFormatText)
+	}
+}
+
+// LoggerFormat returns the corresponding application logger format.
+func (f LogFormat) LoggerFormat() log.Format {
+	switch f {
+	case LogFormatJSON:
+		return log.FormatJSON
+	case LogFormatText:
+		return log.FormatText
+	default:
+		panic(fmt.Sprintf("config: invalid log format %q", f))
+	}
+}
+
 type Configuration struct {
-	// Debug toggles the encoding of log messages to support different reader
-	// contexts.
-	//
-	// If Debug is true, the logger will output human readable logs with ANSI
-	// color codes. This is useful for debugging and development.
-	//
-	// If Debug is false the logger will output JSON formatted messages with no
-	// color codes. This is useful for data analysis and log aggregation.
-	Debug bool
+	// LogFormat controls the encoding of application log messages. Supported
+	// values are "json" for structured output and "text" for human-readable,
+	// colorized output.
+	LogFormat LogFormat
 
 	// DebugListen is the HTTP address of the observability server.
 	DebugListen string
@@ -92,6 +116,7 @@ type Configuration struct {
 
 func (c *Configuration) Validate() error {
 	return errors.Join(
+		c.LogFormat.Validate(),
 		c.A3m.Validate(),
 		c.API.Validate(),
 		c.InternalAPI.Validate(),
@@ -118,6 +143,7 @@ func Read(config *Configuration, configFile string) (found bool, configFileUsed 
 	v.SetDefault("api.listen", "127.0.0.1:9000")
 	v.SetDefault("bagitvalidator.poolSize", 1)
 	v.SetDefault("debugListen", "127.0.0.1:9001")
+	v.SetDefault("logFormat", LogFormatJSON)
 	v.SetDefault("preservation.taskqueue", temporal.A3mWorkerTaskQueue)
 	v.SetDefault("storage.taskqueue", temporal.GlobalTaskQueue)
 	v.SetDefault("temporal.taskqueue", temporal.GlobalTaskQueue)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,7 +35,6 @@ address = "host:port"
 [api]
 listen = "https://example.com:9000"
 CORSOrigin = "https://*.example.com"
-debug = true
 
 [api.log]
 path = "stdout"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/artefactual-sdps/temporal-activities/bagcreate"
 	"github.com/google/uuid"
 	"go.artefactual.dev/tools/clientauth"
+	"go.artefactual.dev/tools/log"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"
 
@@ -25,7 +26,7 @@ import (
 )
 
 const testConfig = `# Config
-debug = true
+logFormat = "text"
 debugListen = "127.0.0.1:9001"
 
 [temporal]
@@ -93,6 +94,13 @@ taskQueue = "poststorage"
 workflowName = "poststorage"
 `
 
+func TestLogFormatLoggerFormat(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, config.LogFormatJSON.LoggerFormat(), log.FormatJSON)
+	assert.Equal(t, config.LogFormatText.LoggerFormat(), log.FormatText)
+}
+
 func TestConfigRead(t *testing.T) {
 	t.Parallel()
 
@@ -107,7 +115,7 @@ func TestConfigRead(t *testing.T) {
 			name:   "Loads TOML configs",
 			config: testConfig,
 			want: config.Configuration{
-				Debug:       true,
+				LogFormat:   config.LogFormatText,
 				DebugListen: "127.0.0.1:9001",
 				A3m: a3m.Config{
 					Processing: a3m.ProcessingDefault,
@@ -216,6 +224,7 @@ func TestConfigRead(t *testing.T) {
 address = "storage-api:9000"
 defaultPermanentLocationId = "f2cc963f-c14d-4eaa-b950-bd207189a1f1"`,
 			want: config.Configuration{
+				LogFormat:   config.LogFormatJSON,
 				DebugListen: "127.0.0.1:9001",
 				A3m: a3m.Config{
 					Processing: a3m.ProcessingDefault,
@@ -265,9 +274,13 @@ defaultPermanentLocationId = "f2cc963f-c14d-4eaa-b950-bd207189a1f1"`,
 			},
 		},
 		{
-			name:    "Returns error if config is invalid",
-			config:  "debug = not-a-boolean",
-			wantErr: "failed to read configuration file: While parsing config: toml: expected 'nan'",
+			name: "Returns error if log format is invalid",
+			config: `logFormat = "invalid"
+
+[ingest.storage]
+address = "storage-api:9000"
+defaultPermanentLocationId = "f2cc963f-c14d-4eaa-b950-bd207189a1f1"`,
+			wantErr: `failed to validate the provided config: LogFormat: unsupported value "invalid" (use "json" or "text")`,
 		},
 		{
 			name: "Returns error if string to UUID hook fails",


### PR DESCRIPTION
Replace the top-level debug boolean with an explicit `logFormat` option, similar to the work done in 468eb9b87c9a3fa4265b8bf1cbcb52a9c41fc080. Accept text and JSON output formats and keep JSON as the runtime default.