### PR TITLE
Replace promise dialog dependency

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -26,8 +26,7 @@
         "pinia": "^3.0.4",
         "ts-debounce": "^4.0.0",
         "vue": "^3.5.31",
-        "vue-router": "^5.0.4",
-        "vue3-promise-dialog": "^0.3.4"
+        "vue-router": "^5.0.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -10117,14 +10116,6 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
-      }
-    },
-    "node_modules/vue3-promise-dialog": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/vue3-promise-dialog/-/vue3-promise-dialog-0.3.4.tgz",
-      "integrity": "sha512-JquYYE+1lxuGgncD8Q+8KTFAWUJsNWnhuYPSsOFRKzz3kz66Rjz5pdlEW6GLfUlV3cKak9T8b3mV49B4ouEgVg==",
-      "peerDependencies": {
-        "vue": "^3.x"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -45,8 +45,7 @@
     "pinia": "^3.0.4",
     "ts-debounce": "^4.0.0",
     "vue": "^3.5.31",
-    "vue-router": "^5.0.4",
-    "vue3-promise-dialog": "^0.3.4"
+    "vue-router": "^5.0.4"
   },
   "overrides": {
     "minimatch": "10.2.5",

--- a/dashboard/src/App.spec.ts
+++ b/dashboard/src/App.spec.ts
@@ -1,0 +1,66 @@
+import { createTestingPinia } from "@pinia/testing";
+import { render } from "@testing-library/vue";
+import { User } from "oidc-client-ts";
+import { describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+
+import App from "@/App.vue";
+import AboutDialog from "@/components/AboutDialog.vue";
+import { openDialog } from "@/dialogs/dialog";
+import { useAuthStore } from "@/stores/auth";
+
+function createValidUser() {
+  return new User({
+    access_token: "",
+    token_type: "",
+    profile: { aud: "", exp: 0, iat: 0, iss: "", sub: "" },
+    expires_at: Date.now() / 1000 + 60,
+  });
+}
+
+describe("App.vue", () => {
+  it("tears down an open dialog when the user session expires", async () => {
+    const { findByRole, queryByRole } = render(App, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              auth: {
+                config: { enabled: true },
+                user: createValidUser(),
+              },
+            },
+          }),
+        ],
+        stubs: {
+          Header: true,
+          RouterView: true,
+          Sidebar: true,
+        },
+      },
+    });
+    const authStore = useAuthStore();
+
+    const result = openDialog(AboutDialog);
+    await findByRole("dialog", { name: "Enduro" });
+
+    expect(document.body.classList.contains("modal-open")).toBe(true);
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(document.querySelector(".modal-backdrop")).not.toBeNull();
+
+    authStore.$patch({ user: null });
+    await nextTick();
+
+    await expect(result).resolves.toBeUndefined();
+    expect(queryByRole("dialog", { name: "Enduro" })).toBeNull();
+    expect(document.body.classList.contains("modal-open")).toBe(false);
+    expect(document.body.style.overflow).toBe("");
+    expect(document.querySelector(".modal-backdrop")).toBeNull();
+
+    authStore.user = createValidUser();
+    await nextTick();
+
+    expect(queryByRole("dialog", { name: "Enduro" })).toBeNull();
+  });
+});

--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import Modal from "bootstrap/js/dist/modal";
 import { watch } from "vue";
-import { DialogWrapper } from "vue3-promise-dialog";
 
 import Header from "@/components/Header.vue";
 import Sidebar from "@/components/Sidebar.vue";
+import DialogHost from "@/dialogs/DialogHost.vue";
 import { useAuthStore } from "@/stores/auth";
 import { useIngestMonitorStore } from "@/stores/ingestMonitor";
 import { useStorageMonitorStore } from "@/stores/storageMonitor";
@@ -56,6 +56,8 @@ watch(
         <RouterView />
       </main>
     </div>
-    <DialogWrapper v-if="authStore.isUserValid" />
+    <!-- Scope dialogs to valid sessions. Unmounting the host resolves an active
+         dialog with undefined. -->
+    <DialogHost v-if="authStore.isUserValid" />
   </div>
 </template>

--- a/dashboard/src/components/AboutDialog.spec.ts
+++ b/dashboard/src/components/AboutDialog.spec.ts
@@ -4,19 +4,19 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import AboutDialog from "@/components/AboutDialog.vue";
 import { EnduroChildworkflowTypeEnum } from "@/openapi-generator";
-import { useAuthStore } from "@/stores/auth";
+import { useAboutStore } from "@/stores/about";
 
-const closeDialogMock = vi.hoisted(() => vi.fn());
 const showMock = vi.hoisted(() => vi.fn());
+const hideMock = vi.hoisted(() => vi.fn());
+const disposeMock = vi.hoisted(() => vi.fn());
 
-vi.mock("vue3-promise-dialog", () => ({ closeDialog: closeDialogMock }));
-vi.mock("bootstrap/js/dist/modal", () => {
-  return {
-    default: class ModalMock {
-      show = showMock;
-    },
-  };
-});
+vi.mock("bootstrap/js/dist/modal", () => ({
+  default: class {
+    show = showMock;
+    hide = hideMock;
+    dispose = disposeMock;
+  },
+}));
 
 function renderDialog(initialState: Record<string, unknown> = {}) {
   return render(AboutDialog, {
@@ -24,13 +24,7 @@ function renderDialog(initialState: Record<string, unknown> = {}) {
       plugins: [
         createTestingPinia({
           createSpy: vi.fn,
-          initialState: {
-            auth: {
-              config: { enabled: true },
-              user: { expired: false },
-            },
-            ...initialState,
-          },
+          initialState,
         }),
       ],
     },
@@ -43,30 +37,18 @@ describe("AboutDialog.vue", () => {
     vi.resetAllMocks();
   });
 
-  it("shows the modal on mount", () => {
-    renderDialog();
+  it("loads application information and resolves when hidden", async () => {
+    const { emitted, getByRole } = renderDialog();
 
     expect(showMock).toHaveBeenCalledOnce();
-  });
+    expect(useAboutStore().load).toHaveBeenCalledOnce();
 
-  it("closes the dialog when the Bootstrap modal is hidden", async () => {
-    const { getByRole } = renderDialog();
+    await fireEvent(
+      getByRole("dialog", { name: "Enduro" }),
+      new Event("hidden.bs.modal"),
+    );
 
-    const modalEl = getByRole("dialog", { name: "Enduro" });
-    await fireEvent(modalEl, new Event("hidden.bs.modal"));
-
-    expect(closeDialogMock).toHaveBeenCalledWith(null);
-  });
-
-  it("closes the dialog immediately when the user session expires", async () => {
-    renderDialog();
-
-    const authStore = useAuthStore();
-    authStore.$patch({ user: null });
-
-    await vi.waitFor(() => {
-      expect(closeDialogMock).toHaveBeenCalledWith(null);
-    });
+    expect(emitted().resolve).toEqual([[]]);
   });
 
   it("does not show child workflows when none are configured", () => {

--- a/dashboard/src/components/AboutDialog.vue
+++ b/dashboard/src/components/AboutDialog.vue
@@ -1,47 +1,32 @@
 <script setup lang="ts">
-import Modal from "bootstrap/js/dist/modal";
-import { onMounted, ref, watch } from "vue";
-import { closeDialog } from "vue3-promise-dialog";
+import { onMounted } from "vue";
 
 import IconDocumentation from "~icons/lucide/book-text";
 import IconLicense from "~icons/lucide/file-text";
 import IconContributing from "~icons/lucide/git-merge";
 
-import useEventListener from "@/composables/useEventListener";
+import useDialog from "@/dialogs/useDialog";
 import { useAboutStore } from "@/stores/about";
-import { useAuthStore } from "@/stores/auth";
+
+const emit = defineEmits<{
+  resolve: [];
+}>();
 
 const aboutStore = useAboutStore();
-const authStore = useAuthStore();
 
-const el = ref<HTMLElement | null>(null);
-const modal = ref<Modal | null>(null);
 const titleId = "about-dialog-title";
 const bodyId = "about-dialog-body";
 
-onMounted(() => {
-  if (!el.value) return;
-  modal.value = new Modal(el.value);
-  modal.value.show();
+const { element } = useDialog(emit);
 
+onMounted(() => {
   aboutStore.load();
 });
-
-useEventListener(el, "hidden.bs.modal", () => closeDialog(null));
-
-watch(
-  () => authStore.isUserValid,
-  (valid) => {
-    if (!valid) {
-      closeDialog(null);
-    }
-  },
-);
 </script>
 
 <template>
   <div
-    ref="el"
+    ref="element"
     class="modal"
     tabindex="-1"
     role="dialog"

--- a/dashboard/src/components/AipDeletionRequestDialog.spec.ts
+++ b/dashboard/src/components/AipDeletionRequestDialog.spec.ts
@@ -1,0 +1,67 @@
+import { createTestingPinia } from "@pinia/testing";
+import { cleanup, fireEvent, render } from "@testing-library/vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import AipDeletionRequestDialog from "@/components/AipDeletionRequestDialog.vue";
+
+const showMock = vi.hoisted(() => vi.fn());
+const hideMock = vi.hoisted(() => vi.fn());
+const disposeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("bootstrap/js/dist/modal", () => ({
+  default: class {
+    show = showMock;
+    hide = hideMock;
+    dispose = disposeMock;
+  },
+}));
+
+const renderDialog = () =>
+  render(AipDeletionRequestDialog, {
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            aip: { current: { name: "Test AIP" } },
+          },
+        }),
+      ],
+    },
+  });
+
+describe("AipDeletionRequestDialog.vue", () => {
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+
+  it("resolves the deletion reason after submission", async () => {
+    const { emitted, getByRole } = renderDialog();
+
+    await fireEvent.update(
+      getByRole("textbox", { name: "Reason:" }),
+      "No longer required",
+    );
+    await fireEvent.click(getByRole("button", { name: "Request deletion" }));
+    expect(hideMock).toHaveBeenCalledOnce();
+
+    await fireEvent(
+      getByRole("dialog", { name: "Delete AIP" }),
+      new Event("hidden.bs.modal"),
+    );
+
+    expect(emitted().resolve).toEqual([["No longer required"]]);
+  });
+
+  it("resolves null when cancelled", async () => {
+    const { emitted, getByRole } = renderDialog();
+
+    await fireEvent(
+      getByRole("dialog", { name: "Delete AIP" }),
+      new Event("hidden.bs.modal"),
+    );
+
+    expect(emitted().resolve).toEqual([[null]]);
+  });
+});

--- a/dashboard/src/components/AipDeletionRequestDialog.vue
+++ b/dashboard/src/components/AipDeletionRequestDialog.vue
@@ -1,44 +1,27 @@
 <script setup lang="ts">
-import Modal from "bootstrap/js/dist/modal";
-import { onMounted, ref } from "vue";
-import { closeDialog } from "vue3-promise-dialog";
+import { ref } from "vue";
 
-import useEventListener from "@/composables/useEventListener";
+import useDialog from "@/dialogs/useDialog";
 import { useAipStore } from "@/stores/aip";
+
+const emit = defineEmits<{
+  resolve: [reason: string | null];
+}>();
 
 const aipStore = useAipStore();
 
-const el = ref<HTMLElement | null>(null);
-const modal = ref<Modal | null>(null);
-const reason = ref<string>("");
-const submit = ref<boolean>(false);
+const reason = ref("");
 const titleId = "aip-deletion-request-dialog-title";
 const bodyId = "aip-deletion-request-dialog-body";
 
-onMounted(() => {
-  if (!el.value) return;
-  modal.value = new Modal(el.value);
-  modal.value.show();
-});
+const { element, close } = useDialog(emit, null);
 
-useEventListener(el, "hidden.bs.modal", () => {
-  if (submit.value) {
-    closeDialog(reason.value);
-  } else {
-    closeDialog(null);
-  }
-  submit.value = false;
-});
-
-const request = () => {
-  submit.value = true;
-  modal.value?.hide();
-};
+const request = () => close(reason.value);
 </script>
 
 <template>
   <div
-    ref="el"
+    ref="element"
     class="modal"
     tabindex="-1"
     role="dialog"

--- a/dashboard/src/components/AipLocationCard.spec.ts
+++ b/dashboard/src/components/AipLocationCard.spec.ts
@@ -1,13 +1,43 @@
 import { createTestingPinia } from "@pinia/testing";
-import { cleanup, render } from "@testing-library/vue";
+import { cleanup, fireEvent, render } from "@testing-library/vue";
+import { flushPromises } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { api } from "@/client";
+import AipDeletionRequestDialog from "@/components/AipDeletionRequestDialog.vue";
 import AipLocationCard from "@/components/AipLocationCard.vue";
 import { useAipStore } from "@/stores/aip";
 
+const openDialogMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/dialogs/dialog", () => ({
+  openDialog: openDialogMock,
+}));
+
+const renderStoredAip = () =>
+  render(AipLocationCard, {
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            aip: {
+              current: {
+                status: api.EnduroStorageAipStatusEnum.Stored,
+                locationUuid: "f8635e46-a320-4152-9a2c-98a28eeb50d1",
+              } as api.EnduroStorageAip,
+            },
+          },
+        }),
+      ],
+    },
+  });
+
 describe("AipLocationCard.vue", () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
 
   it("renders when the AIP is stored", async () => {
     const { html } = render(AipLocationCard, {
@@ -97,6 +127,30 @@ describe("AipLocationCard.vue", () => {
       </div>
       </div>"
     `);
+  });
+
+  it("requests deletion with the reason from the dialog", async () => {
+    openDialogMock.mockResolvedValue("No longer required");
+    const { getByRole } = renderStoredAip();
+    const aipStore = useAipStore();
+
+    await fireEvent.click(getByRole("button", { name: "Delete" }));
+    await flushPromises();
+
+    expect(openDialogMock).toHaveBeenCalledWith(AipDeletionRequestDialog);
+    expect(aipStore.requestDeletion).toHaveBeenCalledWith("No longer required");
+  });
+
+  it("does not request deletion when the dialog is cancelled", async () => {
+    openDialogMock.mockResolvedValue(null);
+    const { getByRole } = renderStoredAip();
+    const aipStore = useAipStore();
+
+    await fireEvent.click(getByRole("button", { name: "Delete" }));
+    await flushPromises();
+
+    expect(openDialogMock).toHaveBeenCalledWith(AipDeletionRequestDialog);
+    expect(aipStore.requestDeletion).not.toHaveBeenCalled();
   });
 
   it("renders when the AIP location is moved", async () => {

--- a/dashboard/src/components/AipLocationCard.vue
+++ b/dashboard/src/components/AipLocationCard.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { openDialog } from "vue3-promise-dialog";
 
 import AipDeletionRequestDialog from "@/components/AipDeletionRequestDialog.vue";
 import LocationDialog from "@/components/LocationDialog.vue";
 import UUID from "@/components/UUID.vue";
+import { openDialog } from "@/dialogs/dialog";
 import { useAipStore } from "@/stores/aip";
 import { useAuthStore } from "@/stores/auth";
 

--- a/dashboard/src/components/BatchReviewAlert.spec.ts
+++ b/dashboard/src/components/BatchReviewAlert.spec.ts
@@ -4,10 +4,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { api } from "@/client";
 import BatchReviewAlert from "@/components/BatchReviewAlert.vue";
+import BatchReviewConfirmDialog from "@/components/BatchReviewConfirmDialog.vue";
 import { useBatchStore } from "@/stores/batch";
 
 const openDialogMock = vi.hoisted(() => vi.fn());
-vi.mock("vue3-promise-dialog", () => ({ openDialog: openDialogMock }));
+vi.mock("@/dialogs/dialog", () => ({
+  openDialog: openDialogMock,
+}));
 
 describe("BatchReviewAlert.vue", () => {
   afterEach(() => {
@@ -63,9 +66,17 @@ describe("BatchReviewAlert.vue", () => {
     await fireEvent.click(
       getByRole("button", { name: "Continue partial ingest" }),
     );
+    expect(openDialogMock).toHaveBeenLastCalledWith(
+      BatchReviewConfirmDialog,
+      expect.objectContaining({ heading: "Continue partial ingest" }),
+    );
     expect(batchStore.reviewBatch).toHaveBeenCalledWith(true);
 
     await fireEvent.click(getByRole("button", { name: "Cancel batch" }));
+    expect(openDialogMock).toHaveBeenLastCalledWith(
+      BatchReviewConfirmDialog,
+      expect.objectContaining({ heading: "Cancel batch" }),
+    );
     expect(batchStore.reviewBatch).toHaveBeenCalledWith(false);
   });
 

--- a/dashboard/src/components/BatchReviewAlert.vue
+++ b/dashboard/src/components/BatchReviewAlert.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import { openDialog } from "vue3-promise-dialog";
-
 import IconContinue from "~icons/clarity/thumbs-up-line";
 import IconCancel from "~icons/clarity/trash-line";
 
 import BatchReviewConfirmDialog from "@/components/BatchReviewConfirmDialog.vue";
+import { openDialog } from "@/dialogs/dialog";
 import { useAuthStore } from "@/stores/auth";
 import { useBatchStore } from "@/stores/batch";
 

--- a/dashboard/src/components/BatchReviewConfirmDialog.spec.ts
+++ b/dashboard/src/components/BatchReviewConfirmDialog.spec.ts
@@ -3,16 +3,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import BatchReviewConfirmDialog from "@/components/BatchReviewConfirmDialog.vue";
 
-const closeDialogMock = vi.hoisted(() => vi.fn());
 const showMock = vi.hoisted(() => vi.fn());
 const hideMock = vi.hoisted(() => vi.fn());
+const disposeMock = vi.hoisted(() => vi.fn());
 
-vi.mock("vue3-promise-dialog", () => ({ closeDialog: closeDialogMock }));
 vi.mock("bootstrap/js/dist/modal", () => {
   return {
     default: class ModalMock {
       show = showMock;
       hide = hideMock;
+      dispose = disposeMock;
     },
   };
 });
@@ -24,7 +24,7 @@ describe("BatchReviewConfirmDialog.vue", () => {
   });
 
   it("renders the dialog and confirms", async () => {
-    const { getByRole, getByText } = render(BatchReviewConfirmDialog, {
+    const { emitted, getByRole, getByText } = render(BatchReviewConfirmDialog, {
       props: {
         heading: "Cancel batch",
         bodyHtml: "<p>Are you sure you want to cancel?</p>",
@@ -47,11 +47,11 @@ describe("BatchReviewConfirmDialog.vue", () => {
     const modalEl = getByRole("dialog", { name: "Cancel batch" });
     await fireEvent(modalEl, new Event("hidden.bs.modal"));
 
-    expect(closeDialogMock).toHaveBeenCalledWith(true);
+    expect(emitted().resolve).toEqual([[true]]);
   });
 
   it("closes without confirmation", async () => {
-    const { getByRole, getByText } = render(BatchReviewConfirmDialog, {
+    const { emitted, getByRole, getByText } = render(BatchReviewConfirmDialog, {
       props: {
         heading: "Continue partial ingest",
         bodyHtml: "<p>Are you sure you want to continue processing?</p>",
@@ -74,6 +74,6 @@ describe("BatchReviewConfirmDialog.vue", () => {
     const modalEl = getByRole("dialog", { name: "Continue partial ingest" });
     await fireEvent(modalEl, new Event("hidden.bs.modal"));
 
-    expect(closeDialogMock).toHaveBeenCalledWith(false);
+    expect(emitted().resolve).toEqual([[false]]);
   });
 });

--- a/dashboard/src/components/BatchReviewConfirmDialog.vue
+++ b/dashboard/src/components/BatchReviewConfirmDialog.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
-import Modal from "bootstrap/js/dist/modal";
-import { onMounted, ref } from "vue";
-import { closeDialog } from "vue3-promise-dialog";
-
 import SafeHtml from "@/components/SafeHtml.vue";
-import useEventListener from "@/composables/useEventListener";
+import useDialog from "@/dialogs/useDialog";
 
 defineProps<{
   heading: string;
@@ -12,32 +8,19 @@ defineProps<{
   confirmClass: "btn-primary" | "btn-danger";
 }>();
 
-const el = ref<HTMLElement | null>(null);
-const modal = ref<Modal | null>(null);
-const confirmed = ref(false);
+const emit = defineEmits<{
+  resolve: [confirmed: boolean];
+}>();
+
 const titleId = "batch-review-confirm-dialog-title";
 const bodyId = "batch-review-confirm-dialog-body";
 
-onMounted(() => {
-  if (!el.value) return;
-  modal.value = new Modal(el.value);
-  modal.value.show();
-});
-
-useEventListener(el, "hidden.bs.modal", () => {
-  closeDialog(confirmed.value);
-  confirmed.value = false;
-});
-
-const confirm = (value: boolean) => {
-  confirmed.value = value;
-  modal.value?.hide();
-};
+const { element, close } = useDialog(emit, false);
 </script>
 
 <template>
   <div
-    ref="el"
+    ref="element"
     class="modal"
     tabindex="-1"
     role="dialog"
@@ -53,7 +36,7 @@ const confirm = (value: boolean) => {
             type="button"
             class="btn-close"
             aria-label="Close"
-            @click="confirm(false)"
+            @click="close(false)"
           ></button>
         </div>
         <div :id="bodyId" class="modal-body">
@@ -63,15 +46,11 @@ const confirm = (value: boolean) => {
           <button
             type="button"
             :class="['btn', confirmClass]"
-            @click="confirm(true)"
+            @click="close(true)"
           >
             Yes
           </button>
-          <button
-            type="button"
-            class="btn btn-secondary"
-            @click="confirm(false)"
-          >
+          <button type="button" class="btn btn-secondary" @click="close(false)">
             No
           </button>
         </div>

--- a/dashboard/src/components/Header.spec.ts
+++ b/dashboard/src/components/Header.spec.ts
@@ -3,8 +3,14 @@ import { cleanup, fireEvent, render } from "@testing-library/vue";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createRouter, createWebHistory } from "vue-router";
 
+import AboutDialog from "@/components/AboutDialog.vue";
 import Header from "@/components/Header.vue";
 import { useLayoutStore } from "@/stores/layout";
+
+const openDialogMock = vi.hoisted(() => vi.fn());
+vi.mock("@/dialogs/dialog", () => ({
+  openDialog: openDialogMock,
+}));
 
 const router = createRouter({
   history: createWebHistory(),
@@ -12,7 +18,10 @@ const router = createRouter({
 });
 
 describe("Header.vue", () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
 
   it("collapses and expands the sidebar", async () => {
     const { getByRole } = render(Header, {
@@ -65,5 +74,18 @@ describe("Header.vue", () => {
     });
 
     getByRole("navigation", { name: "Breadcrumb" });
+  });
+
+  it("opens the About dialog from its button", async () => {
+    openDialogMock.mockResolvedValue(undefined);
+    const { getByRole } = render(Header, {
+      global: {
+        plugins: [createTestingPinia({ createSpy: vi.fn }), router],
+      },
+    });
+
+    await fireEvent.click(getByRole("button", { name: "About Enduro" }));
+
+    expect(openDialogMock).toHaveBeenCalledWith(AboutDialog);
   });
 });

--- a/dashboard/src/components/Header.vue
+++ b/dashboard/src/components/Header.vue
@@ -1,17 +1,16 @@
 <script setup lang="ts">
-import { openDialog } from "vue3-promise-dialog";
-
 import IconInfo from "~icons/clarity/info-standard-solid";
 import IconMenu from "~icons/clarity/menu-line";
 
-import AboutDialogVue from "@/components/AboutDialog.vue";
+import AboutDialog from "@/components/AboutDialog.vue";
 import Breadcrumb from "@/components/Breadcrumb.vue";
 import InstitutionLogo from "@/components/InstitutionLogo.vue";
+import { openDialog } from "@/dialogs/dialog";
 import { useLayoutStore } from "@/stores/layout";
 
 const layoutStore = useLayoutStore();
 
-const showAbout = async () => await openDialog(AboutDialogVue);
+const showAbout = () => openDialog(AboutDialog);
 
 const institution: { logo: string; name: string; url: string } = {
   logo: import.meta.env.VITE_INSTITUTION_LOGO,
@@ -71,12 +70,9 @@ const institution: { logo: string; name: string; url: string } = {
         type="button"
         class="btn btn-link text-decoration-none p-3"
         aria-label="About Enduro"
+        @click="showAbout"
       >
-        <IconInfo
-          class="text-primary fs-4 mx-1"
-          aria-hidden="true"
-          @click="showAbout"
-        />
+        <IconInfo class="text-primary fs-4 mx-1" aria-hidden="true" />
       </button>
     </nav>
   </header>

--- a/dashboard/src/components/LocationDialog.spec.ts
+++ b/dashboard/src/components/LocationDialog.spec.ts
@@ -5,13 +5,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import LocationDialog from "@/components/LocationDialog.vue";
 import { useLocationStore } from "@/stores/location";
 
+const showMock = vi.hoisted(() => vi.fn());
+const hideMock = vi.hoisted(() => vi.fn());
+const disposeMock = vi.hoisted(() => vi.fn());
+
 vi.mock("bootstrap/js/dist/modal", () => ({
   default: class {
-    show() {}
+    show = showMock;
+    hide = hideMock;
+    dispose = disposeMock;
   },
 }));
-
-vi.mock("vue3-promise-dialog", () => ({ closeDialog: vi.fn() }));
 
 describe("LocationDialog.vue", () => {
   afterEach(() => vi.clearAllMocks());
@@ -24,5 +28,31 @@ describe("LocationDialog.vue", () => {
     const reset = vi.spyOn(useLocationStore(), "$reset");
     wrapper.unmount();
     expect(reset).toHaveBeenCalledOnce();
+  });
+
+  it("resolves the selected location after closing", async () => {
+    const wrapper = mount(LocationDialog, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              location: {
+                locations: [{ name: "Location 1", uuid: "location-1" }],
+              },
+            },
+          }),
+        ],
+      },
+    });
+
+    await wrapper.get("button.btn-primary").trigger("click");
+    expect(hideMock).toHaveBeenCalledOnce();
+
+    wrapper
+      .get('[role="dialog"]')
+      .element.dispatchEvent(new Event("hidden.bs.modal"));
+
+    expect(wrapper.emitted("resolve")).toEqual([["location-1"]]);
   });
 });

--- a/dashboard/src/components/LocationDialog.vue
+++ b/dashboard/src/components/LocationDialog.vue
@@ -1,39 +1,28 @@
 <script setup lang="ts">
-import Modal from "bootstrap/js/dist/modal";
-import { onMounted, onUnmounted, ref } from "vue";
-import { closeDialog } from "vue3-promise-dialog";
+import { onUnmounted } from "vue";
 
-import useEventListener from "@/composables/useEventListener";
+import useDialog from "@/dialogs/useDialog";
 import { useLocationStore } from "@/stores/location";
 
-const props = defineProps({
-  currentLocationId: { type: String, required: false, default: undefined },
-});
+const props = defineProps<{
+  currentLocationId?: string;
+}>();
+
+const emit = defineEmits<{
+  resolve: [locationId: string | null];
+}>();
 
 const locationStore = useLocationStore();
 locationStore.fetchLocations();
 
-const el = ref<HTMLElement | null>(null);
-const modal = ref<Modal | null>(null);
 const titleId = "location-dialog-title";
 const bodyId = "location-dialog-body";
 
-onMounted(() => {
-  if (!el.value) return;
-  modal.value = new Modal(el.value);
-  modal.value.show();
-});
-
-let data: string | null = null;
-
-useEventListener(el, "hidden.bs.modal", () => {
-  closeDialog(data);
-});
+const { element, close } = useDialog(emit, null);
 
 const onChoose = (locationId: string) => {
   if (locationId === props.currentLocationId) return;
-  data = locationId;
-  modal.value?.hide();
+  close(locationId);
 };
 
 onUnmounted(() => {
@@ -43,7 +32,7 @@ onUnmounted(() => {
 
 <template>
   <div
-    ref="el"
+    ref="element"
     class="modal"
     tabindex="-1"
     role="dialog"

--- a/dashboard/src/components/SipReviewAlert.spec.ts
+++ b/dashboard/src/components/SipReviewAlert.spec.ts
@@ -1,11 +1,37 @@
 import { createTestingPinia } from "@pinia/testing";
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { api } from "@/client";
+import LocationDialog from "@/components/LocationDialog.vue";
 import SipReviewAlert from "@/components/SipReviewAlert.vue";
 import { useAipStore } from "@/stores/aip";
+import { useSipStore } from "@/stores/sip";
 
-vi.mock("vue3-promise-dialog", () => ({ openDialog: vi.fn() }));
+const openDialogMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/dialogs/dialog", () => ({
+  openDialog: openDialogMock,
+}));
+
+const mountPendingAlert = () =>
+  mount(SipReviewAlert, {
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            sip: {
+              current: {
+                status: api.EnduroIngestSipStatusEnum.Pending,
+                uuid: "sip-1",
+              },
+            },
+          },
+        }),
+      ],
+    },
+  });
 
 describe("SipReviewAlert.vue", () => {
   afterEach(() => vi.clearAllMocks());
@@ -21,18 +47,33 @@ describe("SipReviewAlert.vue", () => {
   });
 
   it("does not offer the obsolete task expansion action", () => {
-    const wrapper = mount(SipReviewAlert, {
-      global: {
-        plugins: [
-          createTestingPinia({
-            createSpy: vi.fn,
-            initialState: { sip: { current: { status: "pending" } } },
-          }),
-        ],
-      },
-    });
+    const wrapper = mountPendingAlert();
 
     expect(wrapper.text()).toContain("Task: Review AIP");
     expect(wrapper.text()).not.toContain("Expand");
+  });
+
+  it("confirms the SIP with the selected location", async () => {
+    openDialogMock.mockResolvedValue("location-1");
+    const wrapper = mountPendingAlert();
+    const sipStore = useSipStore();
+
+    await wrapper.get("button.btn-success").trigger("click");
+    await flushPromises();
+
+    expect(openDialogMock).toHaveBeenCalledWith(LocationDialog);
+    expect(sipStore.confirm).toHaveBeenCalledWith("location-1");
+  });
+
+  it("does not confirm the SIP when location selection is cancelled", async () => {
+    openDialogMock.mockResolvedValue(null);
+    const wrapper = mountPendingAlert();
+    const sipStore = useSipStore();
+
+    await wrapper.get("button.btn-success").trigger("click");
+    await flushPromises();
+
+    expect(openDialogMock).toHaveBeenCalledWith(LocationDialog);
+    expect(sipStore.confirm).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/src/components/SipReviewAlert.vue
+++ b/dashboard/src/components/SipReviewAlert.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { onUnmounted } from "vue";
-import { openDialog } from "vue3-promise-dialog";
 
 import LocationDialog from "@/components/LocationDialog.vue";
+import { openDialog } from "@/dialogs/dialog";
 import { useAipStore } from "@/stores/aip";
 import { useSipStore } from "@/stores/sip";
 

--- a/dashboard/src/dialogs/DialogHost.spec.ts
+++ b/dashboard/src/dialogs/DialogHost.spec.ts
@@ -1,0 +1,67 @@
+import { fireEvent, render } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+import { defineComponent, h } from "vue";
+
+import DialogHost from "@/dialogs/DialogHost.vue";
+import { DialogAlreadyOpenError, openDialog } from "@/dialogs/dialog";
+
+const testDialogComponent = defineComponent({
+  props: {
+    message: { type: String, required: true },
+  },
+  emits: {
+    resolve: (value: string) => typeof value === "string",
+  },
+  setup(props, { emit }) {
+    return () =>
+      h(
+        "button",
+        { onClick: () => emit("resolve", props.message) },
+        props.message,
+      );
+  },
+});
+
+describe("DialogHost.vue", () => {
+  it("renders a dialog and resolves its result", async () => {
+    const { findByRole } = render(DialogHost);
+
+    const result = openDialog(testDialogComponent, {
+      message: "Dialog result",
+    });
+    await fireEvent.click(
+      await findByRole("button", { name: "Dialog result" }),
+    );
+
+    await expect(result).resolves.toBe("Dialog result");
+  });
+
+  it("rejects a second dialog while one is active", async () => {
+    const { findByRole } = render(DialogHost);
+
+    const result = openDialog(testDialogComponent, {
+      message: "First dialog",
+    });
+    await expect(
+      openDialog(testDialogComponent, {
+        message: "Second dialog",
+      }),
+    ).rejects.toBeInstanceOf(DialogAlreadyOpenError);
+
+    await fireEvent.click(await findByRole("button", { name: "First dialog" }));
+    await expect(result).resolves.toBe("First dialog");
+  });
+
+  it("resolves with cancellation when the host is unmounted", async () => {
+    const { findByRole, unmount } = render(DialogHost);
+
+    const result = openDialog(testDialogComponent, {
+      message: "Active dialog",
+    });
+    await findByRole("button", { name: "Active dialog" });
+
+    unmount();
+
+    await expect(result).resolves.toBeUndefined();
+  });
+});

--- a/dashboard/src/dialogs/DialogHost.vue
+++ b/dashboard/src/dialogs/DialogHost.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import DialogInstance from "@/dialogs/DialogInstance.vue";
+import { dialogTemplate } from "@/dialogs/dialog";
+</script>
+
+<template>
+  <Component :is="dialogTemplate" v-slot="{ args, resolve }">
+    <DialogInstance :request="args[0]" :resolve="resolve" />
+  </Component>
+</template>

--- a/dashboard/src/dialogs/DialogInstance.vue
+++ b/dashboard/src/dialogs/DialogInstance.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { onBeforeUnmount } from "vue";
+
+import type { DialogRequest } from "@/dialogs/dialog";
+
+const props = defineProps<{
+  request: DialogRequest;
+  resolve: (value: unknown) => void;
+}>();
+
+// Resolving removes this instance and runs its unmount hook too. The guard
+// keeps a normal result from being replaced by forced cancellation.
+let settled = false;
+
+const settle = (value: unknown) => {
+  if (settled) return;
+
+  settled = true;
+  props.resolve(value);
+};
+
+// Host teardown, such as an invalidated login, must not leave callers waiting
+// on a promise that can no longer be completed by the dialog component.
+onBeforeUnmount(() => {
+  settle(undefined);
+});
+</script>
+
+<template>
+  <Component :is="request.component" v-bind="request.props" @resolve="settle" />
+</template>

--- a/dashboard/src/dialogs/README.md
+++ b/dashboard/src/dialogs/README.md
@@ -1,0 +1,185 @@
+# Promise dialogs
+
+The dashboard treats a dialog as an asynchronous question:
+
+```ts
+const confirmed = await openDialog(ConfirmDialog, {
+  heading: "Continue?",
+});
+
+if (!confirmed) return;
+```
+
+This keeps the business flow in the component that needs the answer without
+making that component own modal visibility, global placement, or Bootstrap
+cleanup.
+
+Concrete dialogs remain regular application components in
+[`components`](../components). The files in this directory provide only the
+shared machinery needed to open those components as promises.
+
+There is no dialog registry and there are no named opener wrappers. Callers
+pass the concrete component directly to `openDialog`. Vue's generated component
+types let `openDialog` infer the component's props and the value carried by its
+typed `resolve` event.
+
+## Architecture
+
+- [`dialog.ts`](dialog.ts) exposes `openDialog`, holds the pending request, and
+  rejects attempts to open overlapping dialogs.
+- [`DialogHost.vue`](DialogHost.vue) renders a pending request at the
+  application root.
+- [`DialogInstance.vue`](DialogInstance.vue) connects the component's `resolve`
+  event to the pending promise. If the host is removed, it resolves with
+  `undefined`.
+- [`useDialog.ts`](useDialog.ts) carries the chosen result through Bootstrap's
+  hide lifecycle and owns the modal instance.
+
+[`App.vue`](../App.vue) mounts one `DialogHost` while the user session is valid.
+When a session expires, removing the host cancels the pending request and
+unmounts its component. The component's Bootstrap lifecycle hook hides the
+modal before disposal, removing its backdrop and restoring document scrolling.
+
+The request flow is:
+
+1. A caller passes a component and optional props to `openDialog`.
+2. `DialogHost` renders that component through `DialogInstance`.
+3. The component asks Bootstrap to hide when the user finishes interacting.
+4. Bootstrap emits `hidden.bs.modal` after restoring the document.
+5. The component emits `resolve`, and `DialogInstance` settles the promise.
+
+Only one dialog may be active. Opening another before the first settles rejects
+with `DialogAlreadyOpenError`. This avoids callers sharing results or stacking
+Bootstrap modals and backdrops.
+
+## Opening a dialog
+
+Import the component and `openDialog`:
+
+```ts
+import AboutDialog from "@/components/AboutDialog.vue";
+import { openDialog } from "@/dialogs/dialog";
+
+await openDialog(AboutDialog);
+```
+
+Pass component props as the second argument:
+
+```ts
+import LocationDialog from "@/components/LocationDialog.vue";
+import { openDialog } from "@/dialogs/dialog";
+
+const locationId = await openDialog(LocationDialog, {
+  currentLocationId: aipStore.current?.locationUuid,
+});
+
+if (!locationId) return;
+```
+
+No result or props types need to be repeated at the call site:
+
+- `defineProps` determines whether the second argument is required and which
+  properties it accepts.
+- The payload of the component's `resolve` event determines the promise result.
+- A forced teardown, such as session expiration, adds `undefined` to the
+  inferred result type.
+
+For example, a dialog emitting `boolean` returns
+`Promise<boolean | undefined>`:
+
+```ts
+const confirmed = await openDialog(BatchReviewConfirmDialog, {
+  heading: "Cancel batch",
+  bodyHtml: "<p>Are you sure?</p>",
+  confirmClass: "btn-danger",
+});
+```
+
+## Creating a dialog
+
+Create a normal component under `src/components`. Give its props and `resolve`
+event explicit TypeScript types, and pass the typed emitter to `useDialog`:
+
+```vue
+<script setup lang="ts">
+import useDialog from "@/dialogs/useDialog";
+
+defineProps<{
+  heading: string;
+}>();
+
+const emit = defineEmits<{
+  resolve: [confirmed: boolean];
+}>();
+
+const { element, close } = useDialog(emit, false);
+</script>
+
+<template>
+  <div ref="element" class="modal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <h1>{{ heading }}</h1>
+        <button type="button" @click="close(true)">Confirm</button>
+        <button type="button" data-bs-dismiss="modal">Cancel</button>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+The result should represent normal user cancellation as well as confirmation.
+Common choices are `false` for confirmation dialogs and `null` for selection or
+text-entry dialogs. Forced host teardown is distinct from user cancellation and
+resolves with `undefined`.
+
+The arguments after `emit` are the default result used when Bootstrap dismisses
+the modal directly. `close(result)` overrides that default and hides the modal.
+For a resultless dialog, declare `resolve: []` and call `useDialog(emit)` with no
+default result.
+
+After creating the component, callers can import and open it directly. There is
+no registration step or companion opener file.
+
+## Lifecycle rules
+
+- Do not emit `resolve` directly from an action button. Call `close(result)` and
+  let `useDialog` emit after Bootstrap finishes hiding. Otherwise Vue can remove
+  the component before Bootstrap restores body scrolling and removes its
+  backdrop.
+- Dialogs currently omit Bootstrap's `.fade` class. Forced teardown calls
+  `hide()` immediately followed by `dispose()`, so hiding must remain
+  synchronous. If animation is added, disposal must wait for
+  `hidden.bs.modal`.
+- Treat `undefined` as forced cancellation when a caller needs to distinguish
+  it from the dialog's normal user-cancellation result.
+- Keep `DialogHost` mounted exactly once. The application owns it; individual
+  pages and components should only call `openDialog`.
+- Do not deliberately overlap dialogs. `DialogAlreadyOpenError` indicates a
+  control-flow problem that should be resolved by the caller.
+
+## Testing
+
+Dialog component tests may mock Bootstrap's `show`, `hide`, and `dispose`
+methods. Dispatch `hidden.bs.modal` explicitly to verify the emitted result.
+
+Caller tests can mock `openDialog` and should verify the component and relevant
+props:
+
+```ts
+expect(openDialogMock).toHaveBeenCalledWith(ExampleDialog, {
+  heading: "Continue?",
+});
+```
+
+Keep lifecycle behavior covered separately with real Bootstrap:
+
+- [`useDialog.spec.ts`](useDialog.spec.ts) verifies that forced unmount restores
+  body styles and removes the backdrop.
+- [`DialogHost.spec.ts`](DialogHost.spec.ts) verifies results, cancellation, and
+  overlapping-request rejection.
+- [`App.spec.ts`](../App.spec.ts) covers the complete session-expiration path.
+
+When adding a dialog, test both its successful result and its user-cancellation
+result. Add or update a caller test so the expected component and props are part
+of the tested contract.

--- a/dashboard/src/dialogs/dialog.ts
+++ b/dashboard/src/dialogs/dialog.ts
@@ -1,0 +1,90 @@
+import { createTemplatePromise } from "@vueuse/core";
+import type { Component } from "vue";
+
+type NoDialogProps = Record<never, never>;
+type DialogComponent = new (...args: never[]) => unknown;
+
+export interface DialogRequest {
+  component: Component;
+  props?: object;
+}
+
+// Vue exposes a component's typed props and emits on its public instance.
+// Derive the request arguments and result so callers do not repeat those types.
+type DialogProps<Dialog extends DialogComponent> =
+  InstanceType<Dialog> extends { $props: infer Props extends object }
+    ? Props
+    : never;
+
+type DialogResult<Dialog extends DialogComponent> =
+  InstanceType<Dialog> extends {
+    $emit: (event: "resolve", ...args: infer Arguments) => void;
+  }
+    ? Arguments[0]
+    : never;
+
+type DialogArguments<Props extends object> = NoDialogProps extends Props
+  ? [props?: Props]
+  : [props: Props];
+
+export class DialogAlreadyOpenError extends Error {
+  constructor() {
+    super("Cannot open a dialog while another dialog is active.");
+    this.name = "DialogAlreadyOpenError";
+  }
+}
+
+// DialogHost renders this template once at the application root. Keeping it in
+// this module lets callers start dialogs without coupling them to the host.
+export const dialogTemplate = createTemplatePromise<
+  unknown,
+  [request: DialogRequest]
+>();
+
+// Overlapping dialogs are rejected explicitly instead of sharing the first
+// promise or rendering multiple Bootstrap modals and backdrops.
+let active = false;
+
+/**
+ * Opens a Vue component as a dialog and resolves with its `resolve` event
+ * payload.
+ *
+ * Pass the concrete dialog component directly; there is no dialog registry or
+ * opener wrapper. Its `defineProps` type determines whether the second argument
+ * is required and which properties it accepts. Its typed `resolve` event
+ * determines the promise result.
+ *
+ * Normal user cancellation should be represented by the component's result,
+ * such as `false` or `null`. The promise instead resolves with `undefined` if
+ * the application removes the dialog host before the component produces a
+ * result, such as when a session expires.
+ *
+ * Only one dialog can be active at a time.
+ *
+ * @throws `DialogAlreadyOpenError` when another dialog is already active.
+ *
+ * @example
+ * ```ts
+ * const confirmed = await openDialog(ConfirmDialog, {
+ *   heading: "Continue?",
+ * });
+ * ```
+ */
+export async function openDialog<Dialog extends DialogComponent>(
+  component: Dialog,
+  ...args: DialogArguments<DialogProps<Dialog>>
+): Promise<DialogResult<Dialog> | undefined> {
+  if (active) {
+    throw new DialogAlreadyOpenError();
+  }
+
+  active = true;
+  try {
+    return (await dialogTemplate.start({
+      component: component as Component,
+      props: args[0],
+    })) as DialogResult<Dialog> | undefined;
+  } finally {
+    active = false;
+  }
+}

--- a/dashboard/src/dialogs/useDialog.spec.ts
+++ b/dashboard/src/dialogs/useDialog.spec.ts
@@ -1,0 +1,34 @@
+import { cleanup, render } from "@testing-library/vue";
+import { afterEach, describe, expect, it } from "vitest";
+import { defineComponent, h } from "vue";
+
+import useDialog from "@/dialogs/useDialog";
+
+const dialogHarness = defineComponent({
+  setup() {
+    const { element } = useDialog(() => {});
+
+    return () =>
+      h("div", { ref: element, class: "modal" }, [
+        h("div", { class: "modal-dialog" }),
+      ]);
+  },
+});
+
+describe("useDialog", () => {
+  afterEach(() => cleanup());
+
+  it("restores document state when unmounted while visible", () => {
+    const { unmount } = render(dialogHarness);
+
+    expect(document.body.classList.contains("modal-open")).toBe(true);
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(document.querySelector(".modal-backdrop")).not.toBeNull();
+
+    unmount();
+
+    expect(document.body.classList.contains("modal-open")).toBe(false);
+    expect(document.body.style.overflow).toBe("");
+    expect(document.querySelector(".modal-backdrop")).toBeNull();
+  });
+});

--- a/dashboard/src/dialogs/useDialog.ts
+++ b/dashboard/src/dialogs/useDialog.ts
@@ -1,0 +1,68 @@
+import Modal from "bootstrap/js/dist/modal";
+import { onBeforeUnmount, onMounted, shallowRef } from "vue";
+
+import useEventListener from "@/composables/useEventListener";
+
+type ResolveArguments = [] | [result: unknown];
+
+/**
+ * Connects a dialog component's typed `resolve` event to its Bootstrap modal.
+ *
+ * Pass the component's typed emitter and its normal cancellation result, such
+ * as `false` or `null`. If Bootstrap dismisses the modal directly, the
+ * arguments passed after `emit` are emitted as that default result. For a
+ * resultless dialog, declare `resolve: []` and omit the default.
+ *
+ * Bind the returned `element` ref to the modal root. Calling `close(result)`
+ * records a result and starts hiding the modal. The composable emits `resolve`
+ * only after Bootstrap finishes hiding, so action handlers must call `close`
+ * rather than emit `resolve` directly.
+ *
+ * The composable owns the Bootstrap instance and hides and disposes it when the
+ * component unmounts. The modal root must omit Bootstrap's `.fade` class so
+ * forced teardown remains synchronous.
+ *
+ * @example
+ * ```ts
+ * const emit = defineEmits<{
+ *   resolve: [confirmed: boolean];
+ * }>();
+ *
+ * const { element, close } = useDialog(emit, false);
+ * ```
+ */
+export default function useDialog<Arguments extends ResolveArguments>(
+  emit: (event: "resolve", ...args: Arguments) => void,
+  ...defaultArguments: NoInfer<Arguments>
+) {
+  const element = shallowRef<HTMLElement | null>(null);
+  const modal = shallowRef<Modal | null>(null);
+  let resultArguments = defaultArguments;
+
+  useEventListener(element, "hidden.bs.modal", () => {
+    emit("resolve", ...resultArguments);
+    resultArguments = defaultArguments;
+  });
+
+  onMounted(() => {
+    if (!element.value) return;
+
+    modal.value = new Modal(element.value);
+    modal.value.show();
+  });
+
+  onBeforeUnmount(() => {
+    // dispose() alone does not undo the body scroll lock installed by show().
+    // Dialogs omit Bootstrap's .fade class so hide() completes before disposal.
+    modal.value?.hide();
+    modal.value?.dispose();
+  });
+
+  return {
+    element,
+    close: (...args: Arguments) => {
+      resultArguments = args;
+      modal.value?.hide();
+    },
+  };
+}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -2,7 +2,6 @@ import { PiniaDebounce } from "@pinia/plugin-debounce";
 import { createPinia } from "pinia";
 import { debounce } from "ts-debounce";
 import { createApp } from "vue";
-import { PromiseDialog } from "vue3-promise-dialog";
 
 import App from "./App.vue";
 import { api } from "./client";
@@ -20,7 +19,6 @@ pinia.use(PiniaDebounce(debounce));
 const app = createApp(App);
 app.use(router);
 app.use(pinia);
-app.use(PromiseDialog);
 app.mount("#app");
 
 interface Filters {

--- a/dashboard/tsconfig.app.json
+++ b/dashboard/tsconfig.app.json
@@ -1,6 +1,6 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "typed-misc.d.ts"],
+  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "composite": true,

--- a/dashboard/typed-misc.d.ts
+++ b/dashboard/typed-misc.d.ts
@@ -1,7 +1,0 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-declare module "vue3-promise-dialog" {
-  export const openDialog;
-  export const closeDialog;
-  export const DialogWrapper;
-  export const PromiseDialog;
-}

--- a/docs/src/dev-manual/README.md
+++ b/docs/src/dev-manual/README.md
@@ -5,6 +5,7 @@ This is the developer manual for Enduro SDPS.
 - [API](api.md)
 - [Database migrations](db-migrations.md)
 - [Documentation](docs.md)
+- [Code documentation](code-documentation.md)
 - [Dependency management](deps.md)
 - Environment setup
     - [Local/Development environment](devel.md)

--- a/docs/src/dev-manual/code-documentation.md
+++ b/docs/src/dev-manual/code-documentation.md
@@ -1,0 +1,140 @@
+# Code documentation
+
+This guide describes how Enduro documents Go, JavaScript, TypeScript, and Vue
+code. Its purpose is not to increase the number of comments, but to make each
+comment intentional, useful, and consistent with the tools and conventions of
+its language.
+
+Code documentation has two audiences:
+
+- callers need to understand the contract of a package, type, function,
+  composable, or component; and
+- maintainers need to understand the context behind an implementation.
+
+These needs call for different kinds of comments.
+
+## Philosophy
+
+Code should explain its own mechanics through clear names, precise types, and
+small, cohesive units. A comment should preserve information that the code
+cannot express clearly by itself.
+
+For implementation comments, document context and intent rather than
+line-by-line mechanics. "Document why, not how" is a useful shorthand. Record
+context such as:
+
+- the reason for a design choice or an unusual sequence of operations;
+- constraints, invariants, and assumptions;
+- trade-offs and rejected alternatives when they still matter;
+- lifecycle and cleanup responsibilities;
+- side effects and concurrency constraints;
+- compatibility workarounds and the conditions under which they can be removed;
+  and
+- behavior that is intentionally surprising or easy to break.
+
+Do not translate a statement or a well-named function into prose. If a comment
+only describes what the next line does, first consider whether clearer code
+would make the comment unnecessary. Comments that divide a long orchestration
+function into meaningful phases can still be useful, but they should aid
+navigation rather than narrate each operation.
+
+API documentation is different. It should describe the purpose of an
+abstraction, how callers use it, and its observable behavior. Include special
+results, errors, side effects, ordering, or concurrency guarantees when they are
+part of the contract, but leave replaceable implementation details out.
+
+[Google's code review guidance] makes the same distinction between comments
+that explain why code exists and API documentation that explains purpose,
+usage, and behavior. Matt Duck's [notes on A Philosophy of Software Design]
+summarize the underlying principle: "Comments should be used to describe things
+that aren't obvious from the code." The article also explores the different
+purposes of interface and implementation comments.
+
+Keep comments close to the code they describe and update or remove them when
+the code changes. A stale comment is more harmful than a missing one. Do not
+edit generated code to improve its comments; change the source or generator
+instead.
+
+## Go
+
+Follow the official [Go doc comment] conventions:
+
+- Give each package and each exported type, function, method, constant, and
+  variable a doc comment.
+- Start a package comment with `Package` followed by the package name.
+- Start other doc comments with the declared name and write complete sentences.
+- Describe what a function does or returns and the special cases callers need
+  to understand.
+- Document non-obvious zero-value behavior and concurrency guarantees on types.
+- Keep algorithm and implementation details in comments inside the function,
+  unless a property such as complexity or stability is part of the contract.
+
+Go doc comments use `//` and are displayed by `go doc`, `pkg.go.dev`, and Go
+language tooling. Let `gofmt` and the project's Go formatters format them.
+
+For example:
+
+```go
+// NewFilter returns a new Filter. It panics if orderingFields is empty.
+func NewFilter(query Query, orderingFields []string) *Filter {
+    // ...
+}
+```
+
+## JavaScript, TypeScript, and Vue
+
+Use ordinary `//` comments by default. Enduro does not generate JavaScript or
+TypeScript API documentation with JSDoc, and most exports do not need
+documentation comments.
+
+A shared API whose contract needs to be visible at call sites is a narrow
+exception. TypeScript-aware editors attach `/** ... */` documentation comments
+to symbols and display them at definitions, imports, and call sites. They do
+not provide the same IDE documentation for ordinary `//` comments.
+
+Use a `/** ... */` comment for a shared function, composable, class, or type
+only when callers need to know something that its name and TypeScript signature
+do not express. In addition to the general guidance above, useful details can
+include:
+
+- special return values, such as a value reserved for cancellation;
+- errors callers can expect; and
+- required integration with a Vue template or another framework.
+
+Start with a short summary of the contract. Add paragraphs for important
+semantics, and use tags such as `@example` and `@throws` when they make the API
+easier to use. Avoid `@param` and `@returns` entries that merely repeat names
+and types already present in the signature.
+
+For example:
+
+```ts
+/**
+ * Opens a component as a dialog and resolves with its result.
+ *
+ * Resolves with `undefined` if the host is removed before the dialog finishes.
+ *
+ * @throws `DialogAlreadyOpenError` when another dialog is already active.
+ */
+async function openDialog<Dialog extends DialogComponent>(
+  component: Dialog,
+  ...args: DialogArguments<DialogProps<Dialog>>
+): Promise<DialogResult<Dialog> | undefined> {
+  // ...
+}
+```
+
+For Vue components, prefer explicit `defineProps` and `defineEmits` types,
+descriptive slot and event names, and clear template structure. Add comments
+only for contracts or lifecycle constraints that those declarations cannot
+express. Use HTML comments in templates sparingly; they should explain
+non-obvious structure rather than label self-explanatory markup.
+
+This narrow `/** ... */` exception is not a reason to document every export.
+Continue to use `//` for implementation context. Longer architecture,
+multi-step workflows, and development or testing instructions belong in
+project documentation rather than source-code comments.
+
+[Go doc comment]: https://go.dev/doc/comment
+[Google's code review guidance]: https://google.github.io/eng-practices/review/reviewer/looking-for.html
+[notes on A Philosophy of Software Design]: https://www.mattduck.com/2021-04-a-philosophy-of-software-design.html


### PR DESCRIPTION
> [!IMPORTANT]
> Developed with assistance from gpt-5.6-sol.

[vue3-promise-dialog] made modal interactions conveniently awaitable, but it is
no longer actively maintained and Enduro uses only a narrow part of its API.
Using it also required application plugin registration, a global
DialogWrapper, and an ambient declaration that erased its types.

Replace the dependency with a small runtime built on VueUse
[createTemplatePromise]. Callers now pass concrete Vue components directly to
openDialog, along with a forced-cancellation value and optional props. Infer
the request props and promise result from component-defined props and the
typed resolve event, avoiding registries and per-dialog opener wrappers.

Keep concrete dialogs in components and colocate the shared host, instance,
Bootstrap lifecycle helper, tests, and documentation under dialogs. Reject
overlapping requests instead of sharing results or stacking Bootstrap modals.

Scope the host to authenticated sessions and resolve each request once when
the host is torn down. Hide modals before disposal so Bootstrap restores body
scrolling and removes its backdrop during session expiry and other forced
teardown.

Migrate the About, location, batch review, and AIP deletion flows. Document
the architecture, usage, lifecycle constraints, and process for developing
and testing new dialogs. Cover normal results, user cancellation, forced
cancellation, concurrent requests, Bootstrap cleanup, migrated callers, and
session expiry.

[vue3-promise-dialog]: https://github.com/rlemaigre/vue3-promise-dialog
[createTemplatePromise]: https://vueuse.org/core/createTemplatePromise/