### PR TITLE
Fix dashboard updates in Nginx mode

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -70,12 +70,10 @@ else:
   if LOCAL_A3M:
     docker_build("ghcr.io/artefactual-labs/a3m", context="../a3m")
 
-docker_build(
-  "enduro-dashboard:dev",
-  context="dashboard",
-  target="builder" if DASHBOARD_DEV else "",
-  live_update=[
-    fall_back_on("dashboard/vite.config.js"),
+dashboard_live_update = []
+if DASHBOARD_DEV:
+  dashboard_live_update = [
+    fall_back_on("dashboard/vite.config.ts"),
     sync("dashboard/", "/app/"),
     run(
       "npm set cache /app/.npm && npm install-clean",
@@ -86,6 +84,12 @@ docker_build(
       ]
     ),
   ]
+
+docker_build(
+  "enduro-dashboard:dev",
+  context="dashboard",
+  target="builder" if DASHBOARD_DEV else "",
+  live_update=dashboard_live_update,
 )
 
 # Get kube overlay path


### PR DESCRIPTION
The dashboard was always configured for Vite-style live updates, even when Tilt was running the production nginx image. As a result, the first refresh copied source files into `/app`, where nginx never looked, and only the second refresh forced the image rebuild that actually updated the frontend.

The fix limits live updates to `DASHBOARD_DEV` mode. In nginx mode, the first refresh now rebuilds and redeploys the image immediately. It also updates the fallback rule to watch the real `vite.config.ts` file instead of the obsolete `vite.config.js` path.