### PR TITLE
Close about dialog on session timeout

### DIFF
--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import Modal from "bootstrap/js/dist/modal";
 import { watch } from "vue";
 import { DialogWrapper } from "vue3-promise-dialog";
 
@@ -22,6 +23,11 @@ watch(
     if (valid) {
       ingestMonitor.connect();
       storageMonitor.connect();
+    } else {
+      // Hide any open modals when the user is logged out or invalidated.
+      document
+        .querySelectorAll<HTMLElement>(".modal.show")
+        .forEach((el) => Modal.getInstance(el)?.hide());
     }
   },
   { immediate: true },

--- a/dashboard/src/components/AboutDialog.spec.ts
+++ b/dashboard/src/components/AboutDialog.spec.ts
@@ -1,0 +1,98 @@
+import { createTestingPinia } from "@pinia/testing";
+import { cleanup, fireEvent, render } from "@testing-library/vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import AboutDialog from "@/components/AboutDialog.vue";
+import { EnduroChildworkflowTypeEnum } from "@/openapi-generator";
+import { useAuthStore } from "@/stores/auth";
+
+const closeDialogMock = vi.hoisted(() => vi.fn());
+const showMock = vi.hoisted(() => vi.fn());
+
+vi.mock("vue3-promise-dialog", () => ({ closeDialog: closeDialogMock }));
+vi.mock("bootstrap/js/dist/modal", () => {
+  return {
+    default: class ModalMock {
+      show = showMock;
+    },
+  };
+});
+
+function renderDialog(initialState: Record<string, unknown> = {}) {
+  return render(AboutDialog, {
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            auth: {
+              config: { enabled: true },
+              user: { expired: false },
+            },
+            ...initialState,
+          },
+        }),
+      ],
+    },
+  });
+}
+
+describe("AboutDialog.vue", () => {
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+
+  it("shows the modal on mount", () => {
+    renderDialog();
+
+    expect(showMock).toHaveBeenCalledOnce();
+  });
+
+  it("closes the dialog when the Bootstrap modal is hidden", async () => {
+    const { getByRole } = renderDialog();
+
+    const modalEl = getByRole("dialog", { name: "Enduro" });
+    await fireEvent(modalEl, new Event("hidden.bs.modal"));
+
+    expect(closeDialogMock).toHaveBeenCalledWith(null);
+  });
+
+  it("closes the dialog immediately when the user session expires", async () => {
+    renderDialog();
+
+    const authStore = useAuthStore();
+    authStore.$patch({ user: null });
+
+    await vi.waitFor(() => {
+      expect(closeDialogMock).toHaveBeenCalledWith(null);
+    });
+  });
+
+  it("does not show child workflows when none are configured", () => {
+    const { queryByText } = renderDialog();
+
+    expect(queryByText("Child workflows:")).toBeNull();
+  });
+
+  it("shows child workflows when configured", () => {
+    const { getByText } = renderDialog({
+      about: {
+        childWorkflows: [
+          {
+            type: EnduroChildworkflowTypeEnum.Preprocessing,
+            workflowName: "my-preprocessing-workflow",
+          },
+          {
+            type: EnduroChildworkflowTypeEnum.Poststorage,
+            workflowName: "my-poststorage-workflow",
+          },
+        ],
+      },
+    });
+
+    getByText("Child workflows:");
+    getByText("my-preprocessing-workflow");
+    getByText("my-poststorage-workflow");
+  });
+});

--- a/dashboard/src/components/AboutDialog.vue
+++ b/dashboard/src/components/AboutDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import Modal from "bootstrap/js/dist/modal";
-import { onMounted, ref } from "vue";
+import { onMounted, ref, watch } from "vue";
 import { closeDialog } from "vue3-promise-dialog";
 
 import IconDocumentation from "~icons/lucide/book-text";
@@ -9,8 +9,10 @@ import IconContributing from "~icons/lucide/git-merge";
 
 import useEventListener from "@/composables/useEventListener";
 import { useAboutStore } from "@/stores/about";
+import { useAuthStore } from "@/stores/auth";
 
 const aboutStore = useAboutStore();
+const authStore = useAuthStore();
 
 const el = ref<HTMLElement | null>(null);
 const modal = ref<Modal | null>(null);
@@ -26,6 +28,15 @@ onMounted(() => {
 });
 
 useEventListener(el, "hidden.bs.modal", () => closeDialog(null));
+
+watch(
+  () => authStore.isUserValid,
+  (valid) => {
+    if (!valid) {
+      closeDialog(null);
+    }
+  },
+);
 </script>
 
 <template>


### PR DESCRIPTION
Fixes #1715.

Developed with assistance from Claude Sonnet 4.6.

- Close the "About" modal when the user login session expires
- Remove Bootstrap 5 modal classes when a user login session expires
- Add unit tests for the "About" modal