### PR TITLE
Upgrade brace-expansion package to v5.0.8

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -3660,16 +3660,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -50,7 +50,7 @@
   },
   "overrides": {
     "minimatch": "10.2.5",
-    "brace-expansion": "5.0.7"
+    "brace-expansion": "5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
Upgrade brace-expansion from v5.0.7 to v5.0.8 to address security vulnerability CVE-2026-14257.