### PR TITLE
Add developer docs for child workflows

### DIFF
--- a/docs/src/admin-manual/configuration.md
+++ b/docs/src/admin-manual/configuration.md
@@ -61,14 +61,13 @@ packages in the `internal` directory have configurable settings found here.
 
 !!! tip
 
-    Note that some [child workflow] activities may have their own configuration
-    files.
+    A custom worker and its registered activities may require configuration in
+    addition to `enduro.toml`. Consult the custom worker and activity
+    documentation for those settings.
 
-    For example, see the
+    For example,
     [ffvalidate](https://github.com/artefactual-sdps/temporal-activities/tree/main/ffvalidate)
-    activity in the temporal-activities repository, which requires an additional
-    CSV configuration file listing an allowed list of file-formats in a SIP when
-    used for ingest validation.
+    can read a CSV file that lists allowed or disallowed formats.
 
 ### Application logging
 
@@ -455,10 +454,10 @@ chechecksumAlgorithm = "sha512"
 ### BagIt validation
 
 Enduro validates any [BagIt] bags submitted for ingest to ensure the contents
-have not been altered or corrupted. In addition Enduro requires a
-[Preprocessing child workflow](#preprocessing-child-workflow) to deliver a
-[BagIt] bag to Enduro, and these bags are also validated by Enduro to ensure
-file integrity.
+have not been altered or corrupted. When a
+[preprocessing child workflow](#preprocessing-child-workflow) is configured,
+its successful result must point to a BagIt bag. Enduro then validates that bag
+to ensure file integrity.
 
 **Example configuration**:
 
@@ -1482,63 +1481,53 @@ samplingRatio = 1.0
 
 ### Child workflows
 
-A child workflow is a concept borrowed from Enduro's [workflow engine],
-[Temporal] where one workflow spawns an ancillary workflow. We use this model in
-Enduro to keep custom activities with organization specific business rules or
-policy requirements separated from the underlying general Enduro code.
+In [Temporal], a [child workflow] is a workflow started by another workflow and
+run as a separate execution. Enduro uses custom child workflows to keep the
+rules and policy of an organization, and any activities they schedule, outside
+the general Enduro code.
 
 Enduro schedules custom child workflows in the same Temporal namespace as their
 parent workflows, as configured by `[temporal].namespace`. Workers that execute
 these child workflows must connect to the same namespace.
 
-All child workflow configurations share three common settings: `type`,
-`taskQueue`, and `workflowName`.  An example configuration for the poststorage
-child workflow is shown below.
+For workflow contracts and behavior, see the [guide to custom child workflows].
+To create and run a Go worker, use the [custom workflow template].
+
+All child workflow configurations share three settings: `type`, `taskQueue`,
+and `workflowName`.
 
 !!! note
 
-    The `childWorkflows` configuration block can be repeated more than once to
-    add multiple child workflows. This is why the `childWorkflows` header is in
-    double brackets rather than single brackets like other configuration blocks.
+    The `childWorkflows` block is a TOML array of tables, so its header uses
+    double brackets and the block can be repeated. Enduro accepts at most one
+    entry for each child workflow type.
 
-**Example configuration**:
-
-```toml
-[[childWorkflows]]
-type = "poststorage"
-taskQueue = "custom-queue"
-workflowName = "custom-poststorage-workflow"
-```
-
-* `type`: The type of child workflow. Type is used to load the correct child
-  workflow configuration in Enduro so only one child workflow of each type may
-  be configured for any instance of Enduro. If multiple child workflows have
-  the same type, an error will be thrown when the configuration is validated.
+* `type`: One of `preprocessing`, `poststorage`, or `postbatch`. Enduro rejects
+  the configuration if more than one child workflow has the same type.
 * `taskQueue`: In Temporal, a [Task Queue] is a lightweight, dynamically
-  allocated queue that one or more workers can poll for tasks. The example
-  value `custom-queue` differentiates this queue from Enduro's general `global`
-  queue. The custom workers must poll the configured queue.
-* `workflowName`: The name of the configured [child workflow] in Temporal. It
-  must exactly match the custom workers registration.
+  allocated queue that one or more workers can poll for tasks. The examples
+  below use `custom-queue` to distinguish it from Enduro's general `global`
+  queue. A worker for the child must poll the configured queue.
+* `workflowName`: The Temporal Workflow Type name. It must exactly match the
+  name registered by the custom worker.
 
-All `[[childWorkflows]]` configuration sections are commented out at Enduro
-installation, disabling the child workflows. Uncomment the relevant
-configuration section to enable a child workflow, adjusting the settings as
-necessary for your environment.
+Enduro runs a custom child workflow only when its corresponding
+`[[childWorkflows]]` entry is present. Add or uncomment the entry for each
+workflow type required by the deployment.
 
-If you are running child workflows in development see the [Tilt environment
+If you are running child workflows in development, see the [Tilt environment
 configuration] documentation for instructions on configuring Tilt to run the
 child workflow workers and load any other required resources.
 
 #### Preprocessing child workflow
 
-The preprocessing child workflow is run before preservation processing by a
-preservation engine (Archivematica or a3m). A preprocessing workflow can support
-automated tasks such as validation and transformation of the SIP to meet
-organization specific expectations and standards before preservation.
+The preprocessing child workflow provides an extension point before
+preservation. It runs before Enduro sends the package to a preservation engine
+such as Archivematica or a3m. It can validate or change the SIP to meet the
+organization's requirements.
 
-The preprocessing configuration supports two parameters in addition
-to the common child workflow settings: `extract` and `sharedPath`.
+The preprocessing configuration supports two settings in addition to the common
+child workflow settings: `extract` and `sharedPath`.
 
 **Example configuration**:
 
@@ -1547,37 +1536,43 @@ to the common child workflow settings: `extract` and `sharedPath`.
 type = "preprocessing"
 taskQueue = "custom-queue"
 workflowName = "custom-preprocessing-workflow"
-extract = true
+extract = false
 sharedPath = "/home/enduro/preprocessing"
 ```
 
-* `extract`: Boolean value, set to `false` by default. This setting determines
-  whether SIP extraction happens as part of the preprocessing child workflow or
-  not. When set to false, SIP extraction will occur in the parent Enduro
-  workflow before the child workflow is run. In some cases, you may wish to
-  design custom child workflow activities that perform operations on the SIP
-  before it is extracted: for example, calculating a checksum of the zipped
-  package to check for prior duplicate ingests before proceeding. When this
-  value is set to `true` Enduro will skip the extraction task at the beginning
-  of the ingest workflow, allowing you to define when and how extraction occurs
-  in the child workflow.
-* `sharedPath`: The absolute path to the directory that Enduro should use to
-  share the SIP between the primary ingest workflow and the configured
-  preprocessing child workflow. A `sharedPath` is required for the preprocessing
-  workflow because it requires access to the SIP for validation and
-  transformation activities.
+* `extract`: Boolean value, set to `false` by default. This setting controls
+  whether Enduro extracts the SIP before running the child workflow, its value
+  is not passed to the child. Set the value based on whether the child workflow
+  expects an archived SIP as-is, or the extracted contents. With `false`, Enduro
+  attempts to extract a downloaded file. After a successful extraction, the
+  child receives the path to the extracted directory. If Enduro does not
+  recognize the file as an archive, the child receives the original file. Enduro
+  leaves directories unchanged. With `true`, Enduro skips this step. The child
+  receives the original downloaded file or directory and decides whether
+  extraction is needed. Enduro calculates the checksum and performs any
+  duplicate check first. With either value, a successful child must return the
+  relative path to a BagIt bag.
+* `sharedPath`: The absolute root for shared SIP files as seen by the Enduro
+  worker. When preprocessing is enabled, Enduro downloads the SIP below this
+  root and sends the child only the relative path. This setting does not create
+  or mount the shared storage. The deployment must make the same files
+  available to the custom worker. That worker may mount the storage at a
+  different absolute path and configure its own local root.
 
 See the [Tilt environment configuration] documentation for instructions on
 configuring Tilt to run the preprocessing worker and provision the shared path
 volume in the Enduro development environment.
 
+See [the preprocessing guide] for the exact input, result, task, metadata,
+decision, and failure behavior.
+
 #### Poststorage child workflow
 
-[Post-storage] is a phase in an ingest or preservation workflow describing all
-the preservation policy-defined tasks performed on an [AIP] following
-preservation processing and AIP storage. Post-storage task examples might
-include metadata extraction and delivery to an external system (such as an
-archival management system), AIP encryption or replication, and more.
+A poststorage child workflow provides the [post-storage] extension point. It
+runs after an [AIP] is stored and can deliver metadata or perform other
+integrations. Enduro passes the initiating user's email when available, the AIP
+UUID, and successful preprocessing metadata. It does not pass a filesystem path
+or full AIP record.
 
 **Example configuration**:
 
@@ -1588,12 +1583,14 @@ taskQueue = "custom-queue"
 workflowName = "custom-poststorage-workflow"
 ```
 
+See [the poststorage guide] for result, task, metadata, and failure behavior.
+
 #### Postbatch child workflow
 
-A postbatch child workflow runs after multiple SIPs are ingested and stored
-using the batch ingest functionality of Enduro. The postbatch workflow can be
-used to report the results of a batch ingest, for instance creating a report
-that collates SIP and AIP data for all of the SIPs in a batch.
+A postbatch child workflow provides the [post-batch] extension point. It runs
+after the SIP workflows in a batch have ended and, for a partial batch, after
+the user chooses to continue. It receives an entry for every SIP originally in
+the batch and can create or send a batch report.
 
 **Example configuration**:
 
@@ -1603,6 +1600,8 @@ type = "postbatch"
 taskQueue = "custom-queue"
 workflowName = "custom-postbatch-workflow"
 ```
+
+See [the postbatch guide] for input, result, and failure behavior.
 
 [a3m]: https://github.com/artefactual-labs/a3m
 [ABAC]: https://en.wikipedia.org/wiki/Attribute-based_access_control
@@ -1618,6 +1617,8 @@ workflowName = "custom-postbatch-workflow"
 [bagit-gython README]: https://github.com/artefactual-labs/bagit-gython/blob/main/README.md
 [child workflow]: ../user-manual/glossary.md#child-workflow
 [components]: ../user-manual/components.md
+[guide to custom child workflows]: ../dev-manual/child-workflows/index.md
+[custom workflow template]: https://github.com/artefactual-sdps/custom-enduro-workflows/blob/main/README.md
 [CORS]: https://en.wikipedia.org/wiki/Cross-origin_resource_sharing
 [Dashboard configuration]: ../admin-manual/dashboard-config.md
 [fileblob URL opener]: https://pkg.go.dev/gocloud.dev/blob/fileblob#URLOpener
@@ -1630,6 +1631,7 @@ workflowName = "custom-postbatch-workflow"
 [OpenTelemetry docs]: https://opentelemetry.io/ecosystem/vendors/
 [ParseDuration]: https://pkg.go.dev/time#ParseDuration
 [PIP]: ../user-manual/glossary.md#processing-information-package-pip
+[post-batch]: ../user-manual/glossary.md#post-batch
 [post-storage]: ../user-manual/glossary.md#post-storage
 [PREMIS]: https://www.loc.gov/standards/premis/
 [preservation engine]: ../user-manual/glossary.md#preservation-engine
@@ -1641,8 +1643,12 @@ workflowName = "custom-postbatch-workflow"
 [system errors]: ../user-manual/glossary.md#system-error
 [Task Queue]: https://docs.temporal.io/task-queue
 [Temporal]: https://temporal.io
+[the postbatch guide]: ../dev-manual/child-workflows/postbatch.md
+[the poststorage guide]: ../dev-manual/child-workflows/poststorage.md
+[the preprocessing guide]: ../dev-manual/child-workflows/preprocessing.md
 [tilt environment configuration]: ../dev-manual/devel.md#tilt-environment-configuration
 [upload-ui]: ../user-manual/ingest/submitting-content.md#upload-sips-via-the-user-interface
 [version 4 UUID]: https://www.rfc-editor.org/rfc/rfc9562.html#name-uuid-version-4
 [watched-location]: ../user-manual/ingest/submitting-content.md#initiate-ingest-via-a-watched-location-upload
 [workflow engine]: ../user-manual/glossary.md#workflow-engine
+[xmlvalidate]: https://github.com/artefactual-sdps/temporal-activities/blob/main/xmlvalidate/README.md

--- a/docs/src/dev-manual/README.md
+++ b/docs/src/dev-manual/README.md
@@ -3,6 +3,11 @@
 This is the developer manual for Enduro SDPS.
 
 - [API](api.md)
+- Child workflows
+    - [Concepts and shared contracts](child-workflows/index.md)
+    - [Preprocessing workflows](child-workflows/preprocessing.md)
+    - [Poststorage workflows](child-workflows/poststorage.md)
+    - [Postbatch workflows](child-workflows/postbatch.md)
 - [Database migrations](db-migrations.md)
 - [Documentation](docs.md)
 - [Code documentation](code-documentation.md)

--- a/docs/src/dev-manual/child-workflows/index.md
+++ b/docs/src/dev-manual/child-workflows/index.md
@@ -1,0 +1,322 @@
+# Custom child workflows
+
+Custom Temporal child workflows let an organization extend Enduro's ingest
+process without adding custom rules to Enduro itself. As it processes a SIP, the
+[processing workflow] starts **preprocessing** and **poststorage** workflows as
+children; once the SIP workflows in a batch have ended, the [batch workflow]
+can start a **postbatch** child. This guide describes the contracts and behavior
+of all three extension points, while the administrator manual covers their
+[child workflow configuration].
+
+## Temporal concepts
+
+An Enduro child workflow uses the following Temporal concepts:
+
+* A **Workflow Definition** is deterministic orchestration code. A **Workflow
+  Execution** is one running instance of that definition, and a **Workflow
+  Type** is the name registered for it. Temporal records execution history and
+  replays workflow code to restore its state. See [Temporal Workflows].
+* An **Activity** is a function or method that performs a specific action, such
+  as filesystem I/O or an API call. Activity code does not have to be
+  deterministic and should normally be idempotent. Workflow code schedules and
+  coordinates activities. See [Temporal Activities].
+* A **Worker** registers workflow and activity implementations and polls a
+  **Task Queue**. Enduro dispatches each custom child workflow to its configured
+  task queue, so a custom worker must poll that exact queue and register the
+  configured workflow name. See [Temporal Workers] and [Temporal Task Queues].
+* A **Child Workflow Execution** is started by another workflow in the same
+  Temporal namespace. Parent and child have separate histories and do not share
+  local state. They exchange serializable parameters, results, and, when
+  needed, messages. See [Temporal Child Workflows].
+* A **Signal** is an asynchronous write. The sender cannot receive a result
+  from the signal handler. Enduro normally exchanges parameters and a final
+  result with its child workflows, and uses Signals only for preprocessing
+  decisions. A preprocessing child sends a decision request to its parent with
+  a Signal, and the parent signals the selected response back. See [Temporal
+  message passing] for more about Signals.
+
+Temporal documents SDKs for [.NET, Go, Java, PHP, Python, Ruby, Rust, and
+TypeScript][Temporal SDKs]. This guide uses the [Temporal Go SDK] because Enduro
+and the existing custom workflow projects are written in Go.
+
+## Extension points
+
+Each extension point has a distinct contract and effect on its parent workflow.
+
+### Preprocessing
+
+Preprocessing runs after Enduro downloads the SIP and performs its initial file
+checks, and before preservation processing. The `extract` setting determines
+whether Enduro attempts archive extraction before the child or leaves extraction
+to the child. This extension supports validation, extraction, restructuring,
+metadata generation, and other preparation before preservation.
+
+**Contract:** The child receives the SIP's relative working path and
+identifiers. It returns a relative path to the modified SIP, which must be
+structured as a [BagIt] bag. It also returns data about the tasks run by the
+child workflow, and optional custom metadata that can be read by poststorage
+and postbatch workflows.
+
+**Behavior:** A successful result replaces the processing path and supplies
+metadata to later custom workflows. A content or system outcome stops SIP
+processing; Enduro does not adopt the returned path or metadata. See
+[Preprocessing workflows] for the complete contract and behavior.
+
+### Poststorage
+
+Poststorage runs after the AIP has been stored and registered and before the
+SIP processing workflow completes. It supports hooks and integrations that
+need a stored AIP.
+
+**Contract:** The child receives the AIP UUID and preprocessing metadata. It
+returns tasks, an outcome, and more metadata.
+
+**Behavior:** Enduro waits for the result and merges the returned metadata. A
+content or system outcome stops the SIP workflow but does not remove the stored
+AIP. See [Poststorage workflows] for the complete contract and behavior.
+
+### Postbatch
+
+Postbatch runs after the workflows that process the SIPs in a batch have ended.
+If only part of the batch is then ingested, it runs only after a user chooses to
+continue. It supports reports and integrations that need data from the completed
+SIP workflows in a batch.
+
+**Contract:** The child receives batch data and one entry for every SIP that
+was originally in the batch, not only the SIPs that succeeded. It returns an
+outcome and message.
+
+**Behavior:** Enduro logs the structured result but does not otherwise act on
+its outcome. An actual Temporal workflow error fails the batch. See [Postbatch
+workflows] for the complete contract and behavior.
+
+## Configuration and dispatch
+
+Enduro accepts at most one configuration for each child workflow `type`.
+`taskQueue` and `workflowName` are deployment values, not fixed Enduro
+constants. The Enduro child workflows configuration for both values much exactly
+match the values registered in the actual child workflow.
+
+```toml
+[[childWorkflows]]
+type = "preprocessing"
+taskQueue = "custom-enduro"
+workflowName = "preprocessing"
+extract = false
+sharedPath = "/home/enduro/preprocessing"
+```
+
+Child workflows inherit `[temporal].namespace` from their Enduro parent, and
+the custom worker must connect to that namespace. A `[[childWorkflows]]` entry
+therefore has no separate `namespace` field. See [child workflow configuration]
+for all three types.
+
+## The shared `pkg/childwf` package
+
+[`pkg/childwf`][childwf source] is the public Go package containing the data
+contracts shared by Enduro and projects that define custom workflows:
+
+```go
+import "github.com/artefactual-sdps/enduro/pkg/childwf"
+```
+
+It defines concrete named types, structs, constants, and helper functions; it
+does not define a workflow interface. The important types are:
+
+| Type | Kind and purpose |
+| --- | --- |
+| `Outcome` | Named `int` with `OutcomeSuccess` (`0`), `OutcomeSystemError` (`1`), and `OutcomeContentError` (`2`). |
+| `CustomMetadata` | Named `map[string]json.RawMessage` for opaque JSON data passed between child workflows. |
+| `User` | Struct containing the initiating user's `Email`, when available. |
+| `PreprocessingParams`, `PreprocessingResult` | Preprocessing input and result structs. |
+| `PostStorageParams`, `PostStorageResult` | Poststorage input and result structs. |
+| `PostbatchParams`, `PostbatchBatch`, `PostbatchSIP`, `PostbatchResult` | Postbatch input, nested batch/SIP data, and result structs. |
+| `Task` | A child task record with `Name`, `Message`, `Outcome`, `StartedAt`, and `CompletedAt`. |
+| `TaskOutcome` | Named `string` with `unspecified`, `success`, `system failure`, and `validation failure` constants. |
+| `DecisionRequest`, `DecisionResponse` | Signal payload structs used for a human decision. |
+
+The parameters and results are ordinary structs serialized by Temporal. A Go
+workflow is not required to use the convenience helpers, but it must accept and
+return data compatible with the configured extension's contract. Importing
+`pkg/childwf` keeps its types and constants aligned with Enduro.
+
+### Version compatibility
+
+`pkg/childwf` is versioned with the Enduro Go module, not as an independent
+module. Pin an Enduro release in the custom project's `go.mod` and compare it
+with the version deployed by the Enduro service. Before upgrading, review
+changes to the parameter structs, result structs, signal payloads, and enum
+values, then run the custom workflow's Temporal tests against the new version.
+An added field may remain compatible with existing serialized data, while a
+renamed field, changed type, or changed meaning may not be.
+
+Temporal workflows that run for a long time also replay old histories with
+current worker code. Keep workflow changes deterministic and follow the
+[Temporal Go SDK versioning guidance] when a change would break replay.
+
+### Tasks and result helpers
+
+`childwf.NewTask` creates a task with an `unspecified` outcome and start time,
+but does not append it to a result.
+`(*Task).Complete` sets its completion time, outcome, and formatted message;
+`(*Task).Succeed` is the success shorthand. `(*Task).IsSuccess` reports whether
+the outcome is `success`.
+
+`PreprocessingResult` and `PostStorageResult` each add three helpers:
+
+* `(*PreprocessingResult).NewTask` and `(*PostStorageResult).NewTask` create a
+  task and append it to the result.
+* `ValidationError` sets `OutcomeContentError` and completes a task with a
+  validation failure. It prefixes the message with `Content error:` and joins
+  multiple message arguments with a blank line.
+* `SystemError` sets `OutcomeSystemError` and completes a task with a system
+  failure. It prefixes the message with `System error:` and joins multiple
+  message arguments with a blank line.
+
+The following fragment shows how to classify `activityErr` when an activity
+cannot complete and `validationFailure` when it completes but finds a content
+problem. In this example, the workflow can still build a trustworthy result,
+so it reports either condition to Enduro in that result:
+
+```go
+result := &childwf.PreprocessingResult{
+    Outcome:      childwf.OutcomeSuccess,
+    RelativePath: params.RelativePath,
+}
+task := result.NewTask(workflow.Now(ctx), "Validate metadata")
+
+// Run the activity here, assigning activityErr and validationFailure.
+completedAt := workflow.Now(ctx)
+
+switch {
+case activityErr != nil:
+    workflow.GetLogger(ctx).Error(
+        "Metadata validation could not be completed",
+        "error", activityErr,
+    )
+    result.SystemError(
+        completedAt,
+        task,
+        "Metadata validation could not be completed.",
+        "Try again or ask an administrator to investigate.",
+    )
+case validationFailure != "":
+    result.ValidationError(
+        completedAt,
+        task,
+        "Metadata does not meet the required policy.",
+        validationFailure,
+    )
+default:
+    task.Succeed(completedAt, "Metadata is valid")
+}
+
+return result, nil
+```
+
+Both error helpers complete the task and set the result outcome. `SystemError`
+does not include the underlying Go error automatically, so log it and add any
+safe details that an operator needs to the task message. Task messages are
+visible through the Enduro API and dashboard, so do not include secrets. On
+success, `Succeed` completes the task but does not change the result outcome.
+The same pattern works with `PostStorageResult`.
+
+Each error helper overwrites the current result outcome. Do not call
+`ValidationError` after `SystemError`, because that would replace
+`OutcomeSystemError` with `OutcomeContentError`. Return after a system error or
+otherwise preserve the intended overall outcome.
+
+Using these helpers is optional. A workflow may construct the result and tasks
+directly, but should use deterministic workflow time, set the overall outcome,
+and finish every task it returns.
+
+When Enduro saves returned preprocessing or poststorage tasks, it maps child
+task outcomes as follows:
+
+| Child task outcome | Enduro task status |
+| --- | --- |
+| `TaskOutcomeUnspecified` | `unspecified` |
+| `TaskOutcomeSuccess` | `done` |
+| `TaskOutcomeSystemFailure` | `error` |
+| `TaskOutcomeValidationFailure` | `failed` |
+
+The returned task list is a completion log, not a live task channel. Enduro
+receives and saves it only when the child workflow completes successfully from
+Temporal's perspective and its result can be decoded.
+
+### Custom metadata
+
+Custom metadata values must be valid JSON. Decide which workflow owns each key
+in the map to avoid conflicts with another custom workflow:
+
+```go
+result.CustomMetadata = childwf.CustomMetadata{
+    "acme": json.RawMessage(`{"recordID":"A-123"}`),
+}
+```
+
+Enduro treats each value as opaque. It does not validate its schema or merge
+inside the JSON value. See each workflow page for when metadata is accepted,
+merged, or omitted.
+
+## Results and workflow errors
+
+A Temporal child completes with either a completion result or a workflow
+failure. When `ChildWorkflowFuture.Get` returns an error, it does not also
+decode a usable completion result. Consequently, returning a populated Go
+result together with a workflow error does not deliver that result to Enduro.
+Enduro cannot then read the outcome, save returned tasks, or propagate custom
+metadata.
+
+`PreprocessingResult` and `PostStorageResult` do not have an error or message
+field at the result's top level, so put failure details for operators in the
+relevant `Task.Message`. `PostbatchResult` instead has a direct `Message` field
+and no task list. See [Temporal Go child workflows] and [Temporal Go error
+handling] for the underlying SDK behavior and error model.
+
+For expected policy, validation, or processing failures where Enduro still
+needs structured data:
+
+1. Handle and classify the failure rather than discarding it.
+2. Put an explanation for operators in the relevant task message or the
+   postbatch result message.
+3. Set the matching `Outcome` and task outcome.
+4. Return the populated result with a nil workflow error.
+
+This completion is successful only from Temporal's point of view. Enduro still
+interprets preprocessing and poststorage content and system outcomes as
+failures in SIP processing.
+
+Return a workflow error for invalid arguments or violated invariants when no
+trustworthy result can be produced.
+
+## Build a custom workflow worker
+
+Use the [custom workflow template README] to create, configure, build, and run a
+Go worker with Enduro and Tilt. It covers the project layout, names to change,
+worker and activity registration, configuration, build commands, container
+image, and projects with more workflow examples.
+
+See [temporal-activities] for reusable Go activities and their configuration.
+
+[BagIt]: https://www.rfc-editor.org/rfc/rfc8493
+[batch workflow]: https://github.com/artefactual-sdps/enduro/blob/main/internal/workflow/batch.go
+[child workflow configuration]: ../../admin-manual/configuration.md#child-workflows
+[childwf source]: https://github.com/artefactual-sdps/enduro/tree/main/pkg/childwf
+[custom workflow template README]: https://github.com/artefactual-sdps/custom-enduro-workflows/blob/main/README.md
+[postbatch workflows]: postbatch.md
+[poststorage workflows]: poststorage.md
+[preprocessing workflows]: preprocessing.md
+[processing workflow]: https://github.com/artefactual-sdps/enduro/blob/main/internal/workflow/processing.go
+[Temporal Activities]: https://docs.temporal.io/activities
+[temporal-activities]: https://github.com/artefactual-sdps/temporal-activities
+[Temporal Child Workflows]: https://docs.temporal.io/child-workflows
+[Temporal Go SDK]: https://docs.temporal.io/develop/go
+[Temporal Go child workflows]: https://docs.temporal.io/develop/go/workflows/child-workflows
+[Temporal Go error handling]: https://docs.temporal.io/develop/go/best-practices/error-handling
+[Temporal Go SDK versioning guidance]: https://docs.temporal.io/develop/go/workflows/versioning
+[Temporal message passing]: https://docs.temporal.io/encyclopedia/workflow-message-passing
+[Temporal SDKs]: https://docs.temporal.io/develop
+[Temporal Task Queues]: https://docs.temporal.io/task-queue
+[Temporal Workers]: https://docs.temporal.io/workers
+[Temporal Workflows]: https://docs.temporal.io/workflows

--- a/docs/src/dev-manual/child-workflows/postbatch.md
+++ b/docs/src/dev-manual/child-workflows/postbatch.md
@@ -1,0 +1,119 @@
+# Postbatch workflows
+
+A postbatch child workflow performs work after the SIPs in the batch have been
+processed. Enduro's batch workflow is the postbatch workflow's parent and it
+does not finalize the batch until postbatch returns. The SIP processing workflow
+started for each SIP in the batch is a separate child execution. Postbatch is
+suited to reports and external integrations that need the batch as a whole.
+
+## When it runs
+
+Postbatch is reachable only after every SIP in a batch first reaches `validated`
+status. If polling finds a terminal SIP status before every SIP reaches
+`validated`, Enduro fails the batch and skips postbatch. Once all SIPs validate,
+Enduro lets their processing workflows continue and polls until every SIP
+reaches a final ingest status.
+
+If all SIPs were ingested, Enduro waits for every processing workflow to finish
+and then proceeds to postbatch. If any SIP failed, entered an error state, or
+was canceled after validation, the batch becomes pending:
+
+* Continuing makes Enduro wait for every processing workflow to finish before
+  constructing the postbatch parameters.
+* Canceling skips postbatch, marks the batch and ingested SIPs as canceled, and
+  requests deletion of AIPs for ingested or already canceled SIPs.
+
+Continuing a partial batch does **not** filter the postbatch input to successful
+SIPs. Enduro includes one `PostbatchSIP` entry for every SIP originally in the
+batch.
+
+## Execution and contract
+
+The Temporal child workflow type name is the configured `workflowName`. Enduro
+dispatches it to the configured `taskQueue` with these options:
+
+* `WorkflowID`: `<workflowName>-<batch UUID>`
+* `TaskQueue`: the configured `taskQueue`
+* `ParentClosePolicy`: `PARENT_CLOSE_POLICY_TERMINATE`
+
+The postbatch worker must register the workflow using the configured
+`workflowName`, poll the configured queue, and connect to Enduro's Temporal
+namespace.
+
+Enduro does not explicitly set a child timeout or retry policy. Other child
+options follow Temporal's inheritance and default rules. Workflow executions
+do not have a retry policy by default.
+
+A postbatch workflow is executed with `childwf.PostbatchParams`:
+
+| Field | Type | Value supplied by Enduro |
+| --- | --- | --- |
+| `User` | `*childwf.User` | The initiating user's email, or `nil` when unavailable. |
+| `Batch` | `*childwf.PostbatchBatch` | Batch `UUID`, `Identifier`, and total `SIPSCount`. |
+| `SIPs` | `[]*childwf.PostbatchSIP` | One record with final data for every SIP in the batch. |
+
+The exact `PostbatchSIP` fields are:
+
+| Field | Type | Value supplied by Enduro |
+| --- | --- | --- |
+| `UUID` | `uuid.UUID` | SIP UUID. |
+| `Name` | `string` | SIP name. |
+| `AIPID` | `*uuid.UUID` | UUID of the stored AIP when one was recorded; otherwise `nil`. |
+| `FileCount` | `int32` | The final number of files recorded for the SIP. |
+| `CustomMetadata` | `childwf.CustomMetadata` | Metadata returned from the SIP processing workflow, if it completed successfully. |
+
+`AIPID` is not a status field. A SIP that failed after storage can still have an
+`AIPID`. Failed or canceled processing produces no `CustomMetadata` in the
+postbatch entry, even if preprocessing or poststorage produced metadata,
+because only a successful processing result returns merged metadata to the
+batch. Select successfully processed SIPs according to the data and business
+rules required by the integration.
+
+A postbatch workflow returns a `childwf.PostbatchResult`:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `Outcome` | `childwf.Outcome` | A structured outcome set by the child. |
+| `Message` | `string` | A result message set by the child. |
+
+## Result and failure behavior
+
+Enduro logs every decoded `Outcome` and `Message` but does not branch on the
+result, save it in Enduro's database, or expose it through the API or dashboard.
+A decodable result returned with a nil Go error therefore allows the batch to
+finish as ingested, regardless of its structured outcome.
+
+`PostbatchResult` has no task or metadata fields, and the batch parent does not
+collect tasks from this child. Postbatch tasks cannot be displayed through the
+Enduro API or dashboard.
+
+For an expected postbatch or domain failure that should not fail the batch, set
+the result's `Outcome` and `Message` and return it with a nil workflow error.
+The details are then available only in the parent workflow log. To fail the
+batch, return a workflow error; on error Enduro will receive a nil
+`childwf.PostbatchResult`.
+
+If the postbatch child returns a workflow error or is canceled while the batch
+parent is waiting, `Get` returns an error, no structured result is decoded, and
+Enduro sets the batch status to failed. Already stored AIPs are not removed as
+a consequence of a postbatch failure. If the parent workflow closes because of a
+failure or timeout while the child is active, the configured parent close
+policy terminates the child and no structured result is available.
+
+The custom postbatch child exchanges no signals with Enduro. The
+`batch-decision-signal` for a partial batch is exchanged only between the
+Enduro API and the batch parent.
+
+## Enable the workflow
+
+Add one `[[childWorkflows]]` entry with `type = "postbatch"`, the worker's task
+queue, and the workflow type name. See the administrator manual's [postbatch
+configuration] and the [custom workflow template].
+
+The [CVA postbatch workflow] is a complete example used in production. Its
+[CSV activity] demonstrates selecting entries with a usable AIP UUID.
+
+[CVA postbatch workflow]: https://github.com/artefactual-sdps/cva-enduro-workflows/blob/main/internal/workflows/postbatch.go
+[CSV activity]: https://github.com/artefactual-sdps/cva-enduro-workflows/blob/main/internal/activities/create_csv.go#L96-L102
+[custom workflow template]: https://github.com/artefactual-sdps/custom-enduro-workflows/blob/main/README.md
+[postbatch configuration]: ../../admin-manual/configuration.md#postbatch-child-workflow

--- a/docs/src/dev-manual/child-workflows/poststorage.md
+++ b/docs/src/dev-manual/child-workflows/poststorage.md
@@ -1,0 +1,131 @@
+# Poststorage workflows
+
+A poststorage child workflow runs institution specific activities after an AIP
+has been stored. It can notify an external system, synchronize metadata, or
+perform other work that needs the stored AIP's identifier.
+
+The parent is the SIP processing workflow. Enduro waits for the poststorage
+result before completing that workflow.
+
+## Execution and contract
+
+For [a3m] processing, Enduro starts poststorage after the accepted AIP has been
+moved to permanent storage and that operation has completed. For
+[Archivematica], it starts after preservation processing has completed and
+Enduro has registered the stored AIP. The poststorage workflow is only run if
+the AIP is stored successfully; it is not run if preservation or storage fail,
+or if the AIP is rejected.
+
+The Temporal child workflow type is the configured `workflowName`. Enduro
+dispatches it to the configured `taskQueue` with these options:
+
+* `WorkflowID`: `<workflowName>-<AIP UUID>`
+* `TaskQueue`: the configured `taskQueue`
+* `ParentClosePolicy`: `PARENT_CLOSE_POLICY_TERMINATE`
+
+The poststorage worker must register the workflow using the configured
+`workflowName`, poll the configured queue, and connect to Enduro's Temporal
+namespace.
+
+Enduro does not explicitly set a child timeout or retry policy. Other child
+options follow Temporal's inheritance and default rules. Workflow executions
+do not have a retry policy by default.
+
+A poststorage workflow is executed with `childwf.PostStorageParams`:
+
+| Field | Type | Value supplied by Enduro |
+| --- | --- | --- |
+| `User` | `*childwf.User` | The initiating user's email, or `nil` when unavailable. |
+| `AIPUUID` | `string` | The stored AIP's UUID as a string. |
+| `CustomMetadata` | `childwf.CustomMetadata` | Metadata from successful preprocessing, or an empty value if no metadata was produced. |
+
+The passed parameters do not include the SIP ID or name, a filesystem path, a
+storage location, or a complete AIP record. Use the AIP UUID to query the Enduro
+or the Archivematica Storage Service APIs if the integration needs more
+information about the stored AIP.
+
+A poststorage workflow returns a `childwf.PostStorageResult`:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `Outcome` | `childwf.Outcome` | `OutcomeSuccess`, `OutcomeSystemError`, or `OutcomeContentError`. |
+| `CustomMetadata` | `childwf.CustomMetadata` | Additional opaque JSON metadata. |
+| `Tasks` | `[]*childwf.Task` | The child workflow's returned task records. |
+
+## Result handling
+
+The Enduro processing workflow waits for the poststorage workflow to complete
+and then, in order:
+
+1. merges returned custom metadata into the preprocessing metadata at the
+   map's top level;
+2. saves the returned tasks; and
+3. interprets the returned outcome.
+
+This order also applies to a decodable content or system failure result.
+
+Enduro does not receive tasks in real time: they appear through the API and
+dashboard only after the child has completed and Temporal has returned its
+result.
+
+The outcome determines the remaining SIP processing behavior:
+
+* `OutcomeSuccess`: continue and finish normal processing.
+* `OutcomeContentError`: set the SIP status to "failed" and exit the processing
+  workflow with a content error.
+* `OutcomeSystemError`: set the SIP status to "error" and exit the processing
+  workflow with a system error.
+* Any other value: treat the result as a system error.
+
+For an expected validation, policy, or integration failure, record the details
+in completed tasks, set the structured outcome, and return the result with a
+nil Go error. Enduro then saves the task records before applying the failure
+state. See [Results and workflow errors] for the shared rule and helpers.
+
+An actual Temporal workflow error prevents Enduro from decoding the result, so
+no returned tasks or metadata are available. Enduro treats an error other than
+cancellation as a system error.
+
+If the Enduro parent closes while poststorage is active, the Parent Close
+Policy terminates the child.
+
+Because storage has already completed, neither a structured failure nor a
+workflow error rolls back or removes the AIP. Enduro may subsequently mark the
+SIP and its processing workflow as failed or in error.
+
+## How metadata is merged
+
+Preprocessing metadata is the base map. For every entry returned by
+poststorage, Enduro assigns its `json.RawMessage` to the same key in the base
+map. Thus:
+
+* a new poststorage key is added;
+* an existing key is replaced in full by the poststorage value;
+* Enduro does not recursively merge JSON objects inside a value; and
+* an empty poststorage map leaves preprocessing metadata unchanged.
+
+A poststorage value replaces the preprocessing value when their keys conflict.
+Use distinct keys when both values must be retained.
+
+The final merged metadata can be supplied to a postbatch workflow, but only if
+the overall SIP processing workflow completes successfully. Metadata from a
+poststorage result may be merged into the processing workflow's state before
+Enduro applies its failure outcome, but failed or canceled SIP processing does
+not return that metadata to the batch parent.
+
+## Enable the workflow
+
+Add one `[[childWorkflows]]` entry with `type = "poststorage"`, the worker's
+task queue, and its registered workflow name. See the administrator manual's
+[poststorage configuration] and the [custom workflow template].
+
+For complete implementations used in production, see the [SFA APIS poststorage
+workflow] and [SFA cantons poststorage workflow].
+
+[a3m]: ../../user-manual/components/#preservation-engine
+[Archivematica]: ../../user-manual/components/#preservation-engine
+[custom workflow template]: https://github.com/artefactual-sdps/custom-enduro-workflows/blob/main/README.md
+[poststorage configuration]: ../../admin-manual/configuration.md#poststorage-child-workflow
+[Results and workflow errors]: index.md#results-and-workflow-errors
+[SFA APIS poststorage workflow]: https://github.com/artefactual-sdps/sfa-enduro-workflows/blob/main/internal/workflows/poststorage_apis.go
+[SFA cantons poststorage workflow]: https://github.com/artefactual-sdps/sfa-enduro-workflows/blob/main/internal/workflows/poststorage_cantons.go

--- a/docs/src/dev-manual/child-workflows/preprocessing.md
+++ b/docs/src/dev-manual/child-workflows/preprocessing.md
@@ -1,0 +1,245 @@
+# Preprocessing workflows
+
+A preprocessing child workflow prepares a SIP after Enduro has downloaded it
+and before Enduro sends a package to the preservation engine. It is the
+extension point for validation, extraction, restructuring, metadata generation,
+and other preparation needed by an organization.
+
+The parent is Enduro's processing workflow. It waits for preprocessing to
+finish, interprets the returned outcome, and requires the successful result to
+identify a BagIt bag that it can continue processing.
+
+## Execution and contract
+
+Before starting the child, Enduro determines the extension and checksum for a
+SIP that is not a directory and performs the duplicate check when
+`ingest.allowDuplicates = false`. It may also extract the object as described
+in [Extraction](#extraction).
+
+The Temporal child workflow type is the configured `workflowName`. Enduro
+dispatches it to the configured `taskQueue` with these options:
+
+* `WorkflowID`: `<workflowName>-<SIP UUID>`
+* `TaskQueue`: the configured `taskQueue`
+* `ParentClosePolicy`: `PARENT_CLOSE_POLICY_TERMINATE`
+
+The preprocessing worker must register the workflow using the configured
+`workflowName`, poll the configured queue, and connect to Enduro's Temporal
+namespace.
+
+Enduro does not explicitly set a child timeout or retry policy. Other child
+options follow Temporal's inheritance and default rules. Workflow executions
+do not have a retry policy by default.
+
+A preprocessing workflow is executed with `childwf.PreprocessingParams`:
+
+| Field | Type | Value supplied by Enduro |
+| --- | --- | --- |
+| `User` | `*childwf.User` | The initiating user's email, or `nil` when no user is associated with the ingest. |
+| `RelativePath` | `string` | The SIP path below the shared storage root. Enduro derives it from the `sharedPath` in its `[[childWorkflows]]` entry. |
+| `SIPID` | `uuid.UUID` | The Enduro SIP UUID. |
+| `BatchID` | `uuid.UUID` | The batch UUID, or `uuid.Nil` when the SIP is not in a batch. |
+| `SIPName` | `string` | The SIP name recorded by Enduro. |
+
+A preprocessing workflow returns a `childwf.PreprocessingResult`:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `Outcome` | `childwf.Outcome` | `OutcomeSuccess`, `OutcomeSystemError`, or `OutcomeContentError`. |
+| `CustomMetadata` | `childwf.CustomMetadata` | Opaque JSON values to make available to later custom workflows. |
+| `RelativePath` | `string` | The final package path below the same shared storage root. The child must return a relative path, not its absolute path. |
+| `Tasks` | `[]*childwf.Task` | The child workflow's returned task records. |
+
+## Shared path
+
+A preprocessing child reads and may change the SIP files. For filesystem
+access, Temporal sends `RelativePath`; it neither transfers the files nor
+exposes either worker's absolute path. The Enduro worker and custom worker must
+therefore have access to the same storage.
+
+Enduro downloads the SIP below the `sharedPath` configured in its
+`[[childWorkflows]]` entry and derives `params.RelativePath` from the path below
+that root.
+
+The custom worker must configure the root as it sees it. The example Go
+projects also call this setting `sharedPath`, but it belongs to the custom
+project and is not part of the `pkg/childwf` contract. The two absolute paths
+may differ. For example, the [template project] uses this mapping:
+
+```text
+Enduro sharedPath:       /home/enduro/preprocessing
+Child sharedPath:        /home/enduro/shared
+params.RelativePath:     ingest-dir/sip.zip
+
+Path seen by Enduro:     /home/enduro/preprocessing/ingest-dir/sip.zip
+Path seen by the child:  /home/enduro/shared/ingest-dir/sip.zip
+```
+
+Both full paths refer to the same file on `preprocessing-pvc`. The child joins
+its own root to the received value before it reads or changes the SIP:
+
+```go
+sipPath := filepath.Join(cfg.SharedPath, params.RelativePath)
+```
+
+The result follows the same rule in the other direction. If the final package
+stays in place, copy `params.RelativePath` to `result.RelativePath`. If the
+child moves it, derive a new path relative to the child's shared root. Return a
+path within the shared storage, not an absolute path from either worker.
+
+On a successful outcome, Enduro cleans `result.RelativePath`, joins it to its
+own `sharedPath`, and uses that full path for the rest of processing. See the
+[template Tilt setup] for the settings and mounts that provide this storage in
+the local development cluster.
+
+## Extraction
+
+The preprocessing `extract` setting controls only whether Enduro runs its
+archive extraction step before it starts the child. It is not a field in
+`childwf.PreprocessingParams`, so the child does not receive its value. Set it
+to match what the registered workflow expects:
+
+* With `extract = false`, the default, Enduro attempts to extract a downloaded
+  file before it starts the child. After a successful extraction,
+  `params.RelativePath` points to the extracted directory. If Enduro does not
+  recognize the file as an archive, the path still points to the original
+  file. Enduro leaves a downloaded directory unchanged. Any other extraction
+  error stops processing before the child starts.
+* With `extract = true`, Enduro skips its archive extraction step.
+  `params.RelativePath` points to the original downloaded file or directory.
+  The child decides whether extraction is needed and must update
+  `result.RelativePath` if the final package is in a different place.
+
+For a source that is not a directory, Enduro calculates the checksum and
+performs any duplicate check before either extraction path. Shared storage is
+always required. Regardless of the `extract` value, a successful child must
+leave a BagIt bag in shared storage and return its relative directory path.
+Enduro then classifies and validates the returned package and stops SIP
+processing if it is not a BagIt bag.
+
+The [template project] uses `extract = false` and bags the received path,
+whereas the [SFA preprocessing workflow] uses `extract = true` and extracts the
+original archive itself.
+
+## Results, tasks, and metadata
+
+Enduro does not receive `Tasks` as they are created. Returned tasks become
+available only when Temporal returns a decodable result. A pending task that
+Enduro creates for a [human decision](#human-decisions) is the exception.
+
+For a decodable result, Enduro adopts the returned path and metadata only when
+the outcome is successful. It then saves, attaches, and exposes the returned
+tasks before applying the outcome behavior:
+
+* `OutcomeSuccess`: use `RelativePath`, retain `CustomMetadata`, and continue
+  processing.
+* `OutcomeContentError`: set the SIP status to "failed" and exit the processing
+  workflow with a content error.
+* `OutcomeSystemError`: set the SIP status to "error" and exit the processing
+  workflow with a system error.
+* Any other value: treat the result as a system error.
+
+Metadata from a successful preprocessing result is passed to the poststorage
+workflow and, if processing ultimately succeeds, to the postbatch workflow.
+Enduro treats the JSON values as opaque.
+
+For an expected validation, policy, or processing failure, populate the result
+outcome and completed tasks and return the result with a nil Go error. This
+preserves the error details and lets Enduro apply the intended SIP failure
+state. See [Results and workflow errors] for the shared rule and helper
+functions.
+
+If the child instead returns a Temporal workflow error, Enduro cannot decode a
+result at the same time. It therefore receives no returned tasks, path, or
+metadata and treats an error other than cancellation as a system error.
+
+If the Enduro parent closes while preprocessing is active, the configured
+parent close policy terminates the child.
+
+## Human decisions
+
+Preprocessing is the only custom extension point with an Enduro bridge for a
+human decision. The bridge uses two Temporal Signals between child and parent,
+a Query for API reads, and an Update for API writes.
+
+The child initiates the exchange by signaling its exact parent execution and
+then waiting for the response signal:
+
+```go
+info := workflow.GetInfo(ctx)
+if info.ParentWorkflowExecution == nil {
+    return nil, errors.New("decision request requires a parent workflow")
+}
+request := childwf.DecisionRequest{
+    Message: "The package needs review.",
+    Options: []string{"Continue", "Reject"},
+}
+err := workflow.SignalExternalWorkflow(
+    ctx,
+    info.ParentWorkflowExecution.ID,
+    info.ParentWorkflowExecution.RunID,
+    childwf.DecisionRequestSignalName,
+    request,
+).Get(ctx, nil)
+if err != nil {
+    return nil, err
+}
+
+var response childwf.DecisionResponse
+workflow.GetSignalChannel(
+    ctx,
+    childwf.DecisionResponseSignalName,
+).Receive(ctx, &response)
+```
+
+Production code should classify signaling failures into an appropriate result
+or workflow error. The [SFA preprocessing workflow] contains a complete
+implementation.
+
+The full flow is:
+
+1. The child signals `decision-request-signal` with
+   `childwf.DecisionRequest{Message string, Options []string}`. Its message must
+   not be blank and it must provide at least one option.
+2. The Enduro processing workflow receives and validates the request. Only one
+   request may be pending at a time. It creates a pending Enduro task named
+   `Preprocessing workflow is waiting for user decision`, records the request
+   in its Temporal workflow state, then changes the SIP and workflow to pending.
+3. `GET /ingest/sips/{uuid}/decision` queries the parent with
+   `child-decision-query`. The dashboard displays the message and options to a
+   user with the `ingest:sips:decision` permission.
+4. The user submits `{"option":"<selected option>"}` through
+   `POST /ingest/sips/{uuid}/decision`. Enduro validates that the option was
+   offered, creates `childwf.DecisionResponse{Option string}`, then sends the
+   parent the tracked `child-decision-update` Update.
+5. The parent records the response in workflow state, signals the exact child
+   execution with `decision-response-signal`, restores processing statuses, and
+   completes the pending Enduro task with the selected option.
+6. The child's call to `Receive` returns. The child interprets
+   `response.Option` and resumes its own workflow logic.
+
+Signals are asynchronous messages recorded in Temporal history. The API waits
+for the parent Update handler to accept and store the response, not for the
+child to resume or finish. The pending request and response are durable
+workflow state that Temporal restores from history. The visible task and entity
+statuses are also persisted in Enduro's database. The child must keep waiting on
+`decision-response-signal` to receive the choice.
+
+Option strings have no predefined meaning. In particular, an option named
+`Cancel` does not cancel the workflow automatically. The child must classify
+and represent the chosen outcome itself.
+
+## Enable the workflow
+
+Add one `[[childWorkflows]]` entry with `type = "preprocessing"`, the worker's
+task queue and registration name, and the required shared path. Set `extract`
+according to whether Enduro or the child extracts the SIP. See the administrator
+manual's [preprocessing configuration] for the complete settings and the
+[custom workflow template] for worker and local Kubernetes setup.
+
+[custom workflow template]: https://github.com/artefactual-sdps/custom-enduro-workflows/blob/main/README.md
+[preprocessing configuration]: ../../admin-manual/configuration.md#preprocessing-child-workflow
+[Results and workflow errors]: index.md#results-and-workflow-errors
+[SFA preprocessing workflow]: https://github.com/artefactual-sdps/sfa-enduro-workflows/blob/main/internal/workflows/preprocessing.go
+[template project]: https://github.com/artefactual-sdps/custom-enduro-workflows
+[template Tilt setup]: https://github.com/artefactual-sdps/custom-enduro-workflows/blob/main/README.md#develop-with-enduro

--- a/docs/src/dev-manual/devel.md
+++ b/docs/src/dev-manual/devel.md
@@ -201,7 +201,7 @@ ENDURO_PRES_SYSTEM=a3m
 LOCAL_A3M=true
 OBJECT_STORE=seaweedfs
 DASHBOARD_DEV=true
-CHILD_WORKFLOW_PATHS='../preprocessing-acme:../acme-enduro-workflows'
+CHILD_WORKFLOW_PATHS='../custom-enduro-workflows:../sfa-enduro-workflows'
 MOUNT_PREPROCESSING_VOLUME=true
 ```
 
@@ -275,10 +275,9 @@ image target and serves the dashboard with Nginx.
 ### CHILD_WORKFLOW_PATHS
 
 A colon (:) separated list of relative paths to child workflow repositories. At
-startup Tilt will attempt to load a `Tiltfile` file from each path which will
-add any workflow specific resources to the Tilt environment (e.g. a child
-worker). See the [Administrator configuration] docs for instructions on
-configuring the child workflows.
+startup, Tilt loads a `Tiltfile` from each path to add a child worker and other
+resources. See the [custom workflow template] for worker setup and [child
+workflow configuration] for the Enduro settings.
 
 ### MOUNT_PREPROCESSING_VOLUME
 
@@ -446,7 +445,8 @@ kubectl -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
     -exec rm -rf {} +
 ```
 
-[administrator configuration]: ../admin-manual/configuration.md
+[child workflow configuration]: ../admin-manual/configuration.md#child-workflows
+[custom workflow template]: https://github.com/artefactual-sdps/custom-enduro-workflows/blob/main/README.md#develop-with-enduro
 [docker]: https://docs.docker.com/get-docker/
 [kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
 [tilt]: https://docs.tilt.dev/tutorial/1-prerequisites.html#install-tilt

--- a/docs/src/user-manual/glossary.md
+++ b/docs/src/user-manual/glossary.md
@@ -1,10 +1,10 @@
 # Glossary
 
-This glossary of terms outlines the domain-specific language used when
-discussing the Enduro functionality described throughout the User Manual, as it
-relates to ingest and digital preservation. While some technical terms are
-included, the definitions provided here may not always match exactly how
-these terms are used in the related technologies used by Enduro.
+This glossary of terms outlines the domain-specific language used throughout
+the Enduro documentation for ingest and digital preservation. While some
+technical terms are included, the definitions provided here may not always
+match exactly how these terms are used in the related technologies used by
+Enduro.
 
 If other glossary terms appear in the definition of a term, they will be
 **bolded** the first time they are used, so readers are aware that a related
@@ -14,7 +14,10 @@ definition is available.
 
 ## Activity
 
-See [Task](#task).
+In Temporal, an Activity is a function or method scheduled by a Workflow,
+usually to perform filesystem or network input and output. It is distinct from
+an Enduro task record. In general preservation language, activity can also mean
+an operation; see [Task](#task).
 
 ## Agent
 
@@ -50,22 +53,20 @@ structure](https://www.archivematica.org/docs/latest/user-manual/archival-storag
 
 ## Child workflow
 
-An ancillary **workflow** that is spawned by another workflow. This capability
-allows breaking down complex **tasks** into manageable units, improving
-maintainability, extensibility and scaling operations.
+A **workflow** started by another workflow, known as its parent. The parent and
+child run as separate Temporal executions.
 
-In Enduro, we recommend using child workflows to manage user-specific tasks and
-**preservation actions** in a workflow, such as **SIP** validation against a set
-of institution-specific requirements. This keeps locally specific
-implementations nicely separated from more general, reusable workflow activities
-available in Enduro Ingest.
+Enduro uses custom child workflows to add processing needed by an organization
+at three extension points: preprocessing, poststorage, and postbatch. This keeps
+custom code separate from Enduro. See [Custom child workflows] for the
+contracts, behavior, and guidance on building and running a worker.
 
 ## Content failure
 
-An failure in an **ingest** **workflow** that occurs during **SIP** validation,
-related to the submitted package's structure, files, or metadata, that must be
-resolved by the original package submitter or another operator. See also:
-[System error](#system-error).
+A failure in an **ingest** **workflow** caused by the submitted package or its
+metadata not meeting a policy requirement, rather than by a technical problem.
+It generally must be resolved by the producer or an operator. See also: [System
+error](#system-error).
 
 ## Derivative
 
@@ -225,6 +226,16 @@ A package will contain one or more **objects**, zero or more **files**, and
 An instance of a **preservation engine** configured with specific **preservation
 policies**, through which **packages** pass as part of a **workflow**.
 
+## Post-batch
+
+Post-batch is a phase in a batch ingest **workflow** for tasks performed after a
+group of **SIPs** has been processed. Examples include preparing reports or
+sending batch data to an external system.
+
+Enduro implements this extension point as the `postbatch` custom child
+workflow, which runs after the SIP workflows in a batch have ended. See
+[Postbatch child workflows].
+
 ## Post-storage
 
 Post-storage is a phase in a **preservation workflow** describing all the
@@ -234,11 +245,18 @@ additional compression and/or encryption of AIPs, sending any **metadata** to an
 external system (such as an archival management system), **DIP** generation and
 delivery, geo-redundant **replication**, etc.
 
+Enduro implements this extension point as the `poststorage` custom child
+workflow, which runs after an AIP is stored. See [Poststorage child workflows].
+
 ## Pre-ingest
 
 Any manual examination, review, and/or additional preparation steps performed on
 **SIPs** received from **producers** prior to **ingest**. Can include activities
-such as appraisal, selection,and SIP arrangement.
+such as appraisal, selection, and SIP arrangement.
+
+Enduro provides a related extension point as the `preprocessing` custom child
+workflow, which runs after a SIP is received and before preservation
+processing. See [Preprocessing child workflows].
 
 ## Preservation action
 
@@ -339,8 +357,9 @@ system administrator or developer to resolve. See also:
 
 ## Task
 
-An operation performed on a **file** or **package** in the context of a
-**workflow**. Also called an **activity**.
+A record of an operation performed on a **file** or **package** in a
+**workflow**. Enduro displays each task with its status and outcome. In general
+preservation language, task and activity may be used interchangeably.
 
 ## Transfer
 
@@ -384,6 +403,10 @@ PREMIS Editorial Committee - "PREMIS Data Dictionary for Preservation Metadata,"
 Version 3.0. June 2015. Glossary, p. 270.
 
 [Add SIPs via a source location]: ../user-manual/ingest/submitting-content.md#initiate-ingest-using-sips-uploaded-to-a-source-location
+[Custom child workflows]: ../dev-manual/child-workflows/index.md
 [Initiate ingest via a watched location upload]: ../user-manual/ingest/submitting-content.md#initiate-ingest-via-a-watched-location-upload
 [object storage]: https://en.wikipedia.org/wiki/Object_storage
+[Postbatch child workflows]: ../dev-manual/child-workflows/postbatch.md
+[Poststorage child workflows]: ../dev-manual/child-workflows/poststorage.md
+[Preprocessing child workflows]: ../dev-manual/child-workflows/preprocessing.md
 [Watched location configuration]: ../admin-manual/configuration.md#watched-location-configuration

--- a/docs/src/user-manual/ingest/index.md
+++ b/docs/src/user-manual/ingest/index.md
@@ -1,27 +1,16 @@
 # Ingest
 
-In Enduro, **[Ingest](../glossary.md#ingest)** is defined as a phase in a
-preservation workflow describing all the preservation policy-defined tasks
-performed on a SIP when it is received from a producer, prior to preservation.
-Typically this phase covers **validation** activities (performed against SIP
-files, structure, and/or metadata) as well as any **package transformations**
-(removal of unneeded or temporary files, restructuring, etc) to optimize the
-package for further processing by the preservation engine.
+In Enduro, **[Ingest]** is defined as a phase in a preservation workflow
+describing all the preservation policy-defined tasks performed on a SIP when it
+is received from a producer, prior to preservation. Typically this phase covers
+**validation** activities (performed against SIP files, structure, and/or
+metadata) as well as any **package transformations** (removal of unneeded or
+temporary files, restructuring, etc) to optimize the package for further
+processing by the preservation engine.
 
-At installation, Enduro's default ingest functionality is minimal - see the
-[Default ingest workflow](managing-ingest-workflows.md#default-ingest-workflow)
-documentation for more details. However, Enduro's workflows are intended to be
-customized via the addition of [child workflows], which can be designed to
-implement the specific ingest needs of a given organization.
+Enduro provides a minimal [Default ingest workflow] that organizations can
+extend with [child workflows].
 
-The Enduro project maintains general default workflow activities in a separate
-code repository, called [temporal-activities][temporal-activities]. An example
-of child workflow activities for a specific organization can be seen in the
-[preprocessing-sfa][preprocessing-sfa] repository. Artefactual also maintains a
-template that organizations can use to create their own child workflow
-activities repository, called [preprocessing-base][preprocessing-base].
-
-[child workflows]: ../../admin-manual/configuration.md#child-workflows
-[preprocessing-base]: https://github.com/artefactual-sdps/preprocessing-base
-[preprocessing-sfa]: https://github.com/artefactual-sdps/preprocessing-sfa
-[temporal-activities]: https://github.com/artefactual-sdps/temporal-activities
+[child workflows]: ../glossary.md#child-workflow
+[Default ingest workflow]: managing-ingest-workflows.md#default-ingest-workflow
+[Ingest]: ../glossary.md#ingest

--- a/docs/src/user-manual/ingest/managing-ingest-workflows.md
+++ b/docs/src/user-manual/ingest/managing-ingest-workflows.md
@@ -125,12 +125,12 @@ task statuses, with a few additional statuses:
 #### Errors vs failures
 
 To help operators better understand the cause of an unsuccessful workflow,
-Enduro uses different statuses for  a [content failure] and a [system error].
+Enduro uses different statuses for a [content failure] and a [system error].
 
-When a task in an ingest workflow fails validation due to some element of the
-submitted content (e.g. SIP structure, metadata, files, etc) not matching the
-criteria defined in the workflow task, this is a **content failure**, and the
-related task will be given a status of: **FAILED**. When the workflow finishes
+When an ingest task provided by Enduro fails validation because some element of
+the submitted content (e.g. SIP structure, metadata, files, etc) does not match
+the criteria defined in the workflow task, this is a **content failure**, and
+the related task will have a **FAILED** status. When the workflow finishes
 running as far as it can, it will then be given the same failed status.
 
 These issues are generally ones that can be fixed by the original producer or by
@@ -145,10 +145,14 @@ not the system itself. Producers and/or operators can then choose to:
 * Resubmit the SIP for ingest
 
 Conversely, Enduro will use an **ERROR** status when a **system error**
-interrupts one or more ingest tasks, causing the workflow to halt. This might be
-due to network interruptions, disk space issues, hardware malfunctions, or
-software bugs - generally, a system administrator will be needed to resolve the
-issue upstream before ingest can be tried again.
+interrupts one or more ingest tasks provided by Enduro, causing the workflow to
+halt. This might be due to network interruptions, disk space issues, hardware
+malfunctions, or software bugs - generally, a system administrator will be
+needed to resolve the issue upstream before ingest can be tried again.
+
+Enduro uses the structured result returned by the preprocessing and poststorage
+[child workflows] to decide whether ingest continues, fails, or enters an error
+state.
 
 #### Pending tasks and workflows
 
@@ -160,21 +164,29 @@ provided and the workflow remains paused until input is received. For example, a
 package deletion request initiated by an operator might then show "Approve" and
 "Deny" buttons in the workflow details header.
 
+A preprocessing child workflow can also request a human decision.
+
 ### Workflow tasks
 
 A workflow is a sequence of tasks managed by Enduro. The **Ingest workflow
-details** area will list all workflows that have been run against a given
-package in ascending order, with the most recent on the top.
+details** area lists all workflows run against a package in reverse
+chronological order, with the most recent first.
 
 Click anywhere on the **workflow header card** to expand it and see a list of
-all tasks run as part of that workflow. Tasks are also shown in ascending order,
-with the most recent tasks at the top of the list.
+all tasks run as part of that workflow. Tasks are also listed with the most
+recent first.
 
 ![A workflow header card expanded to show the task list below](../screenshots/workflow-details-expanded.png)
 
-Tasks shown in this area will include both those ingest tasks performed by
-Enduro, as well as tasks run by the configured [preservation engine] if the SIP
-passes initial validation and transformation.
+Tasks shown in this area include ingest tasks performed by Enduro, tasks run by
+the configured [preservation engine] if the SIP passes initial validation and
+transformation, and task records returned by configured preprocessing and
+poststorage child workflows.
+
+Returned child workflow tasks appear only after the child finishes. A pending
+decision task created by Enduro is the exception: it is visible while a
+preprocessing child waits for an operator's response. Postbatch child workflows
+do not add tasks to the Enduro interface.
 
 Task rows include:
 
@@ -188,17 +200,17 @@ Task rows include:
   error. Otherwise, "**Started**" shows when the task began. A dash is shown if
   neither timestamp is available
 
-Additionally, those ingest tasks run by Enduro will include an additional
-description of the **task outcome**:
+Enduro ingest tasks also include a description of the **task outcome**:
 
 ![Task rows with a successful outcome](../screenshots/task-details-success.png)
 
 ### Errors and failed package downloads
 
-If an ingest task **fails** or encounters an **error**, Enduro will attempt to
-continue running any remaining validation tasks to gather as much information
-about the SIP as possible, but will terminate the workflow before transforming
-the package and delivering it to the [preservation engine].
+If one of the validation tasks provided by Enduro **fails** or encounters an
+**error**, Enduro will attempt to continue running any remaining validation
+tasks to gather as much information about the SIP as possible, but will
+terminate the workflow before transforming the package and delivering it to the
+[preservation engine].
 
 The **task details** will then provide operators with additional context on the
 problem encountered.
@@ -210,39 +222,17 @@ widget](#related-packages) to inspect it.
 
 ## Default ingest workflow
 
-At installation, Enduro's default ingest functionality is minimal - the
-application can receive and unpack SIPs, validate any included
+Enduro's default ingest workflow can receive and unpack SIPs, validate included
 [BagIt bags][bag], and then restructure and deliver the package for
-preservation with either [Archivematica][Archivematica] or [a3m][a3m]. However,
-Enduro's workflows are intended to be customized via the addition of
-**[child workflows]**, which can be designed to implement the specific ingest
-needs of a given organization.
+preservation with either [Archivematica][Archivematica] or [a3m][a3m]. An
+organization can add **[child workflows]** to meet its own ingest needs.
 
-The Enduro project maintains general default workflow activities in a separate
-code repository, called [temporal-activities]. An example set of child workflow
-activities for a specific organization can be seen in the
-[preprocessing-sfa][preprocessing-sfa] repository. Artefactual also maintains a
-template that organizations can use to create their own child workflow
-activities repository, called [preprocessing-base][preprocessing-base].
+Developers can start with the [custom-enduro-workflows] template and use the
+[SFA workflows] or [CVA workflows] as examples used in production. Reusable Go
+activities are available from [temporal-activities].
 
-Below is a description of what Enduro's default "Create AIP" workflow would do
-at installation time with no added child workflow activities configured.
-
-!!! tip
-
-    Some of the activities listed in the temporal-activities repository are
-    not used in the default ingest workflow described below. These activities
-    can be customized and implemented as custom child workflow activities by
-    organizations if desired - examples include:
-
-    * `ffvalidate`, which can check the files in SIP against a configured list
-      of allowed or disallowed file formats
-    * `removefiles`, which can be configured to automatically delete specified
-      file types based format (useful for removing hidden files, etc)
-
-    See the
-    [temporal-activities](https://github.com/artefactual-sdps/temporal-activities/tree/main)
-    repository for more information and examples.
+The following sections describe the default "Create AIP" workflow and its
+optional child workflow extension points.
 
 ### Receive SIP
 
@@ -255,40 +245,34 @@ use the [bucketdownload] Temporal activity to retrieve the SIP. Otherwise, if
 the SIP is ingested via [watched location], Enduro instead uses an internal
 download activity to fetch the SIP for internal processing.
 
-### Check for child workflow
+### Run a preprocessing child workflow
 
-Immediately after initial receipt, Enduro next checks to see if a
-[preprocessing child workflow] has been configured. This happens before
-attempting to [determine the SIP type](#classify-sip-type) because Enduro's SIP
-types are very high-level and generic, and therefore not suitable for the level
-of validation that most organizations using Enduro would want. Instead, we
-recommend that organizations using Enduro define one or more specific SIP
-profiles that SIP-submitting producers can use, and then implement custom child
-workflow activities to validate SIPs based on these defined SIP profile
-criteria.
+After downloading the SIP, Enduro performs its initial checks. For a SIP that
+is not a directory, Enduro determines its file extension, calculates its
+checksum, and checks for duplicates if duplicates are not allowed. The
+preprocessing `extract` setting then controls Enduro's archive extraction step.
+With the default value, `false`, Enduro attempts extraction before it starts the
+child. With `true`, Enduro skips the step and the child receives the original
+download.
 
-If a preprocessing child workflow *is* registered, its activities will be run
-next in their configured order. Enduro is not aware of what activities are
-included in a child workflow - it merely waits for the child workflow outcome
-before proceeding.
+Enduro next checks whether a preprocessing child workflow is configured. It
+starts the child before [determining the SIP type](#classify-sip-type). A custom
+workflow can validate the SIP against profiles defined by the organization and
+perform other preparation before preservation processing.
+
+The custom workflow, rather than Enduro configuration, determines which
+Temporal Activities it schedules and in what order. Enduro waits for the child
+result and saves its returned task records. The result outcome determines what
+happens next; only a successful result supplies the path and metadata used by
+later processing.
 
 !!! important
 
-    Currently, to ensure integrity through all transfers, Enduro requires that
-    the [PIP](../glossary.md#processing-information-package-pip) passed to the
-    [preservation engine](../glossary.md#preservation-engine) be a valid BagIt
-    bag. This means that if a preprocessing child workflow is configured, then
-    Enduro will expect the [Classify SIP type](#classify-sip-type) activity to
-    return "Bag" as the SIP type.
-
-    If you are adding a custom ingest child workflow to Enduro, please **ensure
-    that the PIP is a valid Bag before it ends** - the
-    [Temporal activities](https://github.com/artefactual-sdps/temporal-activities)
-    repo has a `bagcreate` activity you can repurpose in your custom child
-    activities workflow.
-
-    If you don't do this, the ingest workflow will fail after the "Classify SIP
-    type" activity!
+    A successful preprocessing child workflow must return a path to a valid
+    BagIt bag for Enduro to use as the [PIP]. See the
+    [preprocessing package requirements](../../dev-manual/child-workflows/preprocessing.md#shared-path)
+    for the shared path and extraction contract. A custom worker can reuse the
+    [bagcreate] activity to create the bag.
 
 ### Classify SIP type
 
@@ -298,9 +282,9 @@ This is a high-level identification of the SIP type into 3 possible types:
 * Standard Archivematica transfer
 * BagIt bag
 
-If any child worklow is configured and the SIP type is **not** "BagIt
-bag," Enduro will also fail the workflow (see [above](#check-for-child-workflow)
-for an explanation why).
+If a preprocessing child workflow is configured and the SIP type is **not**
+"BagIt bag," Enduro will also fail the workflow (see
+[above](#run-a-preprocessing-child-workflow) for an explanation why).
 
 If the type found *is* a bag, Enduro will then validate the bag against the
 [BagIt specification][bag], using the [bagvalidate] Temporal activity. If the
@@ -368,22 +352,16 @@ Once Enduro receives a "completed" status update from the [preservation engine],
 the application will then register the AIP in Enduro's storage component. The
 process is a bit different depending on the preservation engine used.
 
-If [Archivematica] is being used, then Enduro simply records the storage details
-locally for display in the Enduro interface. Alternatively, if [a3m] is being
-used, then Enduro will first upload the AIP to the configured storage location
-and then records the AIP storage details.
+With [Archivematica], Enduro records the storage details for display in its
+interface. With [a3m], Enduro first uploads the AIP to the configured storage
+location and then records its storage details.
 
-### Check for post-storage tasks
+### Run a poststorage child workflow
 
-Enduro's primary configuration file also includes an optional section to
-configure one or more [post-storage] child workflows. Example activities in this
-phase might include sending ingest or package metadata to an external system
-(such as an archival information system or similar), delivering email
-notifications, etc. When configured, the activities are triggered but Enduro
-does not currently wait to determine the final outcome of the post-storage
-worfklow.
-
-This step is bypassed if nothing has been configured.
+When configured, Enduro starts a poststorage child workflow after the AIP is
+stored and waits for its result. The workflow can send metadata or
+notifications, or perform other integrations. A content or system failure can
+mark the SIP ingest as failed or in error, but does not remove the stored AIP.
 
 ### Perform final cleanup
 
@@ -412,14 +390,13 @@ the workflow.
 [bagcreate]: https://github.com/artefactual-sdps/temporal-activities/blob/main/bagcreate/README.md
 [bagvalidate]: https://github.com/artefactual-sdps/temporal-activities/blob/main/bagvalidate/README.md
 [bucketdownload]: https://github.com/artefactual-sdps/temporal-activities/tree/main/bucketdownload
-[child workflows]: ../../admin-manual/configuration.md#child-workflows
+[child workflows]: ../glossary.md#child-workflow
 [content failure]: ../glossary.md#content-failure
+[custom-enduro-workflows]: https://github.com/artefactual-sdps/custom-enduro-workflows
+[CVA workflows]: https://github.com/artefactual-sdps/cva-enduro-workflows
 [PIP]: ../glossary.md#processing-information-package-pip
-[post-storage]: ../glossary.md#post-storage
-[preprocessing child workflow]: ../../admin-manual/configuration.md#preprocessing-child-workflow
-[preprocessing-base]: https://github.com/artefactual-sdps/preprocessing-base
-[preprocessing-sfa]: https://github.com/artefactual-sdps/preprocessing-sfa
 [preservation engine]: ../glossary.md#preservation-engine
+[SFA workflows]: https://github.com/artefactual-sdps/sfa-enduro-workflows
 [SIP source location]: submitting-content.md#initiate-ingest-using-sips-uploaded-to-a-source-location
 [Submitting content for ingest]: submitting-content.md
 [system error]: ../glossary.md#system-error


### PR DESCRIPTION
Document the preprocessing, poststorage, and postbatch extension points, including their contracts, results, tasks, metadata, human decisions, and failure behavior.

Align the administrator and user manuals with the current configuration, ingest behavior, glossary terms, and local Tilt setup.