### PR TITLE
Document the minio watcher `WatchTimeout` setting

### DIFF
--- a/internal/watcher/config.go
+++ b/internal/watcher/config.go
@@ -124,8 +124,10 @@ type MinioConfig struct {
 	// a successful ingest. If negative, SIPs will be retained indefinitely.
 	RetentionPeriod time.Duration
 
-	// PollInterval sets the length of time between Redis polls (default: 1s).
-	PollInterval time.Duration
+	// WatchTimeout sets the maximum time the Watch() method will wait for a
+	// Redis event when the queue is empty before returning a timeout error
+	// (default: 1 minute).
+	WatchTimeout time.Duration
 
 	// WorkflowType specifies which workflow this watcher should execute
 	// (default: "create aip").

--- a/internal/watcher/minio.go
+++ b/internal/watcher/minio.go
@@ -24,7 +24,7 @@ type minioWatcher struct {
 	logger       logr.Logger
 	listName     string
 	failedList   string
-	pollInterval time.Duration
+	watchTimeout time.Duration
 	bucketConfig *bucket.Config
 	*commonWatcherImpl
 }
@@ -72,18 +72,21 @@ func NewMinioWatcher(
 		config.RedisFailedList = config.RedisList + "-failed"
 	}
 
-	pollInterval := config.PollInterval
-	if pollInterval == 0 {
-		pollInterval = time.Minute // Sane default
-	} else if pollInterval < time.Second {
-		pollInterval = time.Second // Must be at least 1s.
+	// Set the maximum time the Watch() method will wait for an redis event
+	// message before returning an error. The redis client's BLMove command has
+	// a minimum timeout value of 1 second, so we enforce that here.
+	timeout := config.WatchTimeout
+	if timeout == 0 {
+		timeout = time.Minute // Sane default, 0 would wait indefinitely.
+	} else if timeout < time.Second {
+		timeout = time.Second
 	}
 
 	return &minioWatcher{
 		client:       client,
 		listName:     config.RedisList,
 		failedList:   config.RedisFailedList,
-		pollInterval: pollInterval,
+		watchTimeout: timeout,
 		logger:       logger,
 		bucketConfig: bucketConfig,
 		commonWatcherImpl: &commonWatcherImpl{
@@ -94,6 +97,16 @@ func NewMinioWatcher(
 	}, nil
 }
 
+// Watch blocks until a new blob event is available in the Redis list. It
+// returns an ErrWatchTimeout error if no event is received before the
+// watchTimeout is exceeded. The returned Cleanup function should be called
+// after processing the event to remove it from the failed event list (see
+// https://redis.io/docs/latest/commands/lmove/#pattern-reliable-queue).
+//
+// TODO: Implement this watcher in a way that cancels the blocking `pop()` call
+// when context is cancelled. The current implementation does not support this
+// because the redis client does not support context cancellation for the BLMove
+// command.
 func (w *minioWatcher) Watch(ctx context.Context) (*BlobEvent, Cleanup, error) {
 	event, val, err := w.pop(ctx)
 	if err != nil {
@@ -130,7 +143,7 @@ func (w *minioWatcher) rem(val string) func(ctx context.Context) error {
 }
 
 func (w *minioWatcher) pop(ctx context.Context) (*BlobEvent, string, error) {
-	val, err := w.client.BLMove(ctx, w.listName, w.failedList, "RIGHT", "LEFT", w.pollInterval).Result()
+	val, err := w.client.BLMove(ctx, w.listName, w.failedList, "RIGHT", "LEFT", w.watchTimeout).Result()
 	if err != nil {
 		return nil, "", fmt.Errorf("error retrieving from Redis list: %w", err)
 	}

--- a/internal/watcher/minio_test.go
+++ b/internal/watcher/minio_test.go
@@ -65,25 +65,16 @@ func cleanup(t *testing.T, m *miniredis.Miniredis) {
 
 func TestWatcherReturnsErrWhenNoMessages(t *testing.T) {
 	m, w := newWatcher(t, func(c *watcher.MinioConfig) {
-		c.PollInterval = time.Second
+		c.WatchTimeout = time.Second // One second is the minimum timeout.
 	})
 	defer cleanup(t, m)
 
-	check := func(t poll.LogT) poll.Result {
-		_, _, err := w.Watch(context.Background())
-
-		if err == nil {
-			return poll.Error(errors.New("watched did not return an error"))
-		}
-
-		if !errors.Is(err, watcher.ErrWatchTimeout) {
-			return poll.Error(fmt.Errorf("error not expected: %w", err))
-		}
-
-		return poll.Success()
-	}
-
-	poll.WaitOn(t, check, poll.WithTimeout(time.Second*2))
+	// Watch() blocks for a full second because that is the minimum timeout
+	// supported by the redis client BLMove() function, and it doesn't support
+	// context cancellation.
+	_, _, err := w.Watch(t.Context())
+	assert.Assert(t, err != nil, "watched did not return an error")
+	assert.ErrorIs(t, err, watcher.ErrWatchTimeout)
 }
 
 func TestWatcherReturnsErrOnInvalidMessages(t *testing.T) {


### PR DESCRIPTION
I spent several hours trying to reduce the time taken by the minioWatcher tests, only to discover that the "PollInterval" setting was actually a timeout value for the redis BLMove() function, and it also doesn't support context cancellation. Change the minioWatcher "pollInterval" setting name and document it's function and limitations.

- Change the name of the minio watcher "PollInterval" setting to "WatchTimeout" and add documentation to describe how it effects the `Watch()` method.
- Add a TODO to the minioWatcher `Watch()` method to add support for context cancellation.
- Explain the minimum "WatchTimeout" value of 1 second.