### PR TITLE
Prevent duplicate Archivematica transfers

### DIFF
--- a/cmd/enduro-am-worker/main.go
+++ b/cmd/enduro-am-worker/main.go
@@ -341,7 +341,7 @@ func main() {
 			temporalsdk_activity.RegisterOptions{Name: am.DeleteTransferActivityName},
 		)
 		w.RegisterActivityWithOptions(
-			am.NewStartTransferActivity(&cfg.AM, amc.Package).Execute,
+			am.NewStartTransferActivity(&cfg.AM, amc).Execute,
 			temporalsdk_activity.RegisterOptions{Name: am.StartTransferActivityName},
 		)
 		w.RegisterActivityWithOptions(

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.11.1
-	go.artefactual.dev/amclient v0.4.1-0.20240705155055-0c5abef5207c
+	go.artefactual.dev/amclient v0.5.0
 	go.artefactual.dev/ssclient v0.11.0
 	go.artefactual.dev/tools v0.26.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0

--- a/go.sum
+++ b/go.sum
@@ -1038,8 +1038,8 @@ github.com/zclconf/go-cty v1.14.4 h1:uXXczd9QDGsgu0i/QFR/hzI5NYCHLf6NQw/atrbnhq8
 github.com/zclconf/go-cty v1.14.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-yaml v1.1.0 h1:nP+jp0qPHv2IhUVqmQSzjvqAWcObN0KBkUl2rWBdig0=
 github.com/zclconf/go-cty-yaml v1.1.0/go.mod h1:9YLUH4g7lOhVWqUbctnVlZ5KLpg7JAprQNgxSZ1Gyxs=
-go.artefactual.dev/amclient v0.4.1-0.20240705155055-0c5abef5207c h1:kMgKuV9yx0LTQpkWdPxPC4GHAKMS9pDQ0x3CD8SmLfI=
-go.artefactual.dev/amclient v0.4.1-0.20240705155055-0c5abef5207c/go.mod h1:oAOlZHC78IWjWDCqRM1/8K1x/WYmRUL3peujKCdoXaA=
+go.artefactual.dev/amclient v0.5.0 h1:qMxc/9VRRONtRIAXs+qHs3PCDhClGZjQHqjBwjsv/w8=
+go.artefactual.dev/amclient v0.5.0/go.mod h1:v2rDC3LY33Yaf8CYB+dP7Q0Rkwco6orEpvbnFMtiuL4=
 go.artefactual.dev/ssclient v0.11.0 h1:mRjB8J0IQ+gjg6ICtZxJm+whG56tvIyxT+x4bO6CQGc=
 go.artefactual.dev/ssclient v0.11.0/go.mod h1:0tO5nOwQ8naw+GcPBi2A7lXzPt4HUn7MPXqQwi7H3jY=
 go.artefactual.dev/tools v0.26.0 h1:OQR88tp4Sqw2ngID9F2mftRN7mgbIRRd97y2K9O919I=

--- a/hack/kube/overlays/dev-am/ambox.yaml
+++ b/hack/kube/overlays/dev-am/ambox.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: ambox
-          image: docker.io/artefactual/ambox:1.0.12
+          image: docker.io/artefactual/ambox:1.0.16
           ports:
             - name: am-dashboard
               containerPort: 64080

--- a/internal/am/start_transfer.go
+++ b/internal/am/start_transfer.go
@@ -1,18 +1,28 @@
 package am
 
 import (
-	context "context"
+	"context"
+	"errors"
+	"net/http"
 	"path/filepath"
 
 	"go.artefactual.dev/amclient"
 	temporal_tools "go.artefactual.dev/tools/temporal"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
 )
 
 const StartTransferActivityName = "start-transfer-activity"
 
 type StartTransferActivity struct {
-	cfg  *Config
-	amps amclient.PackageService
+	cfg                *Config
+	serverInfoProvider serverInfoProvider
+	amps               amclient.PackageService
+}
+
+// serverInfoProvider keeps server discovery separate from PackageService.
+// amclient exposes it directly on Client rather than through a service.
+type serverInfoProvider interface {
+	ServerInfo(context.Context) (*amclient.ServerInfo, *amclient.Response, error)
 }
 
 type StartTransferActivityParams struct {
@@ -30,10 +40,14 @@ type StartTransferActivityResult struct {
 	TransferID string
 }
 
-func NewStartTransferActivity(cfg *Config, amps amclient.PackageService) *StartTransferActivity {
+func NewStartTransferActivity(
+	cfg *Config,
+	client *amclient.Client,
+) *StartTransferActivity {
 	return &StartTransferActivity{
-		cfg:  cfg,
-		amps: amps,
+		cfg:                cfg,
+		serverInfoProvider: client,
+		amps:               client.Package,
 	}
 }
 
@@ -62,16 +76,72 @@ func (a *StartTransferActivity) Execute(
 		transferType = "zipped bag"
 	}
 
+	// Inspect Archivematica on every execution so a running worker notices an
+	// upgrade. Idempotent transfer submission is supported from 1.19.0; if
+	// discovery fails, preserve existing behavior by submitting without a key.
+	idempotencyKey := ""
+	serverInfo, _, err := a.serverInfoProvider.ServerInfo(ctx)
+	if err != nil {
+		logger.Info(
+			"Archivematica version unavailable; submitting transfer without idempotency protection.",
+			"err", err,
+		)
+	} else if serverInfo.Version.AtLeast(1, 19, 0) {
+		idempotencyKey = transferIdempotencyKey(temporalsdk_activity.GetInfo(ctx))
+	}
+
 	payload, resp, err := a.amps.Create(ctx, &amclient.PackageCreateRequest{
 		Name:             opts.Name,
 		Type:             transferType,
 		Path:             filepath.Join(a.cfg.TransferSourcePath, opts.RelativePath),
 		ProcessingConfig: processingConfig,
-		AutoApprove:      true,
+		AutoApprove:      new(true),
+		IdempotencyKey:   idempotencyKey,
 	})
 	if err != nil {
+		// Interpret 409 and 422 as idempotency responses only when a key was
+		// sent. A pending request should be retried; reusing the key with a
+		// different payload is permanent and must stop Temporal retries.
+		if idempotencyKey != "" && resp != nil && resp.Response != nil {
+			switch resp.StatusCode {
+			case http.StatusConflict:
+				return nil, errors.New("transfer request is still in progress")
+			case http.StatusUnprocessableEntity:
+				return nil, temporal_tools.NewNonRetryableError(
+					errors.New("idempotency key was reused with a different transfer request"),
+				)
+			}
+		}
 		return nil, convertAMClientError(resp, err)
 	}
 
 	return &StartTransferActivityResult{TransferID: payload.ID}, nil
+}
+
+// transferIdempotencyKey derives the key from Temporal's workflow run ID. It
+// identifies one logical Archivematica transfer submission and follows the
+// retry semantics in the IETF HTTPAPI working-group draft:
+// https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/
+//
+// The workflow run ID is the right scope because:
+//
+//   - Automatic retries: Activity and worker-session retries remain in the same
+//     run. If Archivematica commits a request but its response never reaches
+//     Enduro, the same key replays the transfer instead of creating a duplicate.
+//     Activity IDs are too narrow because session retries can change them.
+//   - User-triggered retries: Enduro Retry/reprocessing starts a new run and
+//     should create a new transfer. SIP and workflow IDs are too broad because
+//     they remain stable.
+//   - Changed requests: A worker-session retry can change the PIP path.
+//     Archivematica then returns HTTP 422 instead of creating a duplicate.
+//     Automatic recovery would require Enduro to persist the original request.
+//   - Scope limit: This assumes one transfer per workflow run. Supporting more
+//     would require a persisted per-submission ID.
+func transferIdempotencyKey(info temporalsdk_activity.Info) string {
+	runID := info.WorkflowExecution.RunID
+	if runID == "" {
+		return ""
+	}
+
+	return "enduro-transfer-" + runID
 }

--- a/internal/am/start_transfer_test.go
+++ b/internal/am/start_transfer_test.go
@@ -1,10 +1,13 @@
 package am_test
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"go.artefactual.dev/amclient"
 	"go.artefactual.dev/amclient/amclienttest"
 	"go.artefactual.dev/tools/mockutil"
@@ -20,109 +23,283 @@ import (
 func TestStartTransferActivity(t *testing.T) {
 	t.Parallel()
 
-	transferID := uuid.New().String()
-	opts := am.StartTransferActivityParams{
-		Name:         "Testing",
-		ZipPIP:       true,
-		RelativePath: "/tmp",
-	}
+	for _, tt := range []struct {
+		name            string
+		statusCode      int
+		serverVersion   string
+		wantErr         string
+		wantNonRetryErr bool
+	}{
+		{
+			name:       "Returns transfer ID",
+			statusCode: http.StatusAccepted,
+		},
+		{
+			name:            "Returns an invalid credentials error",
+			statusCode:      http.StatusUnauthorized,
+			wantErr:         "invalid Archivematica credentials",
+			wantNonRetryErr: true,
+		},
+		{
+			name:            "Returns an insufficient permissions error",
+			statusCode:      http.StatusForbidden,
+			wantErr:         "insufficient Archivematica permissions",
+			wantNonRetryErr: true,
+		},
+		{
+			name:            "Returns a not found error",
+			statusCode:      http.StatusNotFound,
+			wantErr:         "Archivematica resource not found",
+			wantNonRetryErr: true,
+		},
+		{
+			name:       "Retries a request in progress",
+			statusCode: http.StatusConflict,
+			wantErr:    "transfer request is still in progress",
+		},
+		{
+			name:            "Rejects a changed idempotent request",
+			statusCode:      http.StatusUnprocessableEntity,
+			wantErr:         "idempotency key was reused with a different transfer request",
+			wantNonRetryErr: true,
+		},
+		{
+			name:            "Preserves ordinary conflict handling without a key",
+			statusCode:      http.StatusConflict,
+			serverVersion:   "1.18.9",
+			wantErr:         "Archivematica error: 409 Conflict",
+			wantNonRetryErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			serverVersion := tt.serverVersion
+			if serverVersion == "" {
+				serverVersion = "1.19.0"
+			}
 
-	amcrDefault := func(m *amclienttest.MockPackageServiceMockRecorder, st http.Response) {
-		m.Create(
-			mockutil.Context(),
-			&amclient.PackageCreateRequest{
-				Name:             opts.Name,
-				Path:             opts.RelativePath,
-				Type:             "zipped bag",
-				ProcessingConfig: "automated",
-				AutoApprove:      true,
-			},
-		).Return(
-			&amclient.PackageCreateResponse{ID: transferID},
-			&amclient.Response{Response: &st},
-			&amclient.ErrorResponse{Response: &st},
-		)
-	}
+			ctrl := gomock.NewController(t)
+			packageService := amclienttest.NewMockPackageService(ctrl)
+			var gotReq *amclient.PackageCreateRequest
+			packageService.EXPECT().
+				Create(mockutil.Context(), gomock.Any()).
+				DoAndReturn(func(
+					_ context.Context,
+					req *amclient.PackageCreateRequest,
+				) (*amclient.PackageCreateResponse, *amclient.Response, error) {
+					gotReq = req
+					resp := packageCreateResponse(tt.statusCode)
+					if tt.statusCode == http.StatusAccepted {
+						return &amclient.PackageCreateResponse{ID: "transfer-id"}, resp, nil
+					}
+					return nil, resp, &amclient.ErrorResponse{Response: resp.Response}
+				})
 
-	type test struct {
-		name   string
-		want   am.StartTransferActivityResult
-		amcr   func(*amclienttest.MockPackageServiceMockRecorder, http.Response)
-		st     http.Response
-		errMsg string
+			client := newStartTransferTestClient(
+				t,
+				packageService,
+				func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("X-Archivematica-Version", serverVersion)
+					w.WriteHeader(http.StatusNotImplemented)
+				},
+			)
+			activity := am.NewStartTransferActivity(&am.Config{}, client)
+
+			result, err := executeStartTransferActivity(t, activity)
+
+			if tt.wantErr == "" {
+				assert.NilError(t, err)
+				assert.DeepEqual(t, result, &am.StartTransferActivityResult{TransferID: "transfer-id"})
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.Equal(t, temporal.NonRetryableError(err), tt.wantNonRetryErr)
+			}
+
+			assert.Assert(t, gotReq != nil)
+			if serverVersion == "1.19.0" {
+				assert.Assert(t, strings.HasPrefix(gotReq.IdempotencyKey, "enduro-transfer-"))
+			} else {
+				assert.Equal(t, gotReq.IdempotencyKey, "")
+			}
+			if tt.statusCode == http.StatusAccepted {
+				assert.DeepEqual(t, gotReq, &amclient.PackageCreateRequest{
+					Name:             "Testing",
+					Type:             "zipped bag",
+					Path:             "/tmp",
+					ProcessingConfig: "automated",
+					AutoApprove:      new(true),
+					IdempotencyKey:   gotReq.IdempotencyKey,
+				})
+			}
+		})
 	}
-	for _, tt := range []test{
+}
+
+func TestStartTransferActivityVersionGate(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name          string
+		serverVersion string
+		wantKey       bool
+	}{
 		{
-			name: "Returns transfer ID",
-			amcr: func(mpsmr *amclienttest.MockPackageServiceMockRecorder, r http.Response) {
-				mpsmr.Create(
-					mockutil.Context(),
-					&amclient.PackageCreateRequest{
-						Name:             opts.Name,
-						Path:             opts.RelativePath,
-						Type:             "zipped bag",
-						ProcessingConfig: "automated",
-						AutoApprove:      true,
-					},
-				).Return(
-					&amclient.PackageCreateResponse{ID: transferID},
-					&amclient.Response{Response: &r},
-					nil,
-				)
-			},
-			want: am.StartTransferActivityResult{TransferID: transferID},
+			name:          "Older server",
+			serverVersion: "1.18.9",
 		},
 		{
-			name:   "Returns an invalid credentials error",
-			amcr:   amcrDefault,
-			st:     http.Response{StatusCode: http.StatusUnauthorized},
-			errMsg: "invalid Archivematica credentials",
+			name:          "Minimum supported server",
+			serverVersion: "1.19.0",
+			wantKey:       true,
 		},
 		{
-			name:   "Returns an insufficient permissions error",
-			amcr:   amcrDefault,
-			st:     http.Response{StatusCode: http.StatusForbidden},
-			errMsg: "insufficient Archivematica permissions",
-		},
-		{
-			name:   "Returns a not found error",
-			amcr:   amcrDefault,
-			st:     http.Response{StatusCode: http.StatusNotFound},
-			errMsg: "Archivematica resource not found",
+			name: "Unavailable server info",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
-			env := ts.NewTestActivityEnvironment()
 			ctrl := gomock.NewController(t)
-			amps := amclienttest.NewMockPackageService(ctrl)
+			packageService := amclienttest.NewMockPackageService(ctrl)
+			var gotKey string
+			packageService.EXPECT().
+				Create(mockutil.Context(), gomock.Any()).
+				DoAndReturn(func(
+					_ context.Context,
+					req *amclient.PackageCreateRequest,
+				) (*amclient.PackageCreateResponse, *amclient.Response, error) {
+					gotKey = req.IdempotencyKey
+					return &amclient.PackageCreateResponse{ID: "transfer-id"},
+						packageCreateResponse(http.StatusAccepted), nil
+				})
 
-			if tt.amcr != nil {
-				tt.amcr(amps.EXPECT(), tt.st)
-			}
-
-			env.RegisterActivityWithOptions(
-				am.NewStartTransferActivity(&am.Config{}, amps).Execute,
-				temporalsdk_activity.RegisterOptions{
-					Name: am.StartTransferActivityName,
+			client := newStartTransferTestClient(
+				t,
+				packageService,
+				func(w http.ResponseWriter, _ *http.Request) {
+					if tt.serverVersion != "" {
+						w.Header().Set("X-Archivematica-Version", tt.serverVersion)
+					}
+					w.WriteHeader(http.StatusNotImplemented)
 				},
 			)
+			activity := am.NewStartTransferActivity(&am.Config{}, client)
 
-			future, err := env.ExecuteActivity(am.StartTransferActivityName, opts)
-			if tt.errMsg != "" {
-				assert.ErrorContains(t, err, tt.errMsg)
-				assert.Assert(t, temporal.NonRetryableError(err))
+			result, err := executeStartTransferActivity(t, activity)
 
-				return
-			}
 			assert.NilError(t, err)
-
-			var r am.StartTransferActivityResult
-			err = future.Get(&r)
-			assert.NilError(t, err)
-			assert.DeepEqual(t, r, am.StartTransferActivityResult{TransferID: transferID})
+			assert.DeepEqual(t, result, &am.StartTransferActivityResult{TransferID: "transfer-id"})
+			assert.Equal(t, gotKey != "", tt.wantKey)
 		})
+	}
+}
+
+func TestStartTransferActivityChecksVersionEveryExecution(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	packageService := amclienttest.NewMockPackageService(ctrl)
+	keys := make([]string, 0, 3)
+	packageService.EXPECT().
+		Create(mockutil.Context(), gomock.Any()).
+		DoAndReturn(func(
+			_ context.Context,
+			req *amclient.PackageCreateRequest,
+		) (*amclient.PackageCreateResponse, *amclient.Response, error) {
+			keys = append(keys, req.IdempotencyKey)
+			return &amclient.PackageCreateResponse{ID: "transfer-id"},
+				packageCreateResponse(http.StatusAccepted), nil
+		}).
+		Times(3)
+
+	versionRequests := 0
+	client := newStartTransferTestClient(
+		t,
+		packageService,
+		func(w http.ResponseWriter, _ *http.Request) {
+			versionRequests++
+			version := "1.19.0"
+			if versionRequests == 1 {
+				version = "1.18.9"
+			}
+			w.Header().Set("X-Archivematica-Version", version)
+			w.WriteHeader(http.StatusNotImplemented)
+		},
+	)
+	activity := am.NewStartTransferActivity(&am.Config{}, client)
+
+	ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+	env := ts.NewTestActivityEnvironment()
+	env.RegisterActivityWithOptions(activity.Execute, temporalsdk_activity.RegisterOptions{
+		Name: am.StartTransferActivityName,
+	})
+	params := startTransferParams()
+	for range 3 {
+		encoded, err := env.ExecuteActivity(am.StartTransferActivityName, params)
+		assert.NilError(t, err)
+		var result am.StartTransferActivityResult
+		assert.NilError(t, encoded.Get(&result))
+	}
+
+	assert.Equal(t, versionRequests, 3)
+	assert.Equal(t, len(keys), 3)
+	assert.Equal(t, keys[0], "")
+	assert.Assert(t, strings.HasPrefix(keys[1], "enduro-transfer-"))
+	assert.Equal(t, keys[2], keys[1])
+}
+
+func newStartTransferTestClient(
+	t *testing.T,
+	packageService amclient.PackageService,
+	serverInfoHandler http.HandlerFunc,
+) *amclient.Client {
+	t.Helper()
+
+	server := httptest.NewServer(serverInfoHandler)
+	t.Cleanup(server.Close)
+	client := amclient.NewClient(server.Client(), server.URL+"/", "test", "test")
+	client.Package = packageService
+
+	return client
+}
+
+func packageCreateResponse(statusCode int) *amclient.Response {
+	return &amclient.Response{
+		Response: &http.Response{
+			StatusCode: statusCode,
+			Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		},
+	}
+}
+
+func executeStartTransferActivity(
+	t *testing.T,
+	activity *am.StartTransferActivity,
+) (*am.StartTransferActivityResult, error) {
+	t.Helper()
+
+	ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+	env := ts.NewTestActivityEnvironment()
+	env.RegisterActivityWithOptions(activity.Execute, temporalsdk_activity.RegisterOptions{
+		Name: am.StartTransferActivityName,
+	})
+
+	encoded, err := env.ExecuteActivity(am.StartTransferActivityName, startTransferParams())
+	if err != nil {
+		return nil, err
+	}
+
+	var result am.StartTransferActivityResult
+	if err := encoded.Get(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func startTransferParams() *am.StartTransferActivityParams {
+	return &am.StartTransferActivityParams{
+		Name:         "Testing",
+		ZipPIP:       true,
+		RelativePath: "/tmp",
 	}
 }

--- a/internal/workflow/processing_setup_test.go
+++ b/internal/workflow/processing_setup_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/artefactual-sdps/temporal-activities/xmlvalidate"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/suite"
+	"go.artefactual.dev/amclient"
 	"go.artefactual.dev/amclient/amclienttest"
 	"go.opentelemetry.io/otel/trace/noop"
 	temporalsdk_activity "go.temporal.io/sdk/activity"
@@ -199,6 +200,7 @@ func (s *ProcessingWorkflowTestSuite) setupAMWorkflowTest(
 ) {
 	clock := clockwork.NewFakeClock()
 	sftpc := sftp_fake.NewMockClient(ctrl)
+	amc := amclient.NewClient(nil, "http://127.0.0.1:0", "", "")
 
 	s.env.RegisterActivityWithOptions(
 		bagcreate.New(bagcreate.Config{}).Execute,
@@ -209,7 +211,7 @@ func (s *ProcessingWorkflowTestSuite) setupAMWorkflowTest(
 		temporalsdk_activity.RegisterOptions{Name: am.UploadTransferActivityName},
 	)
 	s.env.RegisterActivityWithOptions(
-		am.NewStartTransferActivity(&am.Config{}, amclienttest.NewMockPackageService(ctrl)).Execute,
+		am.NewStartTransferActivity(&am.Config{}, amc).Execute,
 		temporalsdk_activity.RegisterOptions{Name: am.StartTransferActivityName},
 	)
 	s.env.RegisterActivityWithOptions(


### PR DESCRIPTION
Archivematica 1.19 [adds support for idempotency keys](https://github.com/artefactual/archivematica/pull/2352) during transfer submission. A client can use a key to identify one specific submission request. If the request is retried, Archivematica can recognize it and return the original transfer instead of creating a duplicate.

This protects against failures that happen midway through submission. For example, Archivematica may create the transfer but Enduro may lose the HTTP response. Enduro cannot know whether the request succeeded, so Temporal retries it. Sending the same idempotency key makes that retry safe.

This feature was initially developed for Wellcome's S3/Lambda submission workflow. It is also used by [legacy Enduro](https://github.com/artefactual-labs/enduro/pull/724).

In this project, I suggest to use the Temporal workflow run ID as the idempotency key. Activity and worker-session retries remain in the same workflow run and therefore reuse the key. A user-triggered Enduro Retry starts a new workflow run and gets a new key, allowing it to create a new transfer as intended.

Enduro will check the Archivematica version before every submission attempt and sends the key to Archivematica 1.19.0 and newer. Requests that are still in progress can be retried, while reuse of the same key with a different request stops further retries.

Idempotency keys are a well-established API pattern. The header and its expected behavior are described in the [IETF HTTPAPI working-group draft](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/). Brandur Leach also provides a useful [high-level overview of idempotency keys](https://brandur.org/idempotency-keys).