### PR TITLE
Upgrade brace-expansion v5.0.8 to v5.0.9

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -3659,9 +3659,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -48,8 +48,7 @@
     "vue-router": "^5.0.4"
   },
   "overrides": {
-    "minimatch": "10.2.5",
-    "brace-expansion": "5.0.8"
+    "minimatch": "10.2.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
- Remove brace-expansion from the `package.json` "overrides" as Dependabot can't seem to upgrade overrides
- Run `npm audit fix` to update the "brace-expansion" package from v5.0.8 to v5.0.9 to fix security vulnerability GHSA-rgw5-rvv9-x895