### PR TITLE
Return API failures as HTTP 500

### DIFF
--- a/docs/src/dev-manual/api/openapi3.2.json
+++ b/docs/src/dev-manual/api/openapi3.2.json
@@ -4332,6 +4332,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -4509,7 +4519,7 @@
                 }
               }
             },
-            "description": "internal_error: Fault while processing upload."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -4610,7 +4620,7 @@
             },
             "description": "not_found: SIP not found"
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -4618,7 +4628,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -4727,6 +4737,16 @@
               }
             },
             "description": "not_available: Conflict response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5283,6 +5303,16 @@
               }
             },
             "description": "not_available: Conflict response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5388,6 +5418,16 @@
               }
             },
             "description": "not_found: SIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5517,6 +5557,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5678,7 +5728,7 @@
             },
             "description": "forbidden: Forbidden response."
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -5686,7 +5736,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5774,6 +5824,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5864,6 +5924,16 @@
               }
             },
             "description": "not_found: AIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -6832,7 +6902,7 @@
             },
             "description": "not_found: AIP not found"
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -6840,7 +6910,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -6935,6 +7005,16 @@
               }
             },
             "description": "failed_dependency: Failed Dependency response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7032,7 +7112,7 @@
             },
             "description": "not_found: AIP not found"
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -7040,7 +7120,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7181,6 +7261,16 @@
               }
             },
             "description": "not_found: AIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7243,6 +7333,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7336,6 +7436,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7438,6 +7548,16 @@
               }
             },
             "description": "not_found: Storage location not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7540,6 +7660,16 @@
               }
             },
             "description": "not_found: Storage location not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [

--- a/docs/src/dev-manual/api/openapi3.json
+++ b/docs/src/dev-manual/api/openapi3.json
@@ -4371,6 +4371,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -4556,7 +4566,7 @@
                 }
               }
             },
-            "description": "internal_error: Fault while processing upload."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -4661,7 +4671,7 @@
             },
             "description": "not_found: SIP not found"
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -4669,7 +4679,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -4782,6 +4792,16 @@
               }
             },
             "description": "not_available: Conflict response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5358,6 +5378,16 @@
               }
             },
             "description": "not_available: Conflict response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5467,6 +5497,16 @@
               }
             },
             "description": "not_found: SIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5600,6 +5640,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5765,7 +5815,7 @@
             },
             "description": "forbidden: Forbidden response."
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -5773,7 +5823,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5865,6 +5915,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5959,6 +6019,16 @@
               }
             },
             "description": "not_found: AIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -6963,7 +7033,7 @@
             },
             "description": "not_found: AIP not found"
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -6971,7 +7041,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7070,6 +7140,16 @@
               }
             },
             "description": "failed_dependency: Failed Dependency response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7171,7 +7251,7 @@
             },
             "description": "not_found: AIP not found"
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -7179,7 +7259,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7324,6 +7404,16 @@
               }
             },
             "description": "not_found: AIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7390,6 +7480,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7487,6 +7587,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7593,6 +7703,16 @@
               }
             },
             "description": "not_found: Storage location not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7699,6 +7819,16 @@
               }
             },
             "description": "not_found: Storage location not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -49,14 +49,14 @@ func HTTPServer(
 	mux.Use(otelhttp.NewMiddleware("api", otelhttp.WithTracerProvider(tp)))
 	mux.Use(middleware.Recover(logger))
 
-	operationInterceptors := newOperationInterceptors(logger)
+	serverInterceptors := newServerInterceptors(logger)
 
 	// Ingest service.
 	ingestEndpoints := ingest.NewEndpoints(
 		ingestsvc,
-		&ingestServerInterceptors{operationInterceptors: operationInterceptors},
+		&ingestServerInterceptors{serverInterceptors: serverInterceptors},
 	)
-	ingestErrorHandler := errorHandler(logger, "Ingest error.")
+	ingestErrorHandler := transportErrorHandler(logger, "Ingest transport error.")
 	ingestServer := ingestsvr.New(ingestEndpoints, mux, dec, enc, ingestErrorHandler, nil)
 	ingestServer.Monitor = middleware.WriteTimeout(0)(ingestServer.Monitor)
 	ingestServer.DownloadSip = middleware.WriteTimeout(0)(ingestServer.DownloadSip)
@@ -67,9 +67,9 @@ func HTTPServer(
 	// Storage service.
 	storageEndpoints := storage.NewEndpoints(
 		storagesvc,
-		&storageServerInterceptors{operationInterceptors: operationInterceptors},
+		&storageServerInterceptors{serverInterceptors: serverInterceptors},
 	)
-	storageErrorHandler := errorHandler(logger, "Storage error.")
+	storageErrorHandler := transportErrorHandler(logger, "Storage transport error.")
 	storageServer := storagesvr.New(storageEndpoints, mux, dec, enc, storageErrorHandler, nil)
 	storageServer.Monitor = middleware.WriteTimeout(0)(storageServer.Monitor)
 	// Streaming downloads can legitimately take longer than the API write
@@ -81,9 +81,9 @@ func HTTPServer(
 	// About service.
 	aboutEndpoints := about.NewEndpoints(
 		aboutsvc,
-		&aboutServerInterceptors{operationInterceptors: operationInterceptors},
+		&aboutServerInterceptors{serverInterceptors: serverInterceptors},
 	)
-	aboutErrorHandler := errorHandler(logger, "About error.")
+	aboutErrorHandler := transportErrorHandler(logger, "About transport error.")
 	aboutServer := aaboutsvr.New(aboutEndpoints, mux, dec, enc, aboutErrorHandler, nil)
 	aaboutsvr.Mount(mux, aboutServer)
 
@@ -113,9 +113,10 @@ type errorMessage struct {
 	Error     error
 }
 
-// errorHandler returns a function that writes and logs the given error
-// including the request ID.
-func errorHandler(logger logr.Logger, msg string) func(context.Context, http.ResponseWriter, error) {
+// transportErrorHandler handles failures raised while the generated HTTP
+// transport encodes a response. Endpoint errors are logged and sanitized by
+// the Goa ServerErrorHandler interceptor before they reach this layer.
+func transportErrorHandler(logger logr.Logger, msg string) func(context.Context, http.ResponseWriter, error) {
 	return func(ctx context.Context, w http.ResponseWriter, err error) {
 		reqID, ok := ctx.Value(goamiddleware.RequestIDKey).(string)
 		if !ok {
@@ -124,6 +125,6 @@ func errorHandler(logger logr.Logger, msg string) func(context.Context, http.Res
 
 		_ = json.NewEncoder(w).Encode(&errorMessage{RequestID: reqID})
 
-		logger.Error(err, "Service error.", "reqID", reqID, "msg", msg)
+		logger.Error(err, "HTTP transport error.", "reqID", reqID, "msg", msg)
 	}
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -235,4 +236,59 @@ func TestHTTPServerMonitorAuth(t *testing.T) {
 			assert.Equal(t, tt.authCalls(api), 1)
 		})
 	}
+}
+
+func TestHTTPServerInternalError(t *testing.T) {
+	api := newTestAPI(t)
+	internalErr := goastorage.MakeInternalError(errors.New("database password leaked"))
+	api.storage.EXPECT().
+		ListAips(gomock.Any(), gomock.Any()).
+		Return(nil, internalErr)
+
+	req := httptest.NewRequest(http.MethodGet, "/storage/aips", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	rec := httptest.NewRecorder()
+	api.handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, rec.Code, http.StatusInternalServerError)
+	var body map[string]any
+	assert.NilError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.DeepEqual(t, body, map[string]any{
+		"name":      "internal_error",
+		"id":        internalErr.ID,
+		"message":   apiInternalErrorMsg,
+		"temporary": false,
+		"timeout":   false,
+		"fault":     true,
+	})
+}
+
+func TestHTTPServerConflict(t *testing.T) {
+	api := newTestAPI(t)
+	sipID := uuid.MustParse("9ef28482-bad9-4823-96f7-0fd1f3e956fd")
+	conflictErr := goaingest.MakeNotAvailable(errors.New("no decision is pending"))
+	api.ingest.EXPECT().
+		ShowSipDecision(gomock.Any(), gomock.Any()).
+		Return(nil, conflictErr)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/ingest/sips/"+sipID.String()+"/decision",
+		nil,
+	)
+	req.Header.Set("Authorization", "Bearer token")
+	rec := httptest.NewRecorder()
+	api.handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, rec.Code, http.StatusConflict)
+	var body map[string]any
+	assert.NilError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.DeepEqual(t, body, map[string]any{
+		"name":      "not_available",
+		"id":        conflictErr.ID,
+		"message":   "no decision is pending",
+		"temporary": false,
+		"timeout":   false,
+		"fault":     false,
+	})
 }

--- a/internal/api/design/design.go
+++ b/internal/api/design/design.go
@@ -50,7 +50,10 @@ var BearerAuth = BearerSecurity("bearer", func() {
 	Scope(auth.StorageLocationsReadAttr)
 })
 
-var OperationTimeout = Interceptor("OperationTimeout")
+var (
+	OperationTimeout   = Interceptor("OperationTimeout")
+	ServerErrorHandler = Interceptor("ServerErrorHandler")
+)
 
 func BearerAuthScopes(scopes ...string) {
 	Security(BearerAuth, func() {
@@ -71,6 +74,7 @@ var _ = API("enduro", func() {
 	Title("Enduro API")
 	Meta("openapi:versions", "2.0", "3.0", "3.2")
 	ServerInterceptor(OperationTimeout)
+	ServerInterceptor(ServerErrorHandler)
 	Randomizer(expr.NewDeterministicRandomizer())
 	Server("enduro", func() {
 		Services("about", "ingest", "storage")

--- a/internal/api/design/ingest.go
+++ b/internal/api/design/ingest.go
@@ -11,10 +11,14 @@ var _ = Service("ingest", func() {
 	Description("The ingest service manages ingested SIPs.")
 	Error("unauthorized", String, "Unauthorized")
 	Error("forbidden", String, "Forbidden")
+	Error("internal_error", ErrorResult, func() {
+		Fault()
+	})
 	HTTP(func() {
 		Path("/ingest")
 		Response("unauthorized", StatusUnauthorized)
 		Response("forbidden", StatusForbidden)
+		Response("internal_error", StatusInternalServerError)
 	})
 	Method("monitor", func() {
 		Description("Obtain access to the /monitor SSE event stream")
@@ -23,11 +27,9 @@ var _ = Service("ingest", func() {
 			BearerToken("token", String)
 		})
 		StreamingResult(IngestEvent)
-		Error("internal_error")
 		HTTP(func() {
 			GET("/monitor")
 			ServerSentEvents()
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("list_sips", func() {
@@ -81,12 +83,10 @@ var _ = Service("ingest", func() {
 		})
 		Result(SIP)
 		Error("not_found", SIPNotFound, "SIP not found")
-		Error("not_available")
 		HTTP(func() {
 			GET("/sips/{uuid}")
 			Response(StatusOK)
 			Response("not_found", StatusNotFound)
-			Response("not_available", StatusConflict)
 		})
 	})
 	Method("list_sip_workflows", func() {
@@ -154,14 +154,12 @@ var _ = Service("ingest", func() {
 		})
 		Result(SIPDecision)
 		Error("not_found", SIPNotFound, "SIP not found")
-		Error("internal_error")
 		Error("not_available")
 		Error("not_valid")
 		HTTP(func() {
 			GET("/sips/{uuid}/decision")
 			Response(StatusOK)
 			Response("not_found", StatusNotFound)
-			Response("internal_error", StatusInternalServerError)
 			Response("not_available", StatusConflict)
 			Response("not_valid", StatusBadRequest)
 		})
@@ -176,14 +174,12 @@ var _ = Service("ingest", func() {
 			Required("uuid", "option")
 		})
 		Error("not_found", SIPNotFound, "SIP not found")
-		Error("internal_error")
 		Error("not_available")
 		Error("not_valid")
 		HTTP(func() {
 			POST("/sips/{uuid}/decision")
 			Response(StatusAccepted)
 			Response("not_found", StatusNotFound)
-			Response("internal_error", StatusInternalServerError)
 			Response("not_available", StatusConflict)
 			Response("not_valid", StatusBadRequest)
 		})
@@ -202,12 +198,10 @@ var _ = Service("ingest", func() {
 			Required("uuid")
 		})
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			POST("/sips")
 			Response(StatusCreated)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("upload_sip", func() {
@@ -237,8 +231,6 @@ var _ = Service("ingest", func() {
 			ErrorResult,
 			"Error returned when the request body is not a valid multipart content.",
 		)
-		Error("internal_error", ErrorResult, "Fault while processing upload.")
-
 		HTTP(func() {
 			POST("/sips/upload")
 			Header("content_type:Content-Type")
@@ -253,7 +245,6 @@ var _ = Service("ingest", func() {
 			// Define error HTTP statuses.
 			Response("invalid_media_type", StatusBadRequest)
 			Response("invalid_multipart_request", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("download_sip_request", func() {
@@ -269,7 +260,6 @@ var _ = Service("ingest", func() {
 		})
 		Error("not_found", SIPNotFound, "SIP not found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			POST("/sips/{uuid}/download")
 			Response(StatusOK, func() {
@@ -280,7 +270,6 @@ var _ = Service("ingest", func() {
 			})
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("download_sip", func() {
@@ -305,7 +294,6 @@ var _ = Service("ingest", func() {
 		})
 		Error("not_found", SIPNotFound, "SIP not found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			GET("/sips/{uuid}/download")
 			Cookie("ticket:enduro-sip-download-ticket")
@@ -317,7 +305,6 @@ var _ = Service("ingest", func() {
 			})
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("list_users", func() {
@@ -366,13 +353,11 @@ var _ = Service("ingest", func() {
 		Result(SIPSourceObjects)
 		Error("not_found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			GET("/sip-sources/{uuid}/objects")
 			Response(StatusOK)
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 			Params(func() {
 				Param("limit")
 				Param("cursor")
@@ -394,12 +379,10 @@ var _ = Service("ingest", func() {
 			Required("uuid")
 		})
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			POST("/batches")
 			Response(StatusCreated)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("list_batches", func() {
@@ -424,12 +407,10 @@ var _ = Service("ingest", func() {
 		})
 		Result(Batches)
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			GET("/batches")
 			Response(StatusOK)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 			Params(func() {
 				Param("identifier")
 				Param("earliest_created_time")
@@ -452,13 +433,11 @@ var _ = Service("ingest", func() {
 		Result(Batch)
 		Error("not_found", BatchNotFound, "Batch not found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			GET("/batches/{uuid}")
 			Response(StatusOK)
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("review_batch", func() {
@@ -472,13 +451,11 @@ var _ = Service("ingest", func() {
 		})
 		Error("not_found", BatchNotFound, "Batch not found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			POST("/batches/{uuid}/review")
 			Response(StatusAccepted)
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 })

--- a/internal/api/design/storage.go
+++ b/internal/api/design/storage.go
@@ -12,10 +12,14 @@ var _ = Service("storage", func() {
 	Description("The storage service manages locations and AIPs.")
 	Error("unauthorized", String, "Unauthorized")
 	Error("forbidden", String, "Forbidden")
+	Error("internal_error", ErrorResult, func() {
+		Fault()
+	})
 	HTTP(func() {
 		Path("/storage")
 		Response("unauthorized", StatusUnauthorized)
 		Response("forbidden", StatusForbidden)
+		Response("internal_error", StatusInternalServerError)
 	})
 	Method("monitor", func() {
 		Description("Obtain access to the /monitor SSE event stream")
@@ -24,11 +28,9 @@ var _ = Service("storage", func() {
 			BearerToken("token", String)
 		})
 		StreamingResult(StorageEvent)
-		Error("internal_error")
 		HTTP(func() {
 			GET("/monitor")
 			ServerSentEvents()
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("list_aips", func() {
@@ -51,12 +53,10 @@ var _ = Service("storage", func() {
 			BearerToken("token", String)
 		})
 		Result(AIPs)
-		Error("not_available")
 		Error("not_valid")
 		HTTP(func() {
 			GET("/aips")
 			Response(StatusOK)
-			Response("not_available", StatusConflict)
 			Response("not_valid", StatusBadRequest)
 			Params(func() {
 				Param("query")
@@ -104,7 +104,6 @@ var _ = Service("storage", func() {
 		})
 		Error("not_found", AIPNotFound, "AIP not found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			POST("/aips/{uuid}/download")
 			Response(StatusOK, func() {
@@ -115,7 +114,6 @@ var _ = Service("storage", func() {
 			})
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("download_aip", func() {
@@ -136,7 +134,6 @@ var _ = Service("storage", func() {
 		})
 		Error("not_found", AIPNotFound, "AIP not found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			GET("/aips/{uuid}/download")
 			Cookie("ticket:enduro-aip-download-ticket")
@@ -148,7 +145,6 @@ var _ = Service("storage", func() {
 			})
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("move_aip", func() {
@@ -161,13 +157,11 @@ var _ = Service("storage", func() {
 			Required("uuid", "location_uuid")
 		})
 		Error("not_found", AIPNotFound, "AIP not found")
-		Error("not_available")
 		Error("not_valid")
 		HTTP(func() {
 			POST("/aips/{uuid}/store")
 			Response(StatusAccepted)
 			Response("not_found", StatusNotFound)
-			Response("not_available", StatusConflict)
 			Response("not_valid", StatusBadRequest)
 		})
 	})
@@ -198,13 +192,11 @@ var _ = Service("storage", func() {
 			Required("uuid")
 		})
 		Error("not_found", AIPNotFound, "AIP not found")
-		Error("not_available")
 		Error("not_valid")
 		HTTP(func() {
 			POST("/aips/{uuid}/reject")
 			Response(StatusAccepted)
 			Response("not_found", StatusNotFound)
-			Response("not_available", StatusConflict)
 			Response("not_valid", StatusBadRequest)
 		})
 	})
@@ -262,13 +254,11 @@ var _ = Service("storage", func() {
 		})
 		Error("not_found", AIPNotFound, "AIP not found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			POST("/aips/{uuid}/deletion-auto")
 			Response(StatusAccepted)
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("request_aip_deletion", func() {
@@ -282,13 +272,11 @@ var _ = Service("storage", func() {
 		})
 		Error("not_found", AIPNotFound, "AIP not found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			POST("/aips/{uuid}/deletion-request")
 			Response(StatusAccepted)
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("review_aip_deletion", func() {
@@ -302,13 +290,11 @@ var _ = Service("storage", func() {
 		})
 		Error("not_found", AIPNotFound, "AIP not found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			POST("/aips/{uuid}/deletion-review")
 			Response(StatusAccepted)
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("cancel_aip_deletion", func() {
@@ -326,13 +312,11 @@ var _ = Service("storage", func() {
 		})
 		Error("not_found", AIPNotFound, "AIP not found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			POST("/aips/{uuid}/deletion-cancel")
 			Response(StatusAccepted)
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("aip_deletion_report_request", func() {
@@ -348,7 +332,6 @@ var _ = Service("storage", func() {
 		})
 		Error("not_found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			POST("/aips/{uuid}/deletion-report")
 			Response(StatusOK, func() {
@@ -359,7 +342,6 @@ var _ = Service("storage", func() {
 			})
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("aip_deletion_report", func() {
@@ -380,7 +362,6 @@ var _ = Service("storage", func() {
 		})
 		Error("not_found")
 		Error("not_valid")
-		Error("internal_error")
 		HTTP(func() {
 			GET("/aips/{uuid}/deletion-report")
 			Cookie("ticket:enduro-delreport-ticket")
@@ -392,7 +373,6 @@ var _ = Service("storage", func() {
 			})
 			Response("not_found", StatusNotFound)
 			Response("not_valid", StatusBadRequest)
-			Response("internal_error", StatusInternalServerError)
 		})
 	})
 	Method("list_locations", func() {

--- a/internal/api/gen/about/interceptor_wrappers.go
+++ b/internal/api/gen/about/interceptor_wrappers.go
@@ -27,3 +27,17 @@ func wrapAboutOperationTimeout(endpoint goa.Endpoint, i ServerInterceptors) goa.
 		return i.OperationTimeout(ctx, info, endpoint)
 	}
 }
+
+// wrapServerErrorHandlerAbout applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapAboutServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "about",
+			method:     "About",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}

--- a/internal/api/gen/about/service_interceptors.go
+++ b/internal/api/gen/about/service_interceptors.go
@@ -20,6 +20,7 @@ import (
 // next to complete the request.
 type ServerInterceptors interface {
 	OperationTimeout(ctx context.Context, info *OperationTimeoutInfo, next goa.Endpoint) (any, error)
+	ServerErrorHandler(ctx context.Context, info *ServerErrorHandlerInfo, next goa.Endpoint) (any, error)
 }
 
 // Access interfaces for interceptor payloads and results
@@ -32,6 +33,14 @@ type (
 		callType   goa.InterceptorCallType
 		rawPayload any
 	}
+	// ServerErrorHandlerInfo provides metadata about the current interception.
+	// It includes service name, method name, and access to the endpoint.
+	ServerErrorHandlerInfo struct {
+		service    string
+		method     string
+		callType   goa.InterceptorCallType
+		rawPayload any
+	}
 )
 
 // WrapAboutEndpoint wraps the about endpoint with the server-side interceptors
@@ -39,6 +48,7 @@ type (
 func WrapAboutEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapAboutOperationTimeout(endpoint, i)
+		endpoint = wrapAboutServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -62,5 +72,25 @@ func (info *OperationTimeoutInfo) CallType() goa.InterceptorCallType {
 
 // RawPayload returns the raw payload of the request.
 func (info *OperationTimeoutInfo) RawPayload() any {
+	return info.rawPayload
+}
+
+// Service returns the name of the service handling the request.
+func (info *ServerErrorHandlerInfo) Service() string {
+	return info.service
+}
+
+// Method returns the name of the method handling the request.
+func (info *ServerErrorHandlerInfo) Method() string {
+	return info.method
+}
+
+// CallType returns the type of call the interceptor is handling.
+func (info *ServerErrorHandlerInfo) CallType() goa.InterceptorCallType {
+	return info.callType
+}
+
+// RawPayload returns the raw payload of the request.
+func (info *ServerErrorHandlerInfo) RawPayload() any {
 	return info.rawPayload
 }

--- a/internal/api/gen/http/ingest/client/encode_decode.go
+++ b/internal/api/gen/http/ingest/client/encode_decode.go
@@ -208,6 +208,7 @@ func EncodeListSipsRequest(encoder func(*http.Request) goahttp.Encoder) func(*ht
 // should be restored after having been read.
 // DecodeListSipsResponse may return the following errors:
 //   - "not_valid" (type *goa.ServiceError): http.StatusBadRequest
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "forbidden" (type ingest.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type ingest.Unauthorized): http.StatusUnauthorized
 //   - error: internal error
@@ -257,6 +258,20 @@ func DecodeListSipsResponse(decoder func(*http.Response) goahttp.Decoder, restor
 				return nil, goahttp.ErrValidationError("ingest", "list_sips", err)
 			}
 			return nil, NewListSipsNotValid(&body)
+		case http.StatusInternalServerError:
+			var (
+				body ListSipsInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("ingest", "list_sips", err)
+			}
+			err = ValidateListSipsInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("ingest", "list_sips", err)
+			}
+			return nil, NewListSipsInternalError(&body)
 		case http.StatusForbidden:
 			var (
 				body string
@@ -333,7 +348,7 @@ func EncodeShowSipRequest(encoder func(*http.Request) goahttp.Encoder) func(*htt
 // show_sip endpoint. restoreBody controls whether the response body should be
 // restored after having been read.
 // DecodeShowSipResponse may return the following errors:
-//   - "not_available" (type *goa.ServiceError): http.StatusConflict
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *ingest.SIPNotFound): http.StatusNotFound
 //   - "forbidden" (type ingest.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type ingest.Unauthorized): http.StatusUnauthorized
@@ -370,20 +385,20 @@ func DecodeShowSipResponse(decoder func(*http.Response) goahttp.Decoder, restore
 			}
 			res := ingest.NewSIP(vres)
 			return res, nil
-		case http.StatusConflict:
+		case http.StatusInternalServerError:
 			var (
-				body ShowSipNotAvailableResponseBody
+				body ShowSipInternalErrorResponseBody
 				err  error
 			)
 			err = decoder(resp).Decode(&body)
 			if err != nil {
 				return nil, goahttp.ErrDecodingError("ingest", "show_sip", err)
 			}
-			err = ValidateShowSipNotAvailableResponseBody(&body)
+			err = ValidateShowSipInternalErrorResponseBody(&body)
 			if err != nil {
 				return nil, goahttp.ErrValidationError("ingest", "show_sip", err)
 			}
-			return nil, NewShowSipNotAvailable(&body)
+			return nil, NewShowSipInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body ShowSipNotFoundResponseBody
@@ -474,6 +489,7 @@ func EncodeListSipWorkflowsRequest(encoder func(*http.Request) goahttp.Encoder) 
 // the ingest list_sip_workflows endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
 // DecodeListSipWorkflowsResponse may return the following errors:
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *ingest.SIPNotFound): http.StatusNotFound
 //   - "forbidden" (type ingest.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type ingest.Unauthorized): http.StatusUnauthorized
@@ -510,6 +526,20 @@ func DecodeListSipWorkflowsResponse(decoder func(*http.Response) goahttp.Decoder
 			}
 			res := ingest.NewSIPWorkflows(vres)
 			return res, nil
+		case http.StatusInternalServerError:
+			var (
+				body ListSipWorkflowsInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("ingest", "list_sip_workflows", err)
+			}
+			err = ValidateListSipWorkflowsInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("ingest", "list_sip_workflows", err)
+			}
+			return nil, NewListSipWorkflowsInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body ListSipWorkflowsNotFoundResponseBody
@@ -606,6 +636,7 @@ func EncodeConfirmSipRequest(encoder func(*http.Request) goahttp.Encoder) func(*
 // DecodeConfirmSipResponse may return the following errors:
 //   - "not_available" (type *goa.ServiceError): http.StatusConflict
 //   - "not_valid" (type *goa.ServiceError): http.StatusBadRequest
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *ingest.SIPNotFound): http.StatusNotFound
 //   - "forbidden" (type ingest.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type ingest.Unauthorized): http.StatusUnauthorized
@@ -655,6 +686,20 @@ func DecodeConfirmSipResponse(decoder func(*http.Response) goahttp.Decoder, rest
 				return nil, goahttp.ErrValidationError("ingest", "confirm_sip", err)
 			}
 			return nil, NewConfirmSipNotValid(&body)
+		case http.StatusInternalServerError:
+			var (
+				body ConfirmSipInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("ingest", "confirm_sip", err)
+			}
+			err = ValidateConfirmSipInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("ingest", "confirm_sip", err)
+			}
+			return nil, NewConfirmSipInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body ConfirmSipNotFoundResponseBody
@@ -747,6 +792,7 @@ func EncodeRejectSipRequest(encoder func(*http.Request) goahttp.Encoder) func(*h
 // DecodeRejectSipResponse may return the following errors:
 //   - "not_available" (type *goa.ServiceError): http.StatusConflict
 //   - "not_valid" (type *goa.ServiceError): http.StatusBadRequest
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *ingest.SIPNotFound): http.StatusNotFound
 //   - "forbidden" (type ingest.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type ingest.Unauthorized): http.StatusUnauthorized
@@ -796,6 +842,20 @@ func DecodeRejectSipResponse(decoder func(*http.Response) goahttp.Decoder, resto
 				return nil, goahttp.ErrValidationError("ingest", "reject_sip", err)
 			}
 			return nil, NewRejectSipNotValid(&body)
+		case http.StatusInternalServerError:
+			var (
+				body RejectSipInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("ingest", "reject_sip", err)
+			}
+			err = ValidateRejectSipInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("ingest", "reject_sip", err)
+			}
+			return nil, NewRejectSipInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body RejectSipNotFoundResponseBody
@@ -886,9 +946,9 @@ func EncodeShowSipDecisionRequest(encoder func(*http.Request) goahttp.Encoder) f
 // the ingest show_sip_decision endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
 // DecodeShowSipDecisionResponse may return the following errors:
-//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_available" (type *goa.ServiceError): http.StatusConflict
 //   - "not_valid" (type *goa.ServiceError): http.StatusBadRequest
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *ingest.SIPNotFound): http.StatusNotFound
 //   - "forbidden" (type ingest.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type ingest.Unauthorized): http.StatusUnauthorized
@@ -925,20 +985,6 @@ func DecodeShowSipDecisionResponse(decoder func(*http.Response) goahttp.Decoder,
 			}
 			res := ingest.NewSIPDecision(vres)
 			return res, nil
-		case http.StatusInternalServerError:
-			var (
-				body ShowSipDecisionInternalErrorResponseBody
-				err  error
-			)
-			err = decoder(resp).Decode(&body)
-			if err != nil {
-				return nil, goahttp.ErrDecodingError("ingest", "show_sip_decision", err)
-			}
-			err = ValidateShowSipDecisionInternalErrorResponseBody(&body)
-			if err != nil {
-				return nil, goahttp.ErrValidationError("ingest", "show_sip_decision", err)
-			}
-			return nil, NewShowSipDecisionInternalError(&body)
 		case http.StatusConflict:
 			var (
 				body ShowSipDecisionNotAvailableResponseBody
@@ -967,6 +1013,20 @@ func DecodeShowSipDecisionResponse(decoder func(*http.Response) goahttp.Decoder,
 				return nil, goahttp.ErrValidationError("ingest", "show_sip_decision", err)
 			}
 			return nil, NewShowSipDecisionNotValid(&body)
+		case http.StatusInternalServerError:
+			var (
+				body ShowSipDecisionInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("ingest", "show_sip_decision", err)
+			}
+			err = ValidateShowSipDecisionInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("ingest", "show_sip_decision", err)
+			}
+			return nil, NewShowSipDecisionInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body ShowSipDecisionNotFoundResponseBody
@@ -1061,9 +1121,9 @@ func EncodeSubmitSipDecisionRequest(encoder func(*http.Request) goahttp.Encoder)
 // the ingest submit_sip_decision endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
 // DecodeSubmitSipDecisionResponse may return the following errors:
-//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_available" (type *goa.ServiceError): http.StatusConflict
 //   - "not_valid" (type *goa.ServiceError): http.StatusBadRequest
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *ingest.SIPNotFound): http.StatusNotFound
 //   - "forbidden" (type ingest.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type ingest.Unauthorized): http.StatusUnauthorized
@@ -1085,20 +1145,6 @@ func DecodeSubmitSipDecisionResponse(decoder func(*http.Response) goahttp.Decode
 		switch resp.StatusCode {
 		case http.StatusAccepted:
 			return nil, nil
-		case http.StatusInternalServerError:
-			var (
-				body SubmitSipDecisionInternalErrorResponseBody
-				err  error
-			)
-			err = decoder(resp).Decode(&body)
-			if err != nil {
-				return nil, goahttp.ErrDecodingError("ingest", "submit_sip_decision", err)
-			}
-			err = ValidateSubmitSipDecisionInternalErrorResponseBody(&body)
-			if err != nil {
-				return nil, goahttp.ErrValidationError("ingest", "submit_sip_decision", err)
-			}
-			return nil, NewSubmitSipDecisionInternalError(&body)
 		case http.StatusConflict:
 			var (
 				body SubmitSipDecisionNotAvailableResponseBody
@@ -1127,6 +1173,20 @@ func DecodeSubmitSipDecisionResponse(decoder func(*http.Response) goahttp.Decode
 				return nil, goahttp.ErrValidationError("ingest", "submit_sip_decision", err)
 			}
 			return nil, NewSubmitSipDecisionNotValid(&body)
+		case http.StatusInternalServerError:
+			var (
+				body SubmitSipDecisionInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("ingest", "submit_sip_decision", err)
+			}
+			err = ValidateSubmitSipDecisionInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("ingest", "submit_sip_decision", err)
+			}
+			return nil, NewSubmitSipDecisionInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body SubmitSipDecisionNotFoundResponseBody
@@ -1859,6 +1919,7 @@ func EncodeListUsersRequest(encoder func(*http.Request) goahttp.Encoder) func(*h
 // should be restored after having been read.
 // DecodeListUsersResponse may return the following errors:
 //   - "not_valid" (type *goa.ServiceError): http.StatusBadRequest
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "forbidden" (type ingest.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type ingest.Unauthorized): http.StatusUnauthorized
 //   - error: internal error
@@ -1908,6 +1969,20 @@ func DecodeListUsersResponse(decoder func(*http.Response) goahttp.Decoder, resto
 				return nil, goahttp.ErrValidationError("ingest", "list_users", err)
 			}
 			return nil, NewListUsersNotValid(&body)
+		case http.StatusInternalServerError:
+			var (
+				body ListUsersInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("ingest", "list_users", err)
+			}
+			err = ValidateListUsersInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("ingest", "list_users", err)
+			}
+			return nil, NewListUsersInternalError(&body)
 		case http.StatusForbidden:
 			var (
 				body string

--- a/internal/api/gen/http/ingest/client/types.go
+++ b/internal/api/gen/http/ingest/client/types.go
@@ -228,9 +228,27 @@ type ListSipsNotValidResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
-// ShowSipNotAvailableResponseBody is the type of the "ingest" service
-// "show_sip" endpoint HTTP response body for the "not_available" error.
-type ShowSipNotAvailableResponseBody struct {
+// ListSipsInternalErrorResponseBody is the type of the "ingest" service
+// "list_sips" endpoint HTTP response body for the "internal_error" error.
+type ListSipsInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ShowSipInternalErrorResponseBody is the type of the "ingest" service
+// "show_sip" endpoint HTTP response body for the "internal_error" error.
+type ShowSipInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -253,6 +271,25 @@ type ShowSipNotFoundResponseBody struct {
 	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
 	// Identifier of missing SIP
 	UUID *string `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
+}
+
+// ListSipWorkflowsInternalErrorResponseBody is the type of the "ingest"
+// service "list_sip_workflows" endpoint HTTP response body for the
+// "internal_error" error.
+type ListSipWorkflowsInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
 // ListSipWorkflowsNotFoundResponseBody is the type of the "ingest" service
@@ -285,6 +322,24 @@ type ConfirmSipNotAvailableResponseBody struct {
 // ConfirmSipNotValidResponseBody is the type of the "ingest" service
 // "confirm_sip" endpoint HTTP response body for the "not_valid" error.
 type ConfirmSipNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ConfirmSipInternalErrorResponseBody is the type of the "ingest" service
+// "confirm_sip" endpoint HTTP response body for the "internal_error" error.
+type ConfirmSipInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -345,19 +400,9 @@ type RejectSipNotValidResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
-// RejectSipNotFoundResponseBody is the type of the "ingest" service
-// "reject_sip" endpoint HTTP response body for the "not_found" error.
-type RejectSipNotFoundResponseBody struct {
-	// Message of error
-	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
-	// Identifier of missing SIP
-	UUID *string `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
-}
-
-// ShowSipDecisionInternalErrorResponseBody is the type of the "ingest" service
-// "show_sip_decision" endpoint HTTP response body for the "internal_error"
-// error.
-type ShowSipDecisionInternalErrorResponseBody struct {
+// RejectSipInternalErrorResponseBody is the type of the "ingest" service
+// "reject_sip" endpoint HTTP response body for the "internal_error" error.
+type RejectSipInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -371,6 +416,15 @@ type ShowSipDecisionInternalErrorResponseBody struct {
 	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
 	// Is the error a server-side fault?
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// RejectSipNotFoundResponseBody is the type of the "ingest" service
+// "reject_sip" endpoint HTTP response body for the "not_found" error.
+type RejectSipNotFoundResponseBody struct {
+	// Message of error
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Identifier of missing SIP
+	UUID *string `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
 }
 
 // ShowSipDecisionNotAvailableResponseBody is the type of the "ingest" service
@@ -410,19 +464,10 @@ type ShowSipDecisionNotValidResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
-// ShowSipDecisionNotFoundResponseBody is the type of the "ingest" service
-// "show_sip_decision" endpoint HTTP response body for the "not_found" error.
-type ShowSipDecisionNotFoundResponseBody struct {
-	// Message of error
-	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
-	// Identifier of missing SIP
-	UUID *string `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
-}
-
-// SubmitSipDecisionInternalErrorResponseBody is the type of the "ingest"
-// service "submit_sip_decision" endpoint HTTP response body for the
-// "internal_error" error.
-type SubmitSipDecisionInternalErrorResponseBody struct {
+// ShowSipDecisionInternalErrorResponseBody is the type of the "ingest" service
+// "show_sip_decision" endpoint HTTP response body for the "internal_error"
+// error.
+type ShowSipDecisionInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -436,6 +481,15 @@ type SubmitSipDecisionInternalErrorResponseBody struct {
 	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
 	// Is the error a server-side fault?
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ShowSipDecisionNotFoundResponseBody is the type of the "ingest" service
+// "show_sip_decision" endpoint HTTP response body for the "not_found" error.
+type ShowSipDecisionNotFoundResponseBody struct {
+	// Message of error
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Identifier of missing SIP
+	UUID *string `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
 }
 
 // SubmitSipDecisionNotAvailableResponseBody is the type of the "ingest"
@@ -460,6 +514,25 @@ type SubmitSipDecisionNotAvailableResponseBody struct {
 // SubmitSipDecisionNotValidResponseBody is the type of the "ingest" service
 // "submit_sip_decision" endpoint HTTP response body for the "not_valid" error.
 type SubmitSipDecisionNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SubmitSipDecisionInternalErrorResponseBody is the type of the "ingest"
+// service "submit_sip_decision" endpoint HTTP response body for the
+// "internal_error" error.
+type SubmitSipDecisionInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -669,6 +742,24 @@ type DownloadSipNotFoundResponseBody struct {
 // ListUsersNotValidResponseBody is the type of the "ingest" service
 // "list_users" endpoint HTTP response body for the "not_valid" error.
 type ListUsersNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ListUsersInternalErrorResponseBody is the type of the "ingest" service
+// "list_users" endpoint HTTP response body for the "internal_error" error.
+type ListUsersInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -1808,6 +1899,21 @@ func NewListSipsNotValid(body *ListSipsNotValidResponseBody) *goa.ServiceError {
 	return v
 }
 
+// NewListSipsInternalError builds a ingest service list_sips endpoint
+// internal_error error.
+func NewListSipsInternalError(body *ListSipsInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // NewListSipsForbidden builds a ingest service list_sips endpoint forbidden
 // error.
 func NewListSipsForbidden(body string) ingest.Forbidden {
@@ -1849,9 +1955,9 @@ func NewShowSipSIPOK(body *ShowSipResponseBody) *ingestviews.SIPView {
 	return v
 }
 
-// NewShowSipNotAvailable builds a ingest service show_sip endpoint
-// not_available error.
-func NewShowSipNotAvailable(body *ShowSipNotAvailableResponseBody) *goa.ServiceError {
+// NewShowSipInternalError builds a ingest service show_sip endpoint
+// internal_error error.
+func NewShowSipInternalError(body *ShowSipInternalErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -1908,6 +2014,21 @@ func NewListSipWorkflowsSIPWorkflowsOK(body *ListSipWorkflowsResponseBody) *inge
 	return v
 }
 
+// NewListSipWorkflowsInternalError builds a ingest service list_sip_workflows
+// endpoint internal_error error.
+func NewListSipWorkflowsInternalError(body *ListSipWorkflowsInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // NewListSipWorkflowsNotFound builds a ingest service list_sip_workflows
 // endpoint not_found error.
 func NewListSipWorkflowsNotFound(body *ListSipWorkflowsNotFoundResponseBody) *ingest.SIPNotFound {
@@ -1953,6 +2074,21 @@ func NewConfirmSipNotAvailable(body *ConfirmSipNotAvailableResponseBody) *goa.Se
 // NewConfirmSipNotValid builds a ingest service confirm_sip endpoint not_valid
 // error.
 func NewConfirmSipNotValid(body *ConfirmSipNotValidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewConfirmSipInternalError builds a ingest service confirm_sip endpoint
+// internal_error error.
+func NewConfirmSipInternalError(body *ConfirmSipInternalErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -2022,6 +2158,21 @@ func NewRejectSipNotValid(body *RejectSipNotValidResponseBody) *goa.ServiceError
 	return v
 }
 
+// NewRejectSipInternalError builds a ingest service reject_sip endpoint
+// internal_error error.
+func NewRejectSipInternalError(body *RejectSipInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // NewRejectSipNotFound builds a ingest service reject_sip endpoint not_found
 // error.
 func NewRejectSipNotFound(body *RejectSipNotFoundResponseBody) *ingest.SIPNotFound {
@@ -2063,21 +2214,6 @@ func NewShowSipDecisionSIPDecisionOK(body *ShowSipDecisionResponseBody) *ingestv
 	return v
 }
 
-// NewShowSipDecisionInternalError builds a ingest service show_sip_decision
-// endpoint internal_error error.
-func NewShowSipDecisionInternalError(body *ShowSipDecisionInternalErrorResponseBody) *goa.ServiceError {
-	v := &goa.ServiceError{
-		Name:      *body.Name,
-		ID:        *body.ID,
-		Message:   *body.Message,
-		Temporary: *body.Temporary,
-		Timeout:   *body.Timeout,
-		Fault:     *body.Fault,
-	}
-
-	return v
-}
-
 // NewShowSipDecisionNotAvailable builds a ingest service show_sip_decision
 // endpoint not_available error.
 func NewShowSipDecisionNotAvailable(body *ShowSipDecisionNotAvailableResponseBody) *goa.ServiceError {
@@ -2096,6 +2232,21 @@ func NewShowSipDecisionNotAvailable(body *ShowSipDecisionNotAvailableResponseBod
 // NewShowSipDecisionNotValid builds a ingest service show_sip_decision
 // endpoint not_valid error.
 func NewShowSipDecisionNotValid(body *ShowSipDecisionNotValidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewShowSipDecisionInternalError builds a ingest service show_sip_decision
+// endpoint internal_error error.
+func NewShowSipDecisionInternalError(body *ShowSipDecisionInternalErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -2135,21 +2286,6 @@ func NewShowSipDecisionUnauthorized(body string) ingest.Unauthorized {
 	return v
 }
 
-// NewSubmitSipDecisionInternalError builds a ingest service
-// submit_sip_decision endpoint internal_error error.
-func NewSubmitSipDecisionInternalError(body *SubmitSipDecisionInternalErrorResponseBody) *goa.ServiceError {
-	v := &goa.ServiceError{
-		Name:      *body.Name,
-		ID:        *body.ID,
-		Message:   *body.Message,
-		Temporary: *body.Temporary,
-		Timeout:   *body.Timeout,
-		Fault:     *body.Fault,
-	}
-
-	return v
-}
-
 // NewSubmitSipDecisionNotAvailable builds a ingest service submit_sip_decision
 // endpoint not_available error.
 func NewSubmitSipDecisionNotAvailable(body *SubmitSipDecisionNotAvailableResponseBody) *goa.ServiceError {
@@ -2168,6 +2304,21 @@ func NewSubmitSipDecisionNotAvailable(body *SubmitSipDecisionNotAvailableRespons
 // NewSubmitSipDecisionNotValid builds a ingest service submit_sip_decision
 // endpoint not_valid error.
 func NewSubmitSipDecisionNotValid(body *SubmitSipDecisionNotValidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSubmitSipDecisionInternalError builds a ingest service
+// submit_sip_decision endpoint internal_error error.
+func NewSubmitSipDecisionInternalError(body *SubmitSipDecisionInternalErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -2486,6 +2637,21 @@ func NewListUsersUsersOK(body *ListUsersResponseBody) *ingestviews.UsersView {
 // NewListUsersNotValid builds a ingest service list_users endpoint not_valid
 // error.
 func NewListUsersNotValid(body *ListUsersNotValidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewListUsersInternalError builds a ingest service list_users endpoint
+// internal_error error.
+func NewListUsersInternalError(body *ListUsersInternalErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -3004,9 +3170,33 @@ func ValidateListSipsNotValidResponseBody(body *ListSipsNotValidResponseBody) (e
 	return
 }
 
-// ValidateShowSipNotAvailableResponseBody runs the validations defined on
-// show_sip_not_available_response_body
-func ValidateShowSipNotAvailableResponseBody(body *ShowSipNotAvailableResponseBody) (err error) {
+// ValidateListSipsInternalErrorResponseBody runs the validations defined on
+// list_sips_internal_error_response_body
+func ValidateListSipsInternalErrorResponseBody(body *ListSipsInternalErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateShowSipInternalErrorResponseBody runs the validations defined on
+// show_sip_internal_error_response_body
+func ValidateShowSipInternalErrorResponseBody(body *ShowSipInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -3039,6 +3229,30 @@ func ValidateShowSipNotFoundResponseBody(body *ShowSipNotFoundResponseBody) (err
 	}
 	if body.UUID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.uuid", *body.UUID, goa.FormatUUID))
+	}
+	return
+}
+
+// ValidateListSipWorkflowsInternalErrorResponseBody runs the validations
+// defined on list_sip_workflows_internal_error_response_body
+func ValidateListSipWorkflowsInternalErrorResponseBody(body *ListSipWorkflowsInternalErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
 	}
 	return
 }
@@ -3085,6 +3299,30 @@ func ValidateConfirmSipNotAvailableResponseBody(body *ConfirmSipNotAvailableResp
 // ValidateConfirmSipNotValidResponseBody runs the validations defined on
 // confirm_sip_not_valid_response_body
 func ValidateConfirmSipNotValidResponseBody(body *ConfirmSipNotValidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateConfirmSipInternalErrorResponseBody runs the validations defined on
+// confirm_sip_internal_error_response_body
+func ValidateConfirmSipInternalErrorResponseBody(body *ConfirmSipInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -3169,24 +3407,9 @@ func ValidateRejectSipNotValidResponseBody(body *RejectSipNotValidResponseBody) 
 	return
 }
 
-// ValidateRejectSipNotFoundResponseBody runs the validations defined on
-// reject_sip_not_found_response_body
-func ValidateRejectSipNotFoundResponseBody(body *RejectSipNotFoundResponseBody) (err error) {
-	if body.Message == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
-	}
-	if body.UUID == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "body"))
-	}
-	if body.UUID != nil {
-		err = goa.MergeErrors(err, goa.ValidateFormat("body.uuid", *body.UUID, goa.FormatUUID))
-	}
-	return
-}
-
-// ValidateShowSipDecisionInternalErrorResponseBody runs the validations
-// defined on show_sip_decision_internal_error_response_body
-func ValidateShowSipDecisionInternalErrorResponseBody(body *ShowSipDecisionInternalErrorResponseBody) (err error) {
+// ValidateRejectSipInternalErrorResponseBody runs the validations defined on
+// reject_sip_internal_error_response_body
+func ValidateRejectSipInternalErrorResponseBody(body *RejectSipInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -3204,6 +3427,21 @@ func ValidateShowSipDecisionInternalErrorResponseBody(body *ShowSipDecisionInter
 	}
 	if body.Fault == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateRejectSipNotFoundResponseBody runs the validations defined on
+// reject_sip_not_found_response_body
+func ValidateRejectSipNotFoundResponseBody(body *RejectSipNotFoundResponseBody) (err error) {
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.UUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "body"))
+	}
+	if body.UUID != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.uuid", *body.UUID, goa.FormatUUID))
 	}
 	return
 }
@@ -3256,24 +3494,9 @@ func ValidateShowSipDecisionNotValidResponseBody(body *ShowSipDecisionNotValidRe
 	return
 }
 
-// ValidateShowSipDecisionNotFoundResponseBody runs the validations defined on
-// show_sip_decision_not_found_response_body
-func ValidateShowSipDecisionNotFoundResponseBody(body *ShowSipDecisionNotFoundResponseBody) (err error) {
-	if body.Message == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
-	}
-	if body.UUID == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "body"))
-	}
-	if body.UUID != nil {
-		err = goa.MergeErrors(err, goa.ValidateFormat("body.uuid", *body.UUID, goa.FormatUUID))
-	}
-	return
-}
-
-// ValidateSubmitSipDecisionInternalErrorResponseBody runs the validations
-// defined on submit_sip_decision_internal_error_response_body
-func ValidateSubmitSipDecisionInternalErrorResponseBody(body *SubmitSipDecisionInternalErrorResponseBody) (err error) {
+// ValidateShowSipDecisionInternalErrorResponseBody runs the validations
+// defined on show_sip_decision_internal_error_response_body
+func ValidateShowSipDecisionInternalErrorResponseBody(body *ShowSipDecisionInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -3291,6 +3514,21 @@ func ValidateSubmitSipDecisionInternalErrorResponseBody(body *SubmitSipDecisionI
 	}
 	if body.Fault == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateShowSipDecisionNotFoundResponseBody runs the validations defined on
+// show_sip_decision_not_found_response_body
+func ValidateShowSipDecisionNotFoundResponseBody(body *ShowSipDecisionNotFoundResponseBody) (err error) {
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.UUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "body"))
+	}
+	if body.UUID != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.uuid", *body.UUID, goa.FormatUUID))
 	}
 	return
 }
@@ -3322,6 +3560,30 @@ func ValidateSubmitSipDecisionNotAvailableResponseBody(body *SubmitSipDecisionNo
 // ValidateSubmitSipDecisionNotValidResponseBody runs the validations defined
 // on submit_sip_decision_not_valid_response_body
 func ValidateSubmitSipDecisionNotValidResponseBody(body *SubmitSipDecisionNotValidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSubmitSipDecisionInternalErrorResponseBody runs the validations
+// defined on submit_sip_decision_internal_error_response_body
+func ValidateSubmitSipDecisionInternalErrorResponseBody(body *SubmitSipDecisionInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -3607,6 +3869,30 @@ func ValidateDownloadSipNotFoundResponseBody(body *DownloadSipNotFoundResponseBo
 // ValidateListUsersNotValidResponseBody runs the validations defined on
 // list_users_not_valid_response_body
 func ValidateListUsersNotValidResponseBody(body *ListUsersNotValidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateListUsersInternalErrorResponseBody runs the validations defined on
+// list_users_internal_error_response_body
+func ValidateListUsersInternalErrorResponseBody(body *ListUsersInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/internal/api/gen/http/ingest/server/encode_decode.go
+++ b/internal/api/gen/http/ingest/server/encode_decode.go
@@ -248,6 +248,19 @@ func EncodeListSipsError(encoder func(context.Context, http.ResponseWriter) goah
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListSipsInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
 		case "forbidden":
 			var res ingest.Forbidden
 			errors.As(v, &res)
@@ -326,7 +339,7 @@ func EncodeShowSipError(encoder func(context.Context, http.ResponseWriter) goaht
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "not_available":
+		case "internal_error":
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			enc := encoder(ctx, w)
@@ -334,10 +347,10 @@ func EncodeShowSipError(encoder func(context.Context, http.ResponseWriter) goaht
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
-				body = NewShowSipNotAvailableResponseBody(res)
+				body = NewShowSipInternalErrorResponseBody(res)
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusConflict)
+			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "not_found":
 			var res *ingest.SIPNotFound
@@ -430,6 +443,19 @@ func EncodeListSipWorkflowsError(encoder func(context.Context, http.ResponseWrit
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListSipWorkflowsInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
 		case "not_found":
 			var res *ingest.SIPNotFound
 			errors.As(v, &res)
@@ -563,6 +589,19 @@ func EncodeConfirmSipError(encoder func(context.Context, http.ResponseWriter) go
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewConfirmSipInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
 		case "not_found":
 			var res *ingest.SIPNotFound
 			errors.As(v, &res)
@@ -677,6 +716,19 @@ func EncodeRejectSipError(encoder func(context.Context, http.ResponseWriter) goa
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewRejectSipInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
 		case "not_found":
 			var res *ingest.SIPNotFound
 			errors.As(v, &res)
@@ -768,19 +820,6 @@ func EncodeShowSipDecisionError(encoder func(context.Context, http.ResponseWrite
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "internal_error":
-			var res *goa.ServiceError
-			errors.As(v, &res)
-			enc := encoder(ctx, w)
-			var body any
-			if formatter != nil {
-				body = formatter(ctx, res)
-			} else {
-				body = NewShowSipDecisionInternalErrorResponseBody(res)
-			}
-			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusInternalServerError)
-			return enc.Encode(body)
 		case "not_available":
 			var res *goa.ServiceError
 			errors.As(v, &res)
@@ -806,6 +845,19 @@ func EncodeShowSipDecisionError(encoder func(context.Context, http.ResponseWrite
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewShowSipDecisionInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "not_found":
 			var res *ingest.SIPNotFound
@@ -914,19 +966,6 @@ func EncodeSubmitSipDecisionError(encoder func(context.Context, http.ResponseWri
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "internal_error":
-			var res *goa.ServiceError
-			errors.As(v, &res)
-			enc := encoder(ctx, w)
-			var body any
-			if formatter != nil {
-				body = formatter(ctx, res)
-			} else {
-				body = NewSubmitSipDecisionInternalErrorResponseBody(res)
-			}
-			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusInternalServerError)
-			return enc.Encode(body)
 		case "not_available":
 			var res *goa.ServiceError
 			errors.As(v, &res)
@@ -952,6 +991,19 @@ func EncodeSubmitSipDecisionError(encoder func(context.Context, http.ResponseWri
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSubmitSipDecisionInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "not_found":
 			var res *ingest.SIPNotFound
@@ -1566,6 +1618,19 @@ func EncodeListUsersError(encoder func(context.Context, http.ResponseWriter) goa
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListUsersInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "forbidden":
 			var res ingest.Forbidden

--- a/internal/api/gen/http/ingest/server/types.go
+++ b/internal/api/gen/http/ingest/server/types.go
@@ -228,9 +228,27 @@ type ListSipsNotValidResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
-// ShowSipNotAvailableResponseBody is the type of the "ingest" service
-// "show_sip" endpoint HTTP response body for the "not_available" error.
-type ShowSipNotAvailableResponseBody struct {
+// ListSipsInternalErrorResponseBody is the type of the "ingest" service
+// "list_sips" endpoint HTTP response body for the "internal_error" error.
+type ListSipsInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ShowSipInternalErrorResponseBody is the type of the "ingest" service
+// "show_sip" endpoint HTTP response body for the "internal_error" error.
+type ShowSipInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -253,6 +271,25 @@ type ShowSipNotFoundResponseBody struct {
 	Message string `form:"message" json:"message" xml:"message"`
 	// Identifier of missing SIP
 	UUID string `form:"uuid" json:"uuid" xml:"uuid"`
+}
+
+// ListSipWorkflowsInternalErrorResponseBody is the type of the "ingest"
+// service "list_sip_workflows" endpoint HTTP response body for the
+// "internal_error" error.
+type ListSipWorkflowsInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
 // ListSipWorkflowsNotFoundResponseBody is the type of the "ingest" service
@@ -285,6 +322,24 @@ type ConfirmSipNotAvailableResponseBody struct {
 // ConfirmSipNotValidResponseBody is the type of the "ingest" service
 // "confirm_sip" endpoint HTTP response body for the "not_valid" error.
 type ConfirmSipNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ConfirmSipInternalErrorResponseBody is the type of the "ingest" service
+// "confirm_sip" endpoint HTTP response body for the "internal_error" error.
+type ConfirmSipInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -345,19 +400,9 @@ type RejectSipNotValidResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
-// RejectSipNotFoundResponseBody is the type of the "ingest" service
-// "reject_sip" endpoint HTTP response body for the "not_found" error.
-type RejectSipNotFoundResponseBody struct {
-	// Message of error
-	Message string `form:"message" json:"message" xml:"message"`
-	// Identifier of missing SIP
-	UUID string `form:"uuid" json:"uuid" xml:"uuid"`
-}
-
-// ShowSipDecisionInternalErrorResponseBody is the type of the "ingest" service
-// "show_sip_decision" endpoint HTTP response body for the "internal_error"
-// error.
-type ShowSipDecisionInternalErrorResponseBody struct {
+// RejectSipInternalErrorResponseBody is the type of the "ingest" service
+// "reject_sip" endpoint HTTP response body for the "internal_error" error.
+type RejectSipInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -371,6 +416,15 @@ type ShowSipDecisionInternalErrorResponseBody struct {
 	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
 	// Is the error a server-side fault?
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// RejectSipNotFoundResponseBody is the type of the "ingest" service
+// "reject_sip" endpoint HTTP response body for the "not_found" error.
+type RejectSipNotFoundResponseBody struct {
+	// Message of error
+	Message string `form:"message" json:"message" xml:"message"`
+	// Identifier of missing SIP
+	UUID string `form:"uuid" json:"uuid" xml:"uuid"`
 }
 
 // ShowSipDecisionNotAvailableResponseBody is the type of the "ingest" service
@@ -410,19 +464,10 @@ type ShowSipDecisionNotValidResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
-// ShowSipDecisionNotFoundResponseBody is the type of the "ingest" service
-// "show_sip_decision" endpoint HTTP response body for the "not_found" error.
-type ShowSipDecisionNotFoundResponseBody struct {
-	// Message of error
-	Message string `form:"message" json:"message" xml:"message"`
-	// Identifier of missing SIP
-	UUID string `form:"uuid" json:"uuid" xml:"uuid"`
-}
-
-// SubmitSipDecisionInternalErrorResponseBody is the type of the "ingest"
-// service "submit_sip_decision" endpoint HTTP response body for the
-// "internal_error" error.
-type SubmitSipDecisionInternalErrorResponseBody struct {
+// ShowSipDecisionInternalErrorResponseBody is the type of the "ingest" service
+// "show_sip_decision" endpoint HTTP response body for the "internal_error"
+// error.
+type ShowSipDecisionInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -436,6 +481,15 @@ type SubmitSipDecisionInternalErrorResponseBody struct {
 	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
 	// Is the error a server-side fault?
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ShowSipDecisionNotFoundResponseBody is the type of the "ingest" service
+// "show_sip_decision" endpoint HTTP response body for the "not_found" error.
+type ShowSipDecisionNotFoundResponseBody struct {
+	// Message of error
+	Message string `form:"message" json:"message" xml:"message"`
+	// Identifier of missing SIP
+	UUID string `form:"uuid" json:"uuid" xml:"uuid"`
 }
 
 // SubmitSipDecisionNotAvailableResponseBody is the type of the "ingest"
@@ -460,6 +514,25 @@ type SubmitSipDecisionNotAvailableResponseBody struct {
 // SubmitSipDecisionNotValidResponseBody is the type of the "ingest" service
 // "submit_sip_decision" endpoint HTTP response body for the "not_valid" error.
 type SubmitSipDecisionNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SubmitSipDecisionInternalErrorResponseBody is the type of the "ingest"
+// service "submit_sip_decision" endpoint HTTP response body for the
+// "internal_error" error.
+type SubmitSipDecisionInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -669,6 +742,24 @@ type DownloadSipNotFoundResponseBody struct {
 // ListUsersNotValidResponseBody is the type of the "ingest" service
 // "list_users" endpoint HTTP response body for the "not_valid" error.
 type ListUsersNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ListUsersInternalErrorResponseBody is the type of the "ingest" service
+// "list_users" endpoint HTTP response body for the "internal_error" error.
+type ListUsersInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -1911,10 +2002,24 @@ func NewListSipsNotValidResponseBody(res *goa.ServiceError) *ListSipsNotValidRes
 	return body
 }
 
-// NewShowSipNotAvailableResponseBody builds the HTTP response body from the
+// NewListSipsInternalErrorResponseBody builds the HTTP response body from the
+// result of the "list_sips" endpoint of the "ingest" service.
+func NewListSipsInternalErrorResponseBody(res *goa.ServiceError) *ListSipsInternalErrorResponseBody {
+	body := &ListSipsInternalErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewShowSipInternalErrorResponseBody builds the HTTP response body from the
 // result of the "show_sip" endpoint of the "ingest" service.
-func NewShowSipNotAvailableResponseBody(res *goa.ServiceError) *ShowSipNotAvailableResponseBody {
-	body := &ShowSipNotAvailableResponseBody{
+func NewShowSipInternalErrorResponseBody(res *goa.ServiceError) *ShowSipInternalErrorResponseBody {
+	body := &ShowSipInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -1931,6 +2036,20 @@ func NewShowSipNotFoundResponseBody(res *ingest.SIPNotFound) *ShowSipNotFoundRes
 	body := &ShowSipNotFoundResponseBody{
 		Message: res.Message,
 		UUID:    res.UUID,
+	}
+	return body
+}
+
+// NewListSipWorkflowsInternalErrorResponseBody builds the HTTP response body
+// from the result of the "list_sip_workflows" endpoint of the "ingest" service.
+func NewListSipWorkflowsInternalErrorResponseBody(res *goa.ServiceError) *ListSipWorkflowsInternalErrorResponseBody {
+	body := &ListSipWorkflowsInternalErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
 	}
 	return body
 }
@@ -1963,6 +2082,20 @@ func NewConfirmSipNotAvailableResponseBody(res *goa.ServiceError) *ConfirmSipNot
 // result of the "confirm_sip" endpoint of the "ingest" service.
 func NewConfirmSipNotValidResponseBody(res *goa.ServiceError) *ConfirmSipNotValidResponseBody {
 	body := &ConfirmSipNotValidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewConfirmSipInternalErrorResponseBody builds the HTTP response body from
+// the result of the "confirm_sip" endpoint of the "ingest" service.
+func NewConfirmSipInternalErrorResponseBody(res *goa.ServiceError) *ConfirmSipInternalErrorResponseBody {
+	body := &ConfirmSipInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -2011,26 +2144,26 @@ func NewRejectSipNotValidResponseBody(res *goa.ServiceError) *RejectSipNotValidR
 	return body
 }
 
-// NewRejectSipNotFoundResponseBody builds the HTTP response body from the
+// NewRejectSipInternalErrorResponseBody builds the HTTP response body from the
 // result of the "reject_sip" endpoint of the "ingest" service.
-func NewRejectSipNotFoundResponseBody(res *ingest.SIPNotFound) *RejectSipNotFoundResponseBody {
-	body := &RejectSipNotFoundResponseBody{
-		Message: res.Message,
-		UUID:    res.UUID,
-	}
-	return body
-}
-
-// NewShowSipDecisionInternalErrorResponseBody builds the HTTP response body
-// from the result of the "show_sip_decision" endpoint of the "ingest" service.
-func NewShowSipDecisionInternalErrorResponseBody(res *goa.ServiceError) *ShowSipDecisionInternalErrorResponseBody {
-	body := &ShowSipDecisionInternalErrorResponseBody{
+func NewRejectSipInternalErrorResponseBody(res *goa.ServiceError) *RejectSipInternalErrorResponseBody {
+	body := &RejectSipInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
 		Temporary: res.Temporary,
 		Timeout:   res.Timeout,
 		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewRejectSipNotFoundResponseBody builds the HTTP response body from the
+// result of the "reject_sip" endpoint of the "ingest" service.
+func NewRejectSipNotFoundResponseBody(res *ingest.SIPNotFound) *RejectSipNotFoundResponseBody {
+	body := &RejectSipNotFoundResponseBody{
+		Message: res.Message,
+		UUID:    res.UUID,
 	}
 	return body
 }
@@ -2063,27 +2196,26 @@ func NewShowSipDecisionNotValidResponseBody(res *goa.ServiceError) *ShowSipDecis
 	return body
 }
 
-// NewShowSipDecisionNotFoundResponseBody builds the HTTP response body from
-// the result of the "show_sip_decision" endpoint of the "ingest" service.
-func NewShowSipDecisionNotFoundResponseBody(res *ingest.SIPNotFound) *ShowSipDecisionNotFoundResponseBody {
-	body := &ShowSipDecisionNotFoundResponseBody{
-		Message: res.Message,
-		UUID:    res.UUID,
-	}
-	return body
-}
-
-// NewSubmitSipDecisionInternalErrorResponseBody builds the HTTP response body
-// from the result of the "submit_sip_decision" endpoint of the "ingest"
-// service.
-func NewSubmitSipDecisionInternalErrorResponseBody(res *goa.ServiceError) *SubmitSipDecisionInternalErrorResponseBody {
-	body := &SubmitSipDecisionInternalErrorResponseBody{
+// NewShowSipDecisionInternalErrorResponseBody builds the HTTP response body
+// from the result of the "show_sip_decision" endpoint of the "ingest" service.
+func NewShowSipDecisionInternalErrorResponseBody(res *goa.ServiceError) *ShowSipDecisionInternalErrorResponseBody {
+	body := &ShowSipDecisionInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
 		Temporary: res.Temporary,
 		Timeout:   res.Timeout,
 		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewShowSipDecisionNotFoundResponseBody builds the HTTP response body from
+// the result of the "show_sip_decision" endpoint of the "ingest" service.
+func NewShowSipDecisionNotFoundResponseBody(res *ingest.SIPNotFound) *ShowSipDecisionNotFoundResponseBody {
+	body := &ShowSipDecisionNotFoundResponseBody{
+		Message: res.Message,
+		UUID:    res.UUID,
 	}
 	return body
 }
@@ -2107,6 +2239,21 @@ func NewSubmitSipDecisionNotAvailableResponseBody(res *goa.ServiceError) *Submit
 // the result of the "submit_sip_decision" endpoint of the "ingest" service.
 func NewSubmitSipDecisionNotValidResponseBody(res *goa.ServiceError) *SubmitSipDecisionNotValidResponseBody {
 	body := &SubmitSipDecisionNotValidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSubmitSipDecisionInternalErrorResponseBody builds the HTTP response body
+// from the result of the "submit_sip_decision" endpoint of the "ingest"
+// service.
+func NewSubmitSipDecisionInternalErrorResponseBody(res *goa.ServiceError) *SubmitSipDecisionInternalErrorResponseBody {
+	body := &SubmitSipDecisionInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -2278,6 +2425,20 @@ func NewDownloadSipNotFoundResponseBody(res *ingest.SIPNotFound) *DownloadSipNot
 // result of the "list_users" endpoint of the "ingest" service.
 func NewListUsersNotValidResponseBody(res *goa.ServiceError) *ListUsersNotValidResponseBody {
 	body := &ListUsersNotValidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewListUsersInternalErrorResponseBody builds the HTTP response body from the
+// result of the "list_users" endpoint of the "ingest" service.
+func NewListUsersInternalErrorResponseBody(res *goa.ServiceError) *ListUsersInternalErrorResponseBody {
+	body := &ListUsersInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,

--- a/internal/api/gen/http/openapi.json
+++ b/internal/api/gen/http/openapi.json
@@ -2240,6 +2240,59 @@
       "title": "IngestAddSipResponseBody",
       "type": "object"
     },
+    "IngestConfirmSipInternalErrorResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
     "IngestConfirmSipNotAvailableResponseBody": {
       "description": "Error response result type (default view)",
       "example": {
@@ -3081,7 +3134,166 @@
       "title": "Mediatype identifier: application/vnd.goa.error; view=default",
       "type": "object"
     },
+    "IngestListSipWorkflowsInternalErrorResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
+    "IngestListSipsInternalErrorResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
     "IngestListSipsNotValidResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
+    "IngestListUsersInternalErrorResponseBody": {
       "description": "Error response result type (default view)",
       "example": {
         "fault": false,
@@ -3251,6 +3463,59 @@
         }
       },
       "title": "IngestPingEvent",
+      "type": "object"
+    },
+    "IngestRejectSipInternalErrorResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
       "type": "object"
     },
     "IngestRejectSipNotAvailableResponseBody": {
@@ -3746,7 +4011,7 @@
       "title": "Mediatype identifier: application/vnd.goa.error; view=default",
       "type": "object"
     },
-    "IngestShowSipNotAvailableResponseBody": {
+    "IngestShowSipInternalErrorResponseBody": {
       "description": "Error response result type (default view)",
       "example": {
         "fault": false,
@@ -3976,7 +4241,7 @@
       "type": "object"
     },
     "IngestUploadSipInternalErrorResponseBody": {
-      "description": "Fault while processing upload. (default view)",
+      "description": "Error response result type (default view)",
       "example": {
         "fault": false,
         "id": "123abc",
@@ -5665,6 +5930,59 @@
       "title": "StorageCancelAipDeletionRequestBody",
       "type": "object"
     },
+    "StorageCreateAipInternalErrorResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
     "StorageCreateAipNotValidResponseBody": {
       "description": "Error response result type (default view)",
       "example": {
@@ -5770,6 +6088,59 @@
         "object_key"
       ],
       "title": "StorageCreateAipRequestBody",
+      "type": "object"
+    },
+    "StorageCreateLocationInternalErrorResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
       "type": "object"
     },
     "StorageCreateLocationNotValidResponseBody": {
@@ -6431,7 +6802,60 @@
       "title": "StorageEvent",
       "type": "object"
     },
-    "StorageListAipsNotAvailableResponseBody": {
+    "StorageListAipWorkflowsInternalErrorResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
+    "StorageListAipsInternalErrorResponseBody": {
       "description": "Error response result type (default view)",
       "example": {
         "fault": false,
@@ -6537,7 +6961,113 @@
       "title": "Mediatype identifier: application/vnd.goa.error; view=default",
       "type": "object"
     },
+    "StorageListLocationAipsInternalErrorResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
     "StorageListLocationAipsNotValidResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
+    "StorageListLocationsInternalErrorResponseBody": {
       "description": "Error response result type (default view)",
       "example": {
         "fault": false,
@@ -6661,7 +7191,7 @@
       "title": "Mediatype identifier: application/vnd.goa.error; view=default",
       "type": "object"
     },
-    "StorageMoveAipNotAvailableResponseBody": {
+    "StorageMoveAipInternalErrorResponseBody": {
       "description": "Error response result type (default view)",
       "example": {
         "fault": false,
@@ -6837,6 +7367,59 @@
       "title": "Mediatype identifier: application/vnd.goa.error; view=default",
       "type": "object"
     },
+    "StorageMoveAipStatusInternalErrorResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
     "StoragePingEvent": {
       "example": {
         "message": "abc123"
@@ -6850,7 +7433,7 @@
       "title": "StoragePingEvent",
       "type": "object"
     },
-    "StorageRejectAipNotAvailableResponseBody": {
+    "StorageRejectAipInternalErrorResponseBody": {
       "description": "Error response result type (default view)",
       "example": {
         "fault": false,
@@ -7198,6 +7781,112 @@
         "approved"
       ],
       "title": "StorageReviewAipDeletionRequestBody",
+      "type": "object"
+    },
+    "StorageShowAipInternalErrorResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
+      "type": "object"
+    },
+    "StorageShowLocationInternalErrorResponseBody": {
+      "description": "Error response result type (default view)",
+      "example": {
+        "fault": false,
+        "id": "123abc",
+        "message": "parameter 'p' must be an integer",
+        "name": "bad_request",
+        "temporary": false,
+        "timeout": false
+      },
+      "properties": {
+        "fault": {
+          "description": "Is the error a server-side fault?",
+          "example": false,
+          "type": "boolean"
+        },
+        "id": {
+          "description": "ID is a unique identifier for this particular occurrence of the problem.",
+          "example": "123abc",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a human-readable explanation specific to this occurrence of the problem.",
+          "example": "parameter 'p' must be an integer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of this class of errors.",
+          "example": "bad_request",
+          "type": "string"
+        },
+        "temporary": {
+          "description": "Is the error temporary?",
+          "example": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Is the error a timeout?",
+          "example": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "id",
+        "message",
+        "temporary",
+        "timeout",
+        "fault"
+      ],
+      "title": "Mediatype identifier: application/vnd.goa.error; view=default",
       "type": "object"
     },
     "URLConfig": {
@@ -7882,6 +8571,12 @@
             "schema": {
               "type": "string"
             }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/IngestListSipsInternalErrorResponseBody"
+            }
           }
         },
         "schemes": [
@@ -8079,10 +8774,10 @@
               ]
             }
           },
-          "409": {
-            "description": "Conflict response.",
+          "500": {
+            "description": "Internal Server Error response.",
             "schema": {
-              "$ref": "#/definitions/IngestShowSipNotAvailableResponseBody"
+              "$ref": "#/definitions/IngestShowSipInternalErrorResponseBody"
             }
           }
         },
@@ -8164,6 +8859,12 @@
             "description": "Conflict response.",
             "schema": {
               "$ref": "#/definitions/IngestConfirmSipNotAvailableResponseBody"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/IngestConfirmSipInternalErrorResponseBody"
             }
           }
         },
@@ -8542,6 +9243,12 @@
             "schema": {
               "$ref": "#/definitions/IngestRejectSipNotAvailableResponseBody"
             }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/IngestRejectSipInternalErrorResponseBody"
+            }
           }
         },
         "schemes": [
@@ -8602,6 +9309,12 @@
                 "message",
                 "uuid"
               ]
+            }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/IngestListSipWorkflowsInternalErrorResponseBody"
             }
           }
         },
@@ -8681,6 +9394,12 @@
             "description": "Forbidden response.",
             "schema": {
               "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/IngestListUsersInternalErrorResponseBody"
             }
           }
         },
@@ -8783,10 +9502,10 @@
               "type": "string"
             }
           },
-          "409": {
-            "description": "Conflict response.",
+          "500": {
+            "description": "Internal Server Error response.",
             "schema": {
-              "$ref": "#/definitions/StorageListAipsNotAvailableResponseBody"
+              "$ref": "#/definitions/StorageListAipsInternalErrorResponseBody"
             }
           }
         },
@@ -8848,6 +9567,12 @@
             "schema": {
               "type": "string"
             }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/StorageCreateAipInternalErrorResponseBody"
+            }
           }
         },
         "schemes": [
@@ -8908,6 +9633,12 @@
                 "message",
                 "uuid"
               ]
+            }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/StorageShowAipInternalErrorResponseBody"
             }
           }
         },
@@ -9573,10 +10304,10 @@
               ]
             }
           },
-          "409": {
-            "description": "Conflict response.",
+          "500": {
+            "description": "Internal Server Error response.",
             "schema": {
-              "$ref": "#/definitions/StorageRejectAipNotAvailableResponseBody"
+              "$ref": "#/definitions/StorageRejectAipInternalErrorResponseBody"
             }
           }
         },
@@ -9647,6 +10378,12 @@
             "description": "Failed Dependency response.",
             "schema": {
               "$ref": "#/definitions/StorageMoveAipStatusFailedDependencyResponseBody"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/StorageMoveAipStatusInternalErrorResponseBody"
             }
           }
         },
@@ -9722,10 +10459,10 @@
               ]
             }
           },
-          "409": {
-            "description": "Conflict response.",
+          "500": {
+            "description": "Internal Server Error response.",
             "schema": {
-              "$ref": "#/definitions/StorageMoveAipNotAvailableResponseBody"
+              "$ref": "#/definitions/StorageMoveAipInternalErrorResponseBody"
             }
           }
         },
@@ -9815,6 +10552,12 @@
                 "uuid"
               ]
             }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/StorageListAipWorkflowsInternalErrorResponseBody"
+            }
           }
         },
         "schemes": [
@@ -9855,6 +10598,12 @@
             "description": "Forbidden response.",
             "schema": {
               "type": "string"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/StorageListLocationsInternalErrorResponseBody"
             }
           }
         },
@@ -9919,6 +10668,12 @@
             "schema": {
               "type": "string"
             }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/StorageCreateLocationInternalErrorResponseBody"
+            }
           }
         },
         "schemes": [
@@ -9979,6 +10734,12 @@
                 "message",
                 "uuid"
               ]
+            }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/StorageShowLocationInternalErrorResponseBody"
             }
           }
         },
@@ -10046,6 +10807,12 @@
                 "message",
                 "uuid"
               ]
+            }
+          },
+          "500": {
+            "description": "Internal Server Error response.",
+            "schema": {
+              "$ref": "#/definitions/StorageListLocationAipsInternalErrorResponseBody"
             }
           }
         },

--- a/internal/api/gen/http/openapi.yaml
+++ b/internal/api/gen/http/openapi.yaml
@@ -442,6 +442,10 @@ paths:
                     description: Forbidden response.
                     schema:
                         type: string
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/IngestListSipsInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -534,10 +538,10 @@ paths:
                         required:
                             - message
                             - uuid
-                "409":
-                    description: Conflict response.
+                "500":
+                    description: Internal Server Error response.
                     schema:
-                        $ref: '#/definitions/IngestShowSipNotAvailableResponseBody'
+                        $ref: '#/definitions/IngestShowSipInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -595,6 +599,10 @@ paths:
                     description: Conflict response.
                     schema:
                         $ref: '#/definitions/IngestConfirmSipNotAvailableResponseBody'
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/IngestConfirmSipInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -861,6 +869,10 @@ paths:
                     description: Conflict response.
                     schema:
                         $ref: '#/definitions/IngestRejectSipNotAvailableResponseBody'
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/IngestRejectSipInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -905,6 +917,10 @@ paths:
                         required:
                             - message
                             - uuid
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/IngestListSipWorkflowsInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1010,6 +1026,10 @@ paths:
                     description: Forbidden response.
                     schema:
                         type: string
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/IngestListUsersInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1083,10 +1103,10 @@ paths:
                     description: Forbidden response.
                     schema:
                         type: string
-                "409":
-                    description: Conflict response.
+                "500":
+                    description: Internal Server Error response.
                     schema:
-                        $ref: '#/definitions/StorageListAipsNotAvailableResponseBody'
+                        $ref: '#/definitions/StorageListAipsInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1130,6 +1150,10 @@ paths:
                     description: Forbidden response.
                     schema:
                         type: string
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/StorageCreateAipInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1174,6 +1198,10 @@ paths:
                         required:
                             - message
                             - uuid
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/StorageShowAipInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1640,10 +1668,10 @@ paths:
                         required:
                             - message
                             - uuid
-                "409":
-                    description: Conflict response.
+                "500":
+                    description: Internal Server Error response.
                     schema:
-                        $ref: '#/definitions/StorageRejectAipNotAvailableResponseBody'
+                        $ref: '#/definitions/StorageRejectAipInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1694,6 +1722,10 @@ paths:
                     description: Failed Dependency response.
                     schema:
                         $ref: '#/definitions/StorageMoveAipStatusFailedDependencyResponseBody'
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/StorageMoveAipStatusInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1746,10 +1778,10 @@ paths:
                         required:
                             - message
                             - uuid
-                "409":
-                    description: Conflict response.
+                "500":
+                    description: Internal Server Error response.
                     schema:
-                        $ref: '#/definitions/StorageMoveAipNotAvailableResponseBody'
+                        $ref: '#/definitions/StorageMoveAipInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1815,6 +1847,10 @@ paths:
                         required:
                             - message
                             - uuid
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/StorageListAipWorkflowsInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1845,6 +1881,10 @@ paths:
                     description: Forbidden response.
                     schema:
                         type: string
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/StorageListLocationsInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1890,6 +1930,10 @@ paths:
                     description: Forbidden response.
                     schema:
                         type: string
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/StorageCreateLocationInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1934,6 +1978,10 @@ paths:
                         required:
                             - message
                             - uuid
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/StorageShowLocationInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -1982,6 +2030,10 @@ paths:
                         required:
                             - message
                             - uuid
+                "500":
+                    description: Internal Server Error response.
+                    schema:
+                        $ref: '#/definitions/StorageListLocationAipsInternalErrorResponseBody'
             schemes:
                 - http
             security:
@@ -3772,6 +3824,49 @@ definitions:
             uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
         required:
             - uuid
+    IngestConfirmSipInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
     IngestConfirmSipNotAvailableResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object
@@ -4417,7 +4512,136 @@ definitions:
             - temporary
             - timeout
             - fault
+    IngestListSipWorkflowsInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
+    IngestListSipsInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
     IngestListSipsNotValidResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
+    IngestListUsersInternalErrorResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object
         properties:
@@ -4555,6 +4779,49 @@ definitions:
                 example: abc123
         example:
             message: abc123
+    IngestRejectSipInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
     IngestRejectSipNotAvailableResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object
@@ -4953,7 +5220,7 @@ definitions:
             - temporary
             - timeout
             - fault
-    IngestShowSipNotAvailableResponseBody:
+    IngestShowSipInternalErrorResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object
         properties:
@@ -5165,7 +5432,7 @@ definitions:
                 type: boolean
                 description: Is the error a timeout?
                 example: false
-        description: Fault while processing upload. (default view)
+        description: Error response result type (default view)
         example:
             fault: false
             id: 123abc
@@ -6481,6 +6748,49 @@ definitions:
                 example: false
         example:
             check: false
+    StorageCreateAipInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
     StorageCreateAipNotValidResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object
@@ -6568,6 +6878,49 @@ definitions:
             - uuid
             - name
             - object_key
+    StorageCreateLocationInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
     StorageCreateLocationNotValidResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object
@@ -7048,7 +7401,50 @@ definitions:
                         source: s3
                         uuid: abc123
                     uuid: d1845cb6-a5ea-474a-9ab8-26f9bcd919f5
-    StorageListAipsNotAvailableResponseBody:
+    StorageListAipWorkflowsInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
+    StorageListAipsInternalErrorResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object
         properties:
@@ -7134,7 +7530,93 @@ definitions:
             - temporary
             - timeout
             - fault
+    StorageListLocationAipsInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
     StorageListLocationAipsNotValidResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
+    StorageListLocationsInternalErrorResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object
         properties:
@@ -7233,7 +7715,7 @@ definitions:
             - temporary
             - timeout
             - fault
-    StorageMoveAipNotAvailableResponseBody:
+    StorageMoveAipInternalErrorResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object
         properties:
@@ -7374,6 +7856,49 @@ definitions:
             - temporary
             - timeout
             - fault
+    StorageMoveAipStatusInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
     StoragePingEvent:
         title: StoragePingEvent
         type: object
@@ -7383,7 +7908,7 @@ definitions:
                 example: abc123
         example:
             message: abc123
-    StorageRejectAipNotAvailableResponseBody:
+    StorageRejectAipInternalErrorResponseBody:
         title: 'Mediatype identifier: application/vnd.goa.error; view=default'
         type: object
         properties:
@@ -7663,6 +8188,92 @@ definitions:
             approved: false
         required:
             - approved
+    StorageShowAipInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
+    StorageShowLocationInternalErrorResponseBody:
+        title: 'Mediatype identifier: application/vnd.goa.error; view=default'
+        type: object
+        properties:
+            fault:
+                type: boolean
+                description: Is the error a server-side fault?
+                example: false
+            id:
+                type: string
+                description: ID is a unique identifier for this particular occurrence of the problem.
+                example: 123abc
+            message:
+                type: string
+                description: Message is a human-readable explanation specific to this occurrence of the problem.
+                example: parameter 'p' must be an integer
+            name:
+                type: string
+                description: Name is the name of this class of errors.
+                example: bad_request
+            temporary:
+                type: boolean
+                description: Is the error temporary?
+                example: false
+            timeout:
+                type: boolean
+                description: Is the error a timeout?
+                example: false
+        description: Error response result type (default view)
+        example:
+            fault: false
+            id: 123abc
+            message: parameter 'p' must be an integer
+            name: bad_request
+            temporary: false
+            timeout: false
+        required:
+            - name
+            - id
+            - message
+            - temporary
+            - timeout
+            - fault
     URLConfig:
         title: URLConfig
         type: object

--- a/internal/api/gen/http/openapi3.2.json
+++ b/internal/api/gen/http/openapi3.2.json
@@ -4332,6 +4332,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -4509,7 +4519,7 @@
                 }
               }
             },
-            "description": "internal_error: Fault while processing upload."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -4610,7 +4620,7 @@
             },
             "description": "not_found: SIP not found"
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -4618,7 +4628,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -4727,6 +4737,16 @@
               }
             },
             "description": "not_available: Conflict response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5283,6 +5303,16 @@
               }
             },
             "description": "not_available: Conflict response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5388,6 +5418,16 @@
               }
             },
             "description": "not_found: SIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5517,6 +5557,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5678,7 +5728,7 @@
             },
             "description": "forbidden: Forbidden response."
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -5686,7 +5736,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5774,6 +5824,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5864,6 +5924,16 @@
               }
             },
             "description": "not_found: AIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -6832,7 +6902,7 @@
             },
             "description": "not_found: AIP not found"
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -6840,7 +6910,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -6935,6 +7005,16 @@
               }
             },
             "description": "failed_dependency: Failed Dependency response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7032,7 +7112,7 @@
             },
             "description": "not_found: AIP not found"
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -7040,7 +7120,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7181,6 +7261,16 @@
               }
             },
             "description": "not_found: AIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7243,6 +7333,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7336,6 +7436,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7438,6 +7548,16 @@
               }
             },
             "description": "not_found: Storage location not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7540,6 +7660,16 @@
               }
             },
             "description": "not_found: Storage location not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [

--- a/internal/api/gen/http/openapi3.2.yaml
+++ b/internal/api/gen/http/openapi3.2.yaml
@@ -643,6 +643,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Unauthorized'
                     description: 'forbidden: Forbidden response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_sips ingest
@@ -767,12 +773,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/SIPNotFound'
                     description: 'not_found: SIP not found'
-                "409":
+                "500":
                     content:
                         application/vnd.goa.error:
                             schema:
                                 $ref: '#/components/schemas/Error'
-                    description: 'not_available: Conflict response.'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: show_sip ingest
@@ -842,6 +848,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'not_available: Conflict response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: confirm_sip ingest
@@ -1200,6 +1212,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'not_available: Conflict response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: reject_sip ingest
@@ -1269,6 +1287,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/SIPNotFound'
                     description: 'not_found: SIP not found'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_sip_workflows ingest
@@ -1325,7 +1349,7 @@ paths:
                         application/vnd.goa.error:
                             schema:
                                 $ref: '#/components/schemas/Error'
-                    description: 'internal_error: Fault while processing upload.'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: upload_sip ingest
@@ -1413,6 +1437,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Unauthorized'
                     description: 'forbidden: Forbidden response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_users ingest
@@ -1524,12 +1554,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Unauthorized'
                     description: 'forbidden: Forbidden response.'
-                "409":
+                "500":
                     content:
                         application/vnd.goa.error:
                             schema:
                                 $ref: '#/components/schemas/Error'
-                    description: 'not_available: Conflict response.'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_aips storage
@@ -1588,6 +1618,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Unauthorized'
                     description: 'forbidden: Forbidden response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: create_aip storage
@@ -1648,6 +1684,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/AIPNotFound'
                     description: 'not_found: AIP not found'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: show_aip storage
@@ -2273,12 +2315,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/AIPNotFound'
                     description: 'not_found: AIP not found'
-                "409":
+                "500":
                     content:
                         application/vnd.goa.error:
                             schema:
                                 $ref: '#/components/schemas/Error'
-                    description: 'not_available: Conflict response.'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: reject_aip storage
@@ -2339,6 +2381,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'failed_dependency: Failed Dependency response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: move_aip_status storage
@@ -2401,12 +2449,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/AIPNotFound'
                     description: 'not_found: AIP not found'
-                "409":
+                "500":
                     content:
                         application/vnd.goa.error:
                             schema:
                                 $ref: '#/components/schemas/Error'
-                    description: 'not_available: Conflict response.'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: move_aip storage
@@ -2503,6 +2551,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/AIPNotFound'
                     description: 'not_found: AIP not found'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_aip_workflows storage
@@ -2542,6 +2596,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Unauthorized'
                     description: 'forbidden: Forbidden response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_locations storage
@@ -2604,6 +2664,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Unauthorized'
                     description: 'forbidden: Forbidden response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: create_location storage
@@ -2674,6 +2740,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/LocationNotFound'
                     description: 'not_found: Storage location not found'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: show_location storage
@@ -2740,6 +2812,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/LocationNotFound'
                     description: 'not_found: Storage location not found'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_location_aips storage

--- a/internal/api/gen/http/openapi3.json
+++ b/internal/api/gen/http/openapi3.json
@@ -4371,6 +4371,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -4556,7 +4566,7 @@
                 }
               }
             },
-            "description": "internal_error: Fault while processing upload."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -4661,7 +4671,7 @@
             },
             "description": "not_found: SIP not found"
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -4669,7 +4679,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -4782,6 +4792,16 @@
               }
             },
             "description": "not_available: Conflict response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5358,6 +5378,16 @@
               }
             },
             "description": "not_available: Conflict response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5467,6 +5497,16 @@
               }
             },
             "description": "not_found: SIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5600,6 +5640,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5765,7 +5815,7 @@
             },
             "description": "forbidden: Forbidden response."
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -5773,7 +5823,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5865,6 +5915,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -5959,6 +6019,16 @@
               }
             },
             "description": "not_found: AIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -6963,7 +7033,7 @@
             },
             "description": "not_found: AIP not found"
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -6971,7 +7041,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7070,6 +7140,16 @@
               }
             },
             "description": "failed_dependency: Failed Dependency response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7171,7 +7251,7 @@
             },
             "description": "not_found: AIP not found"
           },
-          "409": {
+          "500": {
             "content": {
               "application/vnd.goa.error": {
                 "schema": {
@@ -7179,7 +7259,7 @@
                 }
               }
             },
-            "description": "not_available: Conflict response."
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7324,6 +7404,16 @@
               }
             },
             "description": "not_found: AIP not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7390,6 +7480,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7487,6 +7587,16 @@
               }
             },
             "description": "forbidden: Forbidden response."
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7593,6 +7703,16 @@
               }
             },
             "description": "not_found: Storage location not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [
@@ -7699,6 +7819,16 @@
               }
             },
             "description": "not_found: Storage location not found"
+          },
+          "500": {
+            "content": {
+              "application/vnd.goa.error": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "internal_error: Internal Server Error response."
           }
         },
         "security": [

--- a/internal/api/gen/http/openapi3.yaml
+++ b/internal/api/gen/http/openapi3.yaml
@@ -686,6 +686,12 @@ paths:
                                 example: abc123
                                 type: string
                     description: 'forbidden: Forbidden response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_sips ingest
@@ -818,12 +824,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/SIPNotFound'
                     description: 'not_found: SIP not found'
-                "409":
+                "500":
                     content:
                         application/vnd.goa.error:
                             schema:
                                 $ref: '#/components/schemas/Error'
-                    description: 'not_available: Conflict response.'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: show_sip ingest
@@ -897,6 +903,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'not_available: Conflict response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: confirm_sip ingest
@@ -1275,6 +1287,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'not_available: Conflict response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: reject_sip ingest
@@ -1348,6 +1366,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/SIPNotFound'
                     description: 'not_found: SIP not found'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_sip_workflows ingest
@@ -1408,7 +1432,7 @@ paths:
                         application/vnd.goa.error:
                             schema:
                                 $ref: '#/components/schemas/Error'
-                    description: 'internal_error: Fault while processing upload.'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: upload_sip ingest
@@ -1500,6 +1524,12 @@ paths:
                                 example: abc123
                                 type: string
                     description: 'forbidden: Forbidden response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_users ingest
@@ -1615,12 +1645,12 @@ paths:
                                 example: abc123
                                 type: string
                     description: 'forbidden: Forbidden response.'
-                "409":
+                "500":
                     content:
                         application/vnd.goa.error:
                             schema:
                                 $ref: '#/components/schemas/Error'
-                    description: 'not_available: Conflict response.'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_aips storage
@@ -1683,6 +1713,12 @@ paths:
                                 example: abc123
                                 type: string
                     description: 'forbidden: Forbidden response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: create_aip storage
@@ -1747,6 +1783,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/AIPNotFound'
                     description: 'not_found: AIP not found'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: show_aip storage
@@ -2408,12 +2450,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/AIPNotFound'
                     description: 'not_found: AIP not found'
-                "409":
+                "500":
                     content:
                         application/vnd.goa.error:
                             schema:
                                 $ref: '#/components/schemas/Error'
-                    description: 'not_available: Conflict response.'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: reject_aip storage
@@ -2478,6 +2520,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'failed_dependency: Failed Dependency response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: move_aip_status storage
@@ -2544,12 +2592,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/AIPNotFound'
                     description: 'not_found: AIP not found'
-                "409":
+                "500":
                     content:
                         application/vnd.goa.error:
                             schema:
                                 $ref: '#/components/schemas/Error'
-                    description: 'not_available: Conflict response.'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: move_aip storage
@@ -2650,6 +2698,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/AIPNotFound'
                     description: 'not_found: AIP not found'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_aip_workflows storage
@@ -2693,6 +2747,12 @@ paths:
                                 example: abc123
                                 type: string
                     description: 'forbidden: Forbidden response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_locations storage
@@ -2759,6 +2819,12 @@ paths:
                                 example: abc123
                                 type: string
                     description: 'forbidden: Forbidden response.'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: create_location storage
@@ -2833,6 +2899,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/LocationNotFound'
                     description: 'not_found: Storage location not found'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: show_location storage
@@ -2903,6 +2975,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/LocationNotFound'
                     description: 'not_found: Storage location not found'
+                "500":
+                    content:
+                        application/vnd.goa.error:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'internal_error: Internal Server Error response.'
             security:
                 - bearer_header_Authorization: []
             summary: list_location_aips storage

--- a/internal/api/gen/http/storage/client/encode_decode.go
+++ b/internal/api/gen/http/storage/client/encode_decode.go
@@ -197,8 +197,8 @@ func EncodeListAipsRequest(encoder func(*http.Request) goahttp.Encoder) func(*ht
 // storage list_aips endpoint. restoreBody controls whether the response body
 // should be restored after having been read.
 // DecodeListAipsResponse may return the following errors:
-//   - "not_available" (type *goa.ServiceError): http.StatusConflict
 //   - "not_valid" (type *goa.ServiceError): http.StatusBadRequest
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "forbidden" (type storage.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type storage.Unauthorized): http.StatusUnauthorized
 //   - error: internal error
@@ -234,20 +234,6 @@ func DecodeListAipsResponse(decoder func(*http.Response) goahttp.Decoder, restor
 			}
 			res := storage.NewAIPs(vres)
 			return res, nil
-		case http.StatusConflict:
-			var (
-				body ListAipsNotAvailableResponseBody
-				err  error
-			)
-			err = decoder(resp).Decode(&body)
-			if err != nil {
-				return nil, goahttp.ErrDecodingError("storage", "list_aips", err)
-			}
-			err = ValidateListAipsNotAvailableResponseBody(&body)
-			if err != nil {
-				return nil, goahttp.ErrValidationError("storage", "list_aips", err)
-			}
-			return nil, NewListAipsNotAvailable(&body)
 		case http.StatusBadRequest:
 			var (
 				body ListAipsNotValidResponseBody
@@ -262,6 +248,20 @@ func DecodeListAipsResponse(decoder func(*http.Response) goahttp.Decoder, restor
 				return nil, goahttp.ErrValidationError("storage", "list_aips", err)
 			}
 			return nil, NewListAipsNotValid(&body)
+		case http.StatusInternalServerError:
+			var (
+				body ListAipsInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("storage", "list_aips", err)
+			}
+			err = ValidateListAipsInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("storage", "list_aips", err)
+			}
+			return nil, NewListAipsInternalError(&body)
 		case http.StatusForbidden:
 			var (
 				body string
@@ -333,6 +333,7 @@ func EncodeCreateAipRequest(encoder func(*http.Request) goahttp.Encoder) func(*h
 // should be restored after having been read.
 // DecodeCreateAipResponse may return the following errors:
 //   - "not_valid" (type *goa.ServiceError): http.StatusBadRequest
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "forbidden" (type storage.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type storage.Unauthorized): http.StatusUnauthorized
 //   - error: internal error
@@ -382,6 +383,20 @@ func DecodeCreateAipResponse(decoder func(*http.Response) goahttp.Decoder, resto
 				return nil, goahttp.ErrValidationError("storage", "create_aip", err)
 			}
 			return nil, NewCreateAipNotValid(&body)
+		case http.StatusInternalServerError:
+			var (
+				body CreateAipInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("storage", "create_aip", err)
+			}
+			err = ValidateCreateAipInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("storage", "create_aip", err)
+			}
+			return nil, NewCreateAipInternalError(&body)
 		case http.StatusForbidden:
 			var (
 				body string
@@ -789,8 +804,8 @@ func EncodeMoveAipRequest(encoder func(*http.Request) goahttp.Encoder) func(*htt
 // storage move_aip endpoint. restoreBody controls whether the response body
 // should be restored after having been read.
 // DecodeMoveAipResponse may return the following errors:
-//   - "not_available" (type *goa.ServiceError): http.StatusConflict
 //   - "not_valid" (type *goa.ServiceError): http.StatusBadRequest
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *storage.AIPNotFound): http.StatusNotFound
 //   - "forbidden" (type storage.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type storage.Unauthorized): http.StatusUnauthorized
@@ -812,20 +827,6 @@ func DecodeMoveAipResponse(decoder func(*http.Response) goahttp.Decoder, restore
 		switch resp.StatusCode {
 		case http.StatusAccepted:
 			return nil, nil
-		case http.StatusConflict:
-			var (
-				body MoveAipNotAvailableResponseBody
-				err  error
-			)
-			err = decoder(resp).Decode(&body)
-			if err != nil {
-				return nil, goahttp.ErrDecodingError("storage", "move_aip", err)
-			}
-			err = ValidateMoveAipNotAvailableResponseBody(&body)
-			if err != nil {
-				return nil, goahttp.ErrValidationError("storage", "move_aip", err)
-			}
-			return nil, NewMoveAipNotAvailable(&body)
 		case http.StatusBadRequest:
 			var (
 				body MoveAipNotValidResponseBody
@@ -840,6 +841,20 @@ func DecodeMoveAipResponse(decoder func(*http.Response) goahttp.Decoder, restore
 				return nil, goahttp.ErrValidationError("storage", "move_aip", err)
 			}
 			return nil, NewMoveAipNotValid(&body)
+		case http.StatusInternalServerError:
+			var (
+				body MoveAipInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("storage", "move_aip", err)
+			}
+			err = ValidateMoveAipInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("storage", "move_aip", err)
+			}
+			return nil, NewMoveAipInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body MoveAipNotFoundResponseBody
@@ -931,6 +946,7 @@ func EncodeMoveAipStatusRequest(encoder func(*http.Request) goahttp.Encoder) fun
 // body should be restored after having been read.
 // DecodeMoveAipStatusResponse may return the following errors:
 //   - "failed_dependency" (type *goa.ServiceError): http.StatusFailedDependency
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *storage.AIPNotFound): http.StatusNotFound
 //   - "forbidden" (type storage.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type storage.Unauthorized): http.StatusUnauthorized
@@ -979,6 +995,20 @@ func DecodeMoveAipStatusResponse(decoder func(*http.Response) goahttp.Decoder, r
 				return nil, goahttp.ErrValidationError("storage", "move_aip_status", err)
 			}
 			return nil, NewMoveAipStatusFailedDependency(&body)
+		case http.StatusInternalServerError:
+			var (
+				body MoveAipStatusInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("storage", "move_aip_status", err)
+			}
+			err = ValidateMoveAipStatusInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("storage", "move_aip_status", err)
+			}
+			return nil, NewMoveAipStatusInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body MoveAipStatusNotFoundResponseBody
@@ -1069,8 +1099,8 @@ func EncodeRejectAipRequest(encoder func(*http.Request) goahttp.Encoder) func(*h
 // storage reject_aip endpoint. restoreBody controls whether the response body
 // should be restored after having been read.
 // DecodeRejectAipResponse may return the following errors:
-//   - "not_available" (type *goa.ServiceError): http.StatusConflict
 //   - "not_valid" (type *goa.ServiceError): http.StatusBadRequest
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *storage.AIPNotFound): http.StatusNotFound
 //   - "forbidden" (type storage.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type storage.Unauthorized): http.StatusUnauthorized
@@ -1092,20 +1122,6 @@ func DecodeRejectAipResponse(decoder func(*http.Response) goahttp.Decoder, resto
 		switch resp.StatusCode {
 		case http.StatusAccepted:
 			return nil, nil
-		case http.StatusConflict:
-			var (
-				body RejectAipNotAvailableResponseBody
-				err  error
-			)
-			err = decoder(resp).Decode(&body)
-			if err != nil {
-				return nil, goahttp.ErrDecodingError("storage", "reject_aip", err)
-			}
-			err = ValidateRejectAipNotAvailableResponseBody(&body)
-			if err != nil {
-				return nil, goahttp.ErrValidationError("storage", "reject_aip", err)
-			}
-			return nil, NewRejectAipNotAvailable(&body)
 		case http.StatusBadRequest:
 			var (
 				body RejectAipNotValidResponseBody
@@ -1120,6 +1136,20 @@ func DecodeRejectAipResponse(decoder func(*http.Response) goahttp.Decoder, resto
 				return nil, goahttp.ErrValidationError("storage", "reject_aip", err)
 			}
 			return nil, NewRejectAipNotValid(&body)
+		case http.StatusInternalServerError:
+			var (
+				body RejectAipInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("storage", "reject_aip", err)
+			}
+			err = ValidateRejectAipInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("storage", "reject_aip", err)
+			}
+			return nil, NewRejectAipInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body RejectAipNotFoundResponseBody
@@ -1210,6 +1240,7 @@ func EncodeShowAipRequest(encoder func(*http.Request) goahttp.Encoder) func(*htt
 // storage show_aip endpoint. restoreBody controls whether the response body
 // should be restored after having been read.
 // DecodeShowAipResponse may return the following errors:
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *storage.AIPNotFound): http.StatusNotFound
 //   - "forbidden" (type storage.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type storage.Unauthorized): http.StatusUnauthorized
@@ -1246,6 +1277,20 @@ func DecodeShowAipResponse(decoder func(*http.Response) goahttp.Decoder, restore
 			}
 			res := storage.NewAIP(vres)
 			return res, nil
+		case http.StatusInternalServerError:
+			var (
+				body ShowAipInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("storage", "show_aip", err)
+			}
+			err = ValidateShowAipInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("storage", "show_aip", err)
+			}
+			return nil, NewShowAipInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body ShowAipNotFoundResponseBody
@@ -1344,6 +1389,7 @@ func EncodeListAipWorkflowsRequest(encoder func(*http.Request) goahttp.Encoder) 
 // the storage list_aip_workflows endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
 // DecodeListAipWorkflowsResponse may return the following errors:
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *storage.AIPNotFound): http.StatusNotFound
 //   - "forbidden" (type storage.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type storage.Unauthorized): http.StatusUnauthorized
@@ -1380,6 +1426,20 @@ func DecodeListAipWorkflowsResponse(decoder func(*http.Response) goahttp.Decoder
 			}
 			res := storage.NewAIPWorkflows(vres)
 			return res, nil
+		case http.StatusInternalServerError:
+			var (
+				body ListAipWorkflowsInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("storage", "list_aip_workflows", err)
+			}
+			err = ValidateListAipWorkflowsInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("storage", "list_aip_workflows", err)
+			}
+			return nil, NewListAipWorkflowsInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body ListAipWorkflowsNotFoundResponseBody
@@ -2368,6 +2428,7 @@ func EncodeListLocationsRequest(encoder func(*http.Request) goahttp.Encoder) fun
 // storage list_locations endpoint. restoreBody controls whether the response
 // body should be restored after having been read.
 // DecodeListLocationsResponse may return the following errors:
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "forbidden" (type storage.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type storage.Unauthorized): http.StatusUnauthorized
 //   - error: internal error
@@ -2403,6 +2464,20 @@ func DecodeListLocationsResponse(decoder func(*http.Response) goahttp.Decoder, r
 			}
 			res := storage.NewLocationCollection(vres)
 			return res, nil
+		case http.StatusInternalServerError:
+			var (
+				body ListLocationsInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("storage", "list_locations", err)
+			}
+			err = ValidateListLocationsInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("storage", "list_locations", err)
+			}
+			return nil, NewListLocationsInternalError(&body)
 		case http.StatusForbidden:
 			var (
 				body string
@@ -2474,6 +2549,7 @@ func EncodeCreateLocationRequest(encoder func(*http.Request) goahttp.Encoder) fu
 // body should be restored after having been read.
 // DecodeCreateLocationResponse may return the following errors:
 //   - "not_valid" (type *goa.ServiceError): http.StatusBadRequest
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "forbidden" (type storage.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type storage.Unauthorized): http.StatusUnauthorized
 //   - error: internal error
@@ -2521,6 +2597,20 @@ func DecodeCreateLocationResponse(decoder func(*http.Response) goahttp.Decoder, 
 				return nil, goahttp.ErrValidationError("storage", "create_location", err)
 			}
 			return nil, NewCreateLocationNotValid(&body)
+		case http.StatusInternalServerError:
+			var (
+				body CreateLocationInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("storage", "create_location", err)
+			}
+			err = ValidateCreateLocationInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("storage", "create_location", err)
+			}
+			return nil, NewCreateLocationInternalError(&body)
 		case http.StatusForbidden:
 			var (
 				body string
@@ -2597,6 +2687,7 @@ func EncodeShowLocationRequest(encoder func(*http.Request) goahttp.Encoder) func
 // storage show_location endpoint. restoreBody controls whether the response
 // body should be restored after having been read.
 // DecodeShowLocationResponse may return the following errors:
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *storage.LocationNotFound): http.StatusNotFound
 //   - "forbidden" (type storage.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type storage.Unauthorized): http.StatusUnauthorized
@@ -2633,6 +2724,20 @@ func DecodeShowLocationResponse(decoder func(*http.Response) goahttp.Decoder, re
 			}
 			res := storage.NewLocation(vres)
 			return res, nil
+		case http.StatusInternalServerError:
+			var (
+				body ShowLocationInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("storage", "show_location", err)
+			}
+			err = ValidateShowLocationInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("storage", "show_location", err)
+			}
+			return nil, NewShowLocationInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body ShowLocationNotFoundResponseBody
@@ -2724,6 +2829,7 @@ func EncodeListLocationAipsRequest(encoder func(*http.Request) goahttp.Encoder) 
 // response body should be restored after having been read.
 // DecodeListLocationAipsResponse may return the following errors:
 //   - "not_valid" (type *goa.ServiceError): http.StatusBadRequest
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type *storage.LocationNotFound): http.StatusNotFound
 //   - "forbidden" (type storage.Forbidden): http.StatusForbidden
 //   - "unauthorized" (type storage.Unauthorized): http.StatusUnauthorized
@@ -2774,6 +2880,20 @@ func DecodeListLocationAipsResponse(decoder func(*http.Response) goahttp.Decoder
 				return nil, goahttp.ErrValidationError("storage", "list_location_aips", err)
 			}
 			return nil, NewListLocationAipsNotValid(&body)
+		case http.StatusInternalServerError:
+			var (
+				body ListLocationAipsInternalErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("storage", "list_location_aips", err)
+			}
+			err = ValidateListLocationAipsInternalErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("storage", "list_location_aips", err)
+			}
+			return nil, NewListLocationAipsInternalError(&body)
 		case http.StatusNotFound:
 			var (
 				body ListLocationAipsNotFoundResponseBody

--- a/internal/api/gen/http/storage/client/types.go
+++ b/internal/api/gen/http/storage/client/types.go
@@ -184,24 +184,6 @@ type MonitorInternalErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
-// ListAipsNotAvailableResponseBody is the type of the "storage" service
-// "list_aips" endpoint HTTP response body for the "not_available" error.
-type ListAipsNotAvailableResponseBody struct {
-	// Name is the name of this class of errors.
-	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
-	// ID is a unique identifier for this particular occurrence of the problem.
-	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
-	// Message is a human-readable explanation specific to this occurrence of the
-	// problem.
-	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
-	// Is the error temporary?
-	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
-	// Is the error a timeout?
-	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
-	// Is the error a server-side fault?
-	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
-}
-
 // ListAipsNotValidResponseBody is the type of the "storage" service
 // "list_aips" endpoint HTTP response body for the "not_valid" error.
 type ListAipsNotValidResponseBody struct {
@@ -220,9 +202,45 @@ type ListAipsNotValidResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// ListAipsInternalErrorResponseBody is the type of the "storage" service
+// "list_aips" endpoint HTTP response body for the "internal_error" error.
+type ListAipsInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // CreateAipNotValidResponseBody is the type of the "storage" service
 // "create_aip" endpoint HTTP response body for the "not_valid" error.
 type CreateAipNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// CreateAipInternalErrorResponseBody is the type of the "storage" service
+// "create_aip" endpoint HTTP response body for the "internal_error" error.
+type CreateAipInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -329,9 +347,9 @@ type DownloadAipNotFoundResponseBody struct {
 	UUID *uuid.UUID `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
 }
 
-// MoveAipNotAvailableResponseBody is the type of the "storage" service
-// "move_aip" endpoint HTTP response body for the "not_available" error.
-type MoveAipNotAvailableResponseBody struct {
+// MoveAipNotValidResponseBody is the type of the "storage" service "move_aip"
+// endpoint HTTP response body for the "not_valid" error.
+type MoveAipNotValidResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -347,9 +365,9 @@ type MoveAipNotAvailableResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
-// MoveAipNotValidResponseBody is the type of the "storage" service "move_aip"
-// endpoint HTTP response body for the "not_valid" error.
-type MoveAipNotValidResponseBody struct {
+// MoveAipInternalErrorResponseBody is the type of the "storage" service
+// "move_aip" endpoint HTTP response body for the "internal_error" error.
+type MoveAipInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -393,18 +411,9 @@ type MoveAipStatusFailedDependencyResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
-// MoveAipStatusNotFoundResponseBody is the type of the "storage" service
-// "move_aip_status" endpoint HTTP response body for the "not_found" error.
-type MoveAipStatusNotFoundResponseBody struct {
-	// Message of error
-	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
-	// Identifier of missing AIP
-	UUID *uuid.UUID `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
-}
-
-// RejectAipNotAvailableResponseBody is the type of the "storage" service
-// "reject_aip" endpoint HTTP response body for the "not_available" error.
-type RejectAipNotAvailableResponseBody struct {
+// MoveAipStatusInternalErrorResponseBody is the type of the "storage" service
+// "move_aip_status" endpoint HTTP response body for the "internal_error" error.
+type MoveAipStatusInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -420,9 +429,36 @@ type RejectAipNotAvailableResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// MoveAipStatusNotFoundResponseBody is the type of the "storage" service
+// "move_aip_status" endpoint HTTP response body for the "not_found" error.
+type MoveAipStatusNotFoundResponseBody struct {
+	// Message of error
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Identifier of missing AIP
+	UUID *uuid.UUID `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
+}
+
 // RejectAipNotValidResponseBody is the type of the "storage" service
 // "reject_aip" endpoint HTTP response body for the "not_valid" error.
 type RejectAipNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// RejectAipInternalErrorResponseBody is the type of the "storage" service
+// "reject_aip" endpoint HTTP response body for the "internal_error" error.
+type RejectAipInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -447,6 +483,24 @@ type RejectAipNotFoundResponseBody struct {
 	UUID *uuid.UUID `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
 }
 
+// ShowAipInternalErrorResponseBody is the type of the "storage" service
+// "show_aip" endpoint HTTP response body for the "internal_error" error.
+type ShowAipInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // ShowAipNotFoundResponseBody is the type of the "storage" service "show_aip"
 // endpoint HTTP response body for the "not_found" error.
 type ShowAipNotFoundResponseBody struct {
@@ -454,6 +508,25 @@ type ShowAipNotFoundResponseBody struct {
 	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
 	// Identifier of missing AIP
 	UUID *uuid.UUID `form:"uuid,omitempty" json:"uuid,omitempty" xml:"uuid,omitempty"`
+}
+
+// ListAipWorkflowsInternalErrorResponseBody is the type of the "storage"
+// service "list_aip_workflows" endpoint HTTP response body for the
+// "internal_error" error.
+type ListAipWorkflowsInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
 // ListAipWorkflowsNotFoundResponseBody is the type of the "storage" service
@@ -761,9 +834,63 @@ type AipDeletionReportInternalErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// ListLocationsInternalErrorResponseBody is the type of the "storage" service
+// "list_locations" endpoint HTTP response body for the "internal_error" error.
+type ListLocationsInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // CreateLocationNotValidResponseBody is the type of the "storage" service
 // "create_location" endpoint HTTP response body for the "not_valid" error.
 type CreateLocationNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// CreateLocationInternalErrorResponseBody is the type of the "storage" service
+// "create_location" endpoint HTTP response body for the "internal_error" error.
+type CreateLocationInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ShowLocationInternalErrorResponseBody is the type of the "storage" service
+// "show_location" endpoint HTTP response body for the "internal_error" error.
+type ShowLocationInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -790,6 +917,25 @@ type ShowLocationNotFoundResponseBody struct {
 // ListLocationAipsNotValidResponseBody is the type of the "storage" service
 // "list_location_aips" endpoint HTTP response body for the "not_valid" error.
 type ListLocationAipsNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ListLocationAipsInternalErrorResponseBody is the type of the "storage"
+// service "list_location_aips" endpoint HTTP response body for the
+// "internal_error" error.
+type ListLocationAipsInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -2272,9 +2418,9 @@ func NewListAipsAIPsOK(body *ListAipsResponseBody) *storageviews.AIPsView {
 	return v
 }
 
-// NewListAipsNotAvailable builds a storage service list_aips endpoint
-// not_available error.
-func NewListAipsNotAvailable(body *ListAipsNotAvailableResponseBody) *goa.ServiceError {
+// NewListAipsNotValid builds a storage service list_aips endpoint not_valid
+// error.
+func NewListAipsNotValid(body *ListAipsNotValidResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -2287,9 +2433,9 @@ func NewListAipsNotAvailable(body *ListAipsNotAvailableResponseBody) *goa.Servic
 	return v
 }
 
-// NewListAipsNotValid builds a storage service list_aips endpoint not_valid
-// error.
-func NewListAipsNotValid(body *ListAipsNotValidResponseBody) *goa.ServiceError {
+// NewListAipsInternalError builds a storage service list_aips endpoint
+// internal_error error.
+func NewListAipsInternalError(body *ListAipsInternalErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -2337,6 +2483,21 @@ func NewCreateAipAIPOK(body *CreateAipResponseBody) *storageviews.AIPView {
 // NewCreateAipNotValid builds a storage service create_aip endpoint not_valid
 // error.
 func NewCreateAipNotValid(body *CreateAipNotValidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewCreateAipInternalError builds a storage service create_aip endpoint
+// internal_error error.
+func NewCreateAipInternalError(body *CreateAipInternalErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -2499,9 +2660,9 @@ func NewDownloadAipUnauthorized(body string) storage.Unauthorized {
 	return v
 }
 
-// NewMoveAipNotAvailable builds a storage service move_aip endpoint
-// not_available error.
-func NewMoveAipNotAvailable(body *MoveAipNotAvailableResponseBody) *goa.ServiceError {
+// NewMoveAipNotValid builds a storage service move_aip endpoint not_valid
+// error.
+func NewMoveAipNotValid(body *MoveAipNotValidResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -2514,9 +2675,9 @@ func NewMoveAipNotAvailable(body *MoveAipNotAvailableResponseBody) *goa.ServiceE
 	return v
 }
 
-// NewMoveAipNotValid builds a storage service move_aip endpoint not_valid
-// error.
-func NewMoveAipNotValid(body *MoveAipNotValidResponseBody) *goa.ServiceError {
+// NewMoveAipInternalError builds a storage service move_aip endpoint
+// internal_error error.
+func NewMoveAipInternalError(body *MoveAipInternalErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -2581,6 +2742,21 @@ func NewMoveAipStatusFailedDependency(body *MoveAipStatusFailedDependencyRespons
 	return v
 }
 
+// NewMoveAipStatusInternalError builds a storage service move_aip_status
+// endpoint internal_error error.
+func NewMoveAipStatusInternalError(body *MoveAipStatusInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // NewMoveAipStatusNotFound builds a storage service move_aip_status endpoint
 // not_found error.
 func NewMoveAipStatusNotFound(body *MoveAipStatusNotFoundResponseBody) *storage.AIPNotFound {
@@ -2608,9 +2784,9 @@ func NewMoveAipStatusUnauthorized(body string) storage.Unauthorized {
 	return v
 }
 
-// NewRejectAipNotAvailable builds a storage service reject_aip endpoint
-// not_available error.
-func NewRejectAipNotAvailable(body *RejectAipNotAvailableResponseBody) *goa.ServiceError {
+// NewRejectAipNotValid builds a storage service reject_aip endpoint not_valid
+// error.
+func NewRejectAipNotValid(body *RejectAipNotValidResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -2623,9 +2799,9 @@ func NewRejectAipNotAvailable(body *RejectAipNotAvailableResponseBody) *goa.Serv
 	return v
 }
 
-// NewRejectAipNotValid builds a storage service reject_aip endpoint not_valid
-// error.
-func NewRejectAipNotValid(body *RejectAipNotValidResponseBody) *goa.ServiceError {
+// NewRejectAipInternalError builds a storage service reject_aip endpoint
+// internal_error error.
+func NewRejectAipInternalError(body *RejectAipInternalErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -2681,6 +2857,21 @@ func NewShowAipAIPOK(body *ShowAipResponseBody) *storageviews.AIPView {
 	return v
 }
 
+// NewShowAipInternalError builds a storage service show_aip endpoint
+// internal_error error.
+func NewShowAipInternalError(body *ShowAipInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // NewShowAipNotFound builds a storage service show_aip endpoint not_found
 // error.
 func NewShowAipNotFound(body *ShowAipNotFoundResponseBody) *storage.AIPNotFound {
@@ -2721,6 +2912,21 @@ func NewListAipWorkflowsAIPWorkflowsOK(body *ListAipWorkflowsResponseBody) *stor
 			}
 			v.Workflows[i] = unmarshalAIPWorkflowResponseBodyToStorageviewsAIPWorkflowView(val)
 		}
+	}
+
+	return v
+}
+
+// NewListAipWorkflowsInternalError builds a storage service list_aip_workflows
+// endpoint internal_error error.
+func NewListAipWorkflowsInternalError(body *ListAipWorkflowsInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
 	}
 
 	return v
@@ -3138,6 +3344,21 @@ func NewListLocationsLocationCollectionOK(body LocationResponseCollection) stora
 	return v
 }
 
+// NewListLocationsInternalError builds a storage service list_locations
+// endpoint internal_error error.
+func NewListLocationsInternalError(body *ListLocationsInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // NewListLocationsForbidden builds a storage service list_locations endpoint
 // forbidden error.
 func NewListLocationsForbidden(body string) storage.Forbidden {
@@ -3179,6 +3400,21 @@ func NewCreateLocationNotValid(body *CreateLocationNotValidResponseBody) *goa.Se
 	return v
 }
 
+// NewCreateLocationInternalError builds a storage service create_location
+// endpoint internal_error error.
+func NewCreateLocationInternalError(body *CreateLocationInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // NewCreateLocationForbidden builds a storage service create_location endpoint
 // forbidden error.
 func NewCreateLocationForbidden(body string) storage.Forbidden {
@@ -3205,6 +3441,21 @@ func NewShowLocationLocationOK(body *ShowLocationResponseBody) *storageviews.Loc
 		Purpose:     body.Purpose,
 		UUID:        body.UUID,
 		CreatedAt:   body.CreatedAt,
+	}
+
+	return v
+}
+
+// NewShowLocationInternalError builds a storage service show_location endpoint
+// internal_error error.
+func NewShowLocationInternalError(body *ShowLocationInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
 	}
 
 	return v
@@ -3255,6 +3506,21 @@ func NewListLocationAipsAIPCollectionOK(body AIPResponseCollection) storageviews
 // NewListLocationAipsNotValid builds a storage service list_location_aips
 // endpoint not_valid error.
 func NewListLocationAipsNotValid(body *ListLocationAipsNotValidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewListLocationAipsInternalError builds a storage service list_location_aips
+// endpoint internal_error error.
+func NewListLocationAipsInternalError(body *ListLocationAipsInternalErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -3410,30 +3676,6 @@ func ValidateMonitorInternalErrorResponseBody(body *MonitorInternalErrorResponse
 	return
 }
 
-// ValidateListAipsNotAvailableResponseBody runs the validations defined on
-// list_aips_not_available_response_body
-func ValidateListAipsNotAvailableResponseBody(body *ListAipsNotAvailableResponseBody) (err error) {
-	if body.Name == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
-	}
-	if body.ID == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
-	}
-	if body.Message == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
-	}
-	if body.Temporary == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
-	}
-	if body.Timeout == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
-	}
-	if body.Fault == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
-	}
-	return
-}
-
 // ValidateListAipsNotValidResponseBody runs the validations defined on
 // list_aips_not_valid_response_body
 func ValidateListAipsNotValidResponseBody(body *ListAipsNotValidResponseBody) (err error) {
@@ -3458,9 +3700,57 @@ func ValidateListAipsNotValidResponseBody(body *ListAipsNotValidResponseBody) (e
 	return
 }
 
+// ValidateListAipsInternalErrorResponseBody runs the validations defined on
+// list_aips_internal_error_response_body
+func ValidateListAipsInternalErrorResponseBody(body *ListAipsInternalErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
 // ValidateCreateAipNotValidResponseBody runs the validations defined on
 // create_aip_not_valid_response_body
 func ValidateCreateAipNotValidResponseBody(body *CreateAipNotValidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateCreateAipInternalErrorResponseBody runs the validations defined on
+// create_aip_internal_error_response_body
+func ValidateCreateAipInternalErrorResponseBody(body *CreateAipInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -3602,9 +3892,9 @@ func ValidateDownloadAipNotFoundResponseBody(body *DownloadAipNotFoundResponseBo
 	return
 }
 
-// ValidateMoveAipNotAvailableResponseBody runs the validations defined on
-// move_aip_not_available_response_body
-func ValidateMoveAipNotAvailableResponseBody(body *MoveAipNotAvailableResponseBody) (err error) {
+// ValidateMoveAipNotValidResponseBody runs the validations defined on
+// move_aip_not_valid_response_body
+func ValidateMoveAipNotValidResponseBody(body *MoveAipNotValidResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -3626,9 +3916,9 @@ func ValidateMoveAipNotAvailableResponseBody(body *MoveAipNotAvailableResponseBo
 	return
 }
 
-// ValidateMoveAipNotValidResponseBody runs the validations defined on
-// move_aip_not_valid_response_body
-func ValidateMoveAipNotValidResponseBody(body *MoveAipNotValidResponseBody) (err error) {
+// ValidateMoveAipInternalErrorResponseBody runs the validations defined on
+// move_aip_internal_error_response_body
+func ValidateMoveAipInternalErrorResponseBody(body *MoveAipInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -3686,21 +3976,9 @@ func ValidateMoveAipStatusFailedDependencyResponseBody(body *MoveAipStatusFailed
 	return
 }
 
-// ValidateMoveAipStatusNotFoundResponseBody runs the validations defined on
-// move_aip_status_not_found_response_body
-func ValidateMoveAipStatusNotFoundResponseBody(body *MoveAipStatusNotFoundResponseBody) (err error) {
-	if body.Message == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
-	}
-	if body.UUID == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "body"))
-	}
-	return
-}
-
-// ValidateRejectAipNotAvailableResponseBody runs the validations defined on
-// reject_aip_not_available_response_body
-func ValidateRejectAipNotAvailableResponseBody(body *RejectAipNotAvailableResponseBody) (err error) {
+// ValidateMoveAipStatusInternalErrorResponseBody runs the validations defined
+// on move_aip_status_internal_error_response_body
+func ValidateMoveAipStatusInternalErrorResponseBody(body *MoveAipStatusInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -3722,9 +4000,45 @@ func ValidateRejectAipNotAvailableResponseBody(body *RejectAipNotAvailableRespon
 	return
 }
 
+// ValidateMoveAipStatusNotFoundResponseBody runs the validations defined on
+// move_aip_status_not_found_response_body
+func ValidateMoveAipStatusNotFoundResponseBody(body *MoveAipStatusNotFoundResponseBody) (err error) {
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.UUID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "body"))
+	}
+	return
+}
+
 // ValidateRejectAipNotValidResponseBody runs the validations defined on
 // reject_aip_not_valid_response_body
 func ValidateRejectAipNotValidResponseBody(body *RejectAipNotValidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateRejectAipInternalErrorResponseBody runs the validations defined on
+// reject_aip_internal_error_response_body
+func ValidateRejectAipInternalErrorResponseBody(body *RejectAipInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -3758,6 +4072,30 @@ func ValidateRejectAipNotFoundResponseBody(body *RejectAipNotFoundResponseBody) 
 	return
 }
 
+// ValidateShowAipInternalErrorResponseBody runs the validations defined on
+// show_aip_internal_error_response_body
+func ValidateShowAipInternalErrorResponseBody(body *ShowAipInternalErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
 // ValidateShowAipNotFoundResponseBody runs the validations defined on
 // show_aip_not_found_response_body
 func ValidateShowAipNotFoundResponseBody(body *ShowAipNotFoundResponseBody) (err error) {
@@ -3766,6 +4104,30 @@ func ValidateShowAipNotFoundResponseBody(body *ShowAipNotFoundResponseBody) (err
 	}
 	if body.UUID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("uuid", "body"))
+	}
+	return
+}
+
+// ValidateListAipWorkflowsInternalErrorResponseBody runs the validations
+// defined on list_aip_workflows_internal_error_response_body
+func ValidateListAipWorkflowsInternalErrorResponseBody(body *ListAipWorkflowsInternalErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
 	}
 	return
 }
@@ -4167,9 +4529,81 @@ func ValidateAipDeletionReportInternalErrorResponseBody(body *AipDeletionReportI
 	return
 }
 
+// ValidateListLocationsInternalErrorResponseBody runs the validations defined
+// on list_locations_internal_error_response_body
+func ValidateListLocationsInternalErrorResponseBody(body *ListLocationsInternalErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
 // ValidateCreateLocationNotValidResponseBody runs the validations defined on
 // create_location_not_valid_response_body
 func ValidateCreateLocationNotValidResponseBody(body *CreateLocationNotValidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateCreateLocationInternalErrorResponseBody runs the validations defined
+// on create_location_internal_error_response_body
+func ValidateCreateLocationInternalErrorResponseBody(body *CreateLocationInternalErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateShowLocationInternalErrorResponseBody runs the validations defined
+// on show_location_internal_error_response_body
+func ValidateShowLocationInternalErrorResponseBody(body *ShowLocationInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -4206,6 +4640,30 @@ func ValidateShowLocationNotFoundResponseBody(body *ShowLocationNotFoundResponse
 // ValidateListLocationAipsNotValidResponseBody runs the validations defined on
 // list_location_aips_not_valid_response_body
 func ValidateListLocationAipsNotValidResponseBody(body *ListLocationAipsNotValidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateListLocationAipsInternalErrorResponseBody runs the validations
+// defined on list_location_aips_internal_error_response_body
+func ValidateListLocationAipsInternalErrorResponseBody(body *ListLocationAipsInternalErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/internal/api/gen/http/storage/server/encode_decode.go
+++ b/internal/api/gen/http/storage/server/encode_decode.go
@@ -211,19 +211,6 @@ func EncodeListAipsError(encoder func(context.Context, http.ResponseWriter) goah
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "not_available":
-			var res *goa.ServiceError
-			errors.As(v, &res)
-			enc := encoder(ctx, w)
-			var body any
-			if formatter != nil {
-				body = formatter(ctx, res)
-			} else {
-				body = NewListAipsNotAvailableResponseBody(res)
-			}
-			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusConflict)
-			return enc.Encode(body)
 		case "not_valid":
 			var res *goa.ServiceError
 			errors.As(v, &res)
@@ -236,6 +223,19 @@ func EncodeListAipsError(encoder func(context.Context, http.ResponseWriter) goah
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListAipsInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "forbidden":
 			var res storage.Forbidden
@@ -338,6 +338,19 @@ func EncodeCreateAipError(encoder func(context.Context, http.ResponseWriter) goa
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewCreateAipInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "forbidden":
 			var res storage.Forbidden
@@ -678,19 +691,6 @@ func EncodeMoveAipError(encoder func(context.Context, http.ResponseWriter) goaht
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "not_available":
-			var res *goa.ServiceError
-			errors.As(v, &res)
-			enc := encoder(ctx, w)
-			var body any
-			if formatter != nil {
-				body = formatter(ctx, res)
-			} else {
-				body = NewMoveAipNotAvailableResponseBody(res)
-			}
-			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusConflict)
-			return enc.Encode(body)
 		case "not_valid":
 			var res *goa.ServiceError
 			errors.As(v, &res)
@@ -703,6 +703,19 @@ func EncodeMoveAipError(encoder func(context.Context, http.ResponseWriter) goaht
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMoveAipInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "not_found":
 			var res *storage.AIPNotFound
@@ -808,6 +821,19 @@ func EncodeMoveAipStatusError(encoder func(context.Context, http.ResponseWriter)
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusFailedDependency)
 			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMoveAipStatusInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
 		case "not_found":
 			var res *storage.AIPNotFound
 			errors.As(v, &res)
@@ -896,19 +922,6 @@ func EncodeRejectAipError(encoder func(context.Context, http.ResponseWriter) goa
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "not_available":
-			var res *goa.ServiceError
-			errors.As(v, &res)
-			enc := encoder(ctx, w)
-			var body any
-			if formatter != nil {
-				body = formatter(ctx, res)
-			} else {
-				body = NewRejectAipNotAvailableResponseBody(res)
-			}
-			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusConflict)
-			return enc.Encode(body)
 		case "not_valid":
 			var res *goa.ServiceError
 			errors.As(v, &res)
@@ -921,6 +934,19 @@ func EncodeRejectAipError(encoder func(context.Context, http.ResponseWriter) goa
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewRejectAipInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "not_found":
 			var res *storage.AIPNotFound
@@ -1013,6 +1039,19 @@ func EncodeShowAipError(encoder func(context.Context, http.ResponseWriter) goaht
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewShowAipInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
 		case "not_found":
 			var res *storage.AIPNotFound
 			errors.As(v, &res)
@@ -1125,6 +1164,19 @@ func EncodeListAipWorkflowsError(encoder func(context.Context, http.ResponseWrit
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListAipWorkflowsInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
 		case "not_found":
 			var res *storage.AIPNotFound
 			errors.As(v, &res)
@@ -1980,6 +2032,19 @@ func EncodeListLocationsError(encoder func(context.Context, http.ResponseWriter)
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListLocationsInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
 		case "forbidden":
 			var res storage.Forbidden
 			errors.As(v, &res)
@@ -2082,6 +2147,19 @@ func EncodeCreateLocationError(encoder func(context.Context, http.ResponseWriter
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewCreateLocationInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
 		case "forbidden":
 			var res storage.Forbidden
 			errors.As(v, &res)
@@ -2160,6 +2238,19 @@ func EncodeShowLocationError(encoder func(context.Context, http.ResponseWriter) 
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewShowLocationInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
 		case "not_found":
 			var res *storage.LocationNotFound
 			errors.As(v, &res)
@@ -2263,6 +2354,19 @@ func EncodeListLocationAipsError(encoder func(context.Context, http.ResponseWrit
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "internal_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListLocationAipsInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "not_found":
 			var res *storage.LocationNotFound

--- a/internal/api/gen/http/storage/server/types.go
+++ b/internal/api/gen/http/storage/server/types.go
@@ -184,24 +184,6 @@ type MonitorInternalErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
-// ListAipsNotAvailableResponseBody is the type of the "storage" service
-// "list_aips" endpoint HTTP response body for the "not_available" error.
-type ListAipsNotAvailableResponseBody struct {
-	// Name is the name of this class of errors.
-	Name string `form:"name" json:"name" xml:"name"`
-	// ID is a unique identifier for this particular occurrence of the problem.
-	ID string `form:"id" json:"id" xml:"id"`
-	// Message is a human-readable explanation specific to this occurrence of the
-	// problem.
-	Message string `form:"message" json:"message" xml:"message"`
-	// Is the error temporary?
-	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
-	// Is the error a timeout?
-	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
-	// Is the error a server-side fault?
-	Fault bool `form:"fault" json:"fault" xml:"fault"`
-}
-
 // ListAipsNotValidResponseBody is the type of the "storage" service
 // "list_aips" endpoint HTTP response body for the "not_valid" error.
 type ListAipsNotValidResponseBody struct {
@@ -220,9 +202,45 @@ type ListAipsNotValidResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// ListAipsInternalErrorResponseBody is the type of the "storage" service
+// "list_aips" endpoint HTTP response body for the "internal_error" error.
+type ListAipsInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // CreateAipNotValidResponseBody is the type of the "storage" service
 // "create_aip" endpoint HTTP response body for the "not_valid" error.
 type CreateAipNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// CreateAipInternalErrorResponseBody is the type of the "storage" service
+// "create_aip" endpoint HTTP response body for the "internal_error" error.
+type CreateAipInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -329,9 +347,9 @@ type DownloadAipNotFoundResponseBody struct {
 	UUID uuid.UUID `form:"uuid" json:"uuid" xml:"uuid"`
 }
 
-// MoveAipNotAvailableResponseBody is the type of the "storage" service
-// "move_aip" endpoint HTTP response body for the "not_available" error.
-type MoveAipNotAvailableResponseBody struct {
+// MoveAipNotValidResponseBody is the type of the "storage" service "move_aip"
+// endpoint HTTP response body for the "not_valid" error.
+type MoveAipNotValidResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -347,9 +365,9 @@ type MoveAipNotAvailableResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
-// MoveAipNotValidResponseBody is the type of the "storage" service "move_aip"
-// endpoint HTTP response body for the "not_valid" error.
-type MoveAipNotValidResponseBody struct {
+// MoveAipInternalErrorResponseBody is the type of the "storage" service
+// "move_aip" endpoint HTTP response body for the "internal_error" error.
+type MoveAipInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -393,18 +411,9 @@ type MoveAipStatusFailedDependencyResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
-// MoveAipStatusNotFoundResponseBody is the type of the "storage" service
-// "move_aip_status" endpoint HTTP response body for the "not_found" error.
-type MoveAipStatusNotFoundResponseBody struct {
-	// Message of error
-	Message string `form:"message" json:"message" xml:"message"`
-	// Identifier of missing AIP
-	UUID uuid.UUID `form:"uuid" json:"uuid" xml:"uuid"`
-}
-
-// RejectAipNotAvailableResponseBody is the type of the "storage" service
-// "reject_aip" endpoint HTTP response body for the "not_available" error.
-type RejectAipNotAvailableResponseBody struct {
+// MoveAipStatusInternalErrorResponseBody is the type of the "storage" service
+// "move_aip_status" endpoint HTTP response body for the "internal_error" error.
+type MoveAipStatusInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -420,9 +429,36 @@ type RejectAipNotAvailableResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// MoveAipStatusNotFoundResponseBody is the type of the "storage" service
+// "move_aip_status" endpoint HTTP response body for the "not_found" error.
+type MoveAipStatusNotFoundResponseBody struct {
+	// Message of error
+	Message string `form:"message" json:"message" xml:"message"`
+	// Identifier of missing AIP
+	UUID uuid.UUID `form:"uuid" json:"uuid" xml:"uuid"`
+}
+
 // RejectAipNotValidResponseBody is the type of the "storage" service
 // "reject_aip" endpoint HTTP response body for the "not_valid" error.
 type RejectAipNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// RejectAipInternalErrorResponseBody is the type of the "storage" service
+// "reject_aip" endpoint HTTP response body for the "internal_error" error.
+type RejectAipInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -447,6 +483,24 @@ type RejectAipNotFoundResponseBody struct {
 	UUID uuid.UUID `form:"uuid" json:"uuid" xml:"uuid"`
 }
 
+// ShowAipInternalErrorResponseBody is the type of the "storage" service
+// "show_aip" endpoint HTTP response body for the "internal_error" error.
+type ShowAipInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // ShowAipNotFoundResponseBody is the type of the "storage" service "show_aip"
 // endpoint HTTP response body for the "not_found" error.
 type ShowAipNotFoundResponseBody struct {
@@ -454,6 +508,25 @@ type ShowAipNotFoundResponseBody struct {
 	Message string `form:"message" json:"message" xml:"message"`
 	// Identifier of missing AIP
 	UUID uuid.UUID `form:"uuid" json:"uuid" xml:"uuid"`
+}
+
+// ListAipWorkflowsInternalErrorResponseBody is the type of the "storage"
+// service "list_aip_workflows" endpoint HTTP response body for the
+// "internal_error" error.
+type ListAipWorkflowsInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
 // ListAipWorkflowsNotFoundResponseBody is the type of the "storage" service
@@ -761,9 +834,63 @@ type AipDeletionReportInternalErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// ListLocationsInternalErrorResponseBody is the type of the "storage" service
+// "list_locations" endpoint HTTP response body for the "internal_error" error.
+type ListLocationsInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // CreateLocationNotValidResponseBody is the type of the "storage" service
 // "create_location" endpoint HTTP response body for the "not_valid" error.
 type CreateLocationNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// CreateLocationInternalErrorResponseBody is the type of the "storage" service
+// "create_location" endpoint HTTP response body for the "internal_error" error.
+type CreateLocationInternalErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ShowLocationInternalErrorResponseBody is the type of the "storage" service
+// "show_location" endpoint HTTP response body for the "internal_error" error.
+type ShowLocationInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -790,6 +917,25 @@ type ShowLocationNotFoundResponseBody struct {
 // ListLocationAipsNotValidResponseBody is the type of the "storage" service
 // "list_location_aips" endpoint HTTP response body for the "not_valid" error.
 type ListLocationAipsNotValidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ListLocationAipsInternalErrorResponseBody is the type of the "storage"
+// service "list_location_aips" endpoint HTTP response body for the
+// "internal_error" error.
+type ListLocationAipsInternalErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -2261,20 +2407,6 @@ func NewMonitorInternalErrorResponseBody(res *goa.ServiceError) *MonitorInternal
 	return body
 }
 
-// NewListAipsNotAvailableResponseBody builds the HTTP response body from the
-// result of the "list_aips" endpoint of the "storage" service.
-func NewListAipsNotAvailableResponseBody(res *goa.ServiceError) *ListAipsNotAvailableResponseBody {
-	body := &ListAipsNotAvailableResponseBody{
-		Name:      res.Name,
-		ID:        res.ID,
-		Message:   res.Message,
-		Temporary: res.Temporary,
-		Timeout:   res.Timeout,
-		Fault:     res.Fault,
-	}
-	return body
-}
-
 // NewListAipsNotValidResponseBody builds the HTTP response body from the
 // result of the "list_aips" endpoint of the "storage" service.
 func NewListAipsNotValidResponseBody(res *goa.ServiceError) *ListAipsNotValidResponseBody {
@@ -2289,10 +2421,38 @@ func NewListAipsNotValidResponseBody(res *goa.ServiceError) *ListAipsNotValidRes
 	return body
 }
 
+// NewListAipsInternalErrorResponseBody builds the HTTP response body from the
+// result of the "list_aips" endpoint of the "storage" service.
+func NewListAipsInternalErrorResponseBody(res *goa.ServiceError) *ListAipsInternalErrorResponseBody {
+	body := &ListAipsInternalErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
 // NewCreateAipNotValidResponseBody builds the HTTP response body from the
 // result of the "create_aip" endpoint of the "storage" service.
 func NewCreateAipNotValidResponseBody(res *goa.ServiceError) *CreateAipNotValidResponseBody {
 	body := &CreateAipNotValidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewCreateAipInternalErrorResponseBody builds the HTTP response body from the
+// result of the "create_aip" endpoint of the "storage" service.
+func NewCreateAipInternalErrorResponseBody(res *goa.ServiceError) *CreateAipInternalErrorResponseBody {
+	body := &CreateAipInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -2380,10 +2540,10 @@ func NewDownloadAipNotFoundResponseBody(res *storage.AIPNotFound) *DownloadAipNo
 	return body
 }
 
-// NewMoveAipNotAvailableResponseBody builds the HTTP response body from the
-// result of the "move_aip" endpoint of the "storage" service.
-func NewMoveAipNotAvailableResponseBody(res *goa.ServiceError) *MoveAipNotAvailableResponseBody {
-	body := &MoveAipNotAvailableResponseBody{
+// NewMoveAipNotValidResponseBody builds the HTTP response body from the result
+// of the "move_aip" endpoint of the "storage" service.
+func NewMoveAipNotValidResponseBody(res *goa.ServiceError) *MoveAipNotValidResponseBody {
+	body := &MoveAipNotValidResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -2394,10 +2554,10 @@ func NewMoveAipNotAvailableResponseBody(res *goa.ServiceError) *MoveAipNotAvaila
 	return body
 }
 
-// NewMoveAipNotValidResponseBody builds the HTTP response body from the result
-// of the "move_aip" endpoint of the "storage" service.
-func NewMoveAipNotValidResponseBody(res *goa.ServiceError) *MoveAipNotValidResponseBody {
-	body := &MoveAipNotValidResponseBody{
+// NewMoveAipInternalErrorResponseBody builds the HTTP response body from the
+// result of the "move_aip" endpoint of the "storage" service.
+func NewMoveAipInternalErrorResponseBody(res *goa.ServiceError) *MoveAipInternalErrorResponseBody {
+	body := &MoveAipInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -2432,20 +2592,10 @@ func NewMoveAipStatusFailedDependencyResponseBody(res *goa.ServiceError) *MoveAi
 	return body
 }
 
-// NewMoveAipStatusNotFoundResponseBody builds the HTTP response body from the
-// result of the "move_aip_status" endpoint of the "storage" service.
-func NewMoveAipStatusNotFoundResponseBody(res *storage.AIPNotFound) *MoveAipStatusNotFoundResponseBody {
-	body := &MoveAipStatusNotFoundResponseBody{
-		Message: res.Message,
-		UUID:    res.UUID,
-	}
-	return body
-}
-
-// NewRejectAipNotAvailableResponseBody builds the HTTP response body from the
-// result of the "reject_aip" endpoint of the "storage" service.
-func NewRejectAipNotAvailableResponseBody(res *goa.ServiceError) *RejectAipNotAvailableResponseBody {
-	body := &RejectAipNotAvailableResponseBody{
+// NewMoveAipStatusInternalErrorResponseBody builds the HTTP response body from
+// the result of the "move_aip_status" endpoint of the "storage" service.
+func NewMoveAipStatusInternalErrorResponseBody(res *goa.ServiceError) *MoveAipStatusInternalErrorResponseBody {
+	body := &MoveAipStatusInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -2456,10 +2606,34 @@ func NewRejectAipNotAvailableResponseBody(res *goa.ServiceError) *RejectAipNotAv
 	return body
 }
 
+// NewMoveAipStatusNotFoundResponseBody builds the HTTP response body from the
+// result of the "move_aip_status" endpoint of the "storage" service.
+func NewMoveAipStatusNotFoundResponseBody(res *storage.AIPNotFound) *MoveAipStatusNotFoundResponseBody {
+	body := &MoveAipStatusNotFoundResponseBody{
+		Message: res.Message,
+		UUID:    res.UUID,
+	}
+	return body
+}
+
 // NewRejectAipNotValidResponseBody builds the HTTP response body from the
 // result of the "reject_aip" endpoint of the "storage" service.
 func NewRejectAipNotValidResponseBody(res *goa.ServiceError) *RejectAipNotValidResponseBody {
 	body := &RejectAipNotValidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewRejectAipInternalErrorResponseBody builds the HTTP response body from the
+// result of the "reject_aip" endpoint of the "storage" service.
+func NewRejectAipInternalErrorResponseBody(res *goa.ServiceError) *RejectAipInternalErrorResponseBody {
+	body := &RejectAipInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -2480,12 +2654,41 @@ func NewRejectAipNotFoundResponseBody(res *storage.AIPNotFound) *RejectAipNotFou
 	return body
 }
 
+// NewShowAipInternalErrorResponseBody builds the HTTP response body from the
+// result of the "show_aip" endpoint of the "storage" service.
+func NewShowAipInternalErrorResponseBody(res *goa.ServiceError) *ShowAipInternalErrorResponseBody {
+	body := &ShowAipInternalErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
 // NewShowAipNotFoundResponseBody builds the HTTP response body from the result
 // of the "show_aip" endpoint of the "storage" service.
 func NewShowAipNotFoundResponseBody(res *storage.AIPNotFound) *ShowAipNotFoundResponseBody {
 	body := &ShowAipNotFoundResponseBody{
 		Message: res.Message,
 		UUID:    res.UUID,
+	}
+	return body
+}
+
+// NewListAipWorkflowsInternalErrorResponseBody builds the HTTP response body
+// from the result of the "list_aip_workflows" endpoint of the "storage"
+// service.
+func NewListAipWorkflowsInternalErrorResponseBody(res *goa.ServiceError) *ListAipWorkflowsInternalErrorResponseBody {
+	body := &ListAipWorkflowsInternalErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
 	}
 	return body
 }
@@ -2743,10 +2946,52 @@ func NewAipDeletionReportInternalErrorResponseBody(res *goa.ServiceError) *AipDe
 	return body
 }
 
+// NewListLocationsInternalErrorResponseBody builds the HTTP response body from
+// the result of the "list_locations" endpoint of the "storage" service.
+func NewListLocationsInternalErrorResponseBody(res *goa.ServiceError) *ListLocationsInternalErrorResponseBody {
+	body := &ListLocationsInternalErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
 // NewCreateLocationNotValidResponseBody builds the HTTP response body from the
 // result of the "create_location" endpoint of the "storage" service.
 func NewCreateLocationNotValidResponseBody(res *goa.ServiceError) *CreateLocationNotValidResponseBody {
 	body := &CreateLocationNotValidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewCreateLocationInternalErrorResponseBody builds the HTTP response body
+// from the result of the "create_location" endpoint of the "storage" service.
+func NewCreateLocationInternalErrorResponseBody(res *goa.ServiceError) *CreateLocationInternalErrorResponseBody {
+	body := &CreateLocationInternalErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewShowLocationInternalErrorResponseBody builds the HTTP response body from
+// the result of the "show_location" endpoint of the "storage" service.
+func NewShowLocationInternalErrorResponseBody(res *goa.ServiceError) *ShowLocationInternalErrorResponseBody {
+	body := &ShowLocationInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -2771,6 +3016,21 @@ func NewShowLocationNotFoundResponseBody(res *storage.LocationNotFound) *ShowLoc
 // the result of the "list_location_aips" endpoint of the "storage" service.
 func NewListLocationAipsNotValidResponseBody(res *goa.ServiceError) *ListLocationAipsNotValidResponseBody {
 	body := &ListLocationAipsNotValidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewListLocationAipsInternalErrorResponseBody builds the HTTP response body
+// from the result of the "list_location_aips" endpoint of the "storage"
+// service.
+func NewListLocationAipsInternalErrorResponseBody(res *goa.ServiceError) *ListLocationAipsInternalErrorResponseBody {
+	body := &ListLocationAipsInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,

--- a/internal/api/gen/ingest/client.go
+++ b/internal/api/gen/ingest/client.go
@@ -63,9 +63,9 @@ func NewClient(monitor, listSips, showSip, listSipWorkflows, confirmSip, rejectS
 
 // Monitor calls the "monitor" endpoint of the "ingest" service.
 // Monitor may return the following errors:
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) Monitor(ctx context.Context, p *MonitorPayload) (res MonitorClientStream, err error) {
 	var ires any
@@ -81,6 +81,7 @@ func (c *Client) Monitor(ctx context.Context, p *MonitorPayload) (res MonitorCli
 //   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ListSips(ctx context.Context, p *ListSipsPayload) (res *SIPs, err error) {
 	var ires any
@@ -94,9 +95,9 @@ func (c *Client) ListSips(ctx context.Context, p *ListSipsPayload) (res *SIPs, e
 // ShowSip calls the "show_sip" endpoint of the "ingest" service.
 // ShowSip may return the following errors:
 //   - "not_found" (type *SIPNotFound): SIP not found
-//   - "not_available" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ShowSip(ctx context.Context, p *ShowSipPayload) (res *SIP, err error) {
 	var ires any
@@ -113,6 +114,7 @@ func (c *Client) ShowSip(ctx context.Context, p *ShowSipPayload) (res *SIP, err 
 //   - "not_found" (type *SIPNotFound): SIP not found
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ListSipWorkflows(ctx context.Context, p *ListSipWorkflowsPayload) (res *SIPWorkflows, err error) {
 	var ires any
@@ -130,6 +132,7 @@ func (c *Client) ListSipWorkflows(ctx context.Context, p *ListSipWorkflowsPayloa
 //   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ConfirmSip(ctx context.Context, p *ConfirmSipPayload) (err error) {
 	_, err = c.ConfirmSipEndpoint(ctx, p)
@@ -143,6 +146,7 @@ func (c *Client) ConfirmSip(ctx context.Context, p *ConfirmSipPayload) (err erro
 //   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) RejectSip(ctx context.Context, p *RejectSipPayload) (err error) {
 	_, err = c.RejectSipEndpoint(ctx, p)
@@ -153,11 +157,11 @@ func (c *Client) RejectSip(ctx context.Context, p *RejectSipPayload) (err error)
 // service.
 // ShowSipDecision may return the following errors:
 //   - "not_found" (type *SIPNotFound): SIP not found
-//   - "internal_error" (type *goa.ServiceError)
 //   - "not_available" (type *goa.ServiceError)
 //   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ShowSipDecision(ctx context.Context, p *ShowSipDecisionPayload) (res *SIPDecision, err error) {
 	var ires any
@@ -172,11 +176,11 @@ func (c *Client) ShowSipDecision(ctx context.Context, p *ShowSipDecisionPayload)
 // service.
 // SubmitSipDecision may return the following errors:
 //   - "not_found" (type *SIPNotFound): SIP not found
-//   - "internal_error" (type *goa.ServiceError)
 //   - "not_available" (type *goa.ServiceError)
 //   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) SubmitSipDecision(ctx context.Context, p *SubmitSipDecisionPayload) (err error) {
 	_, err = c.SubmitSipDecisionEndpoint(ctx, p)
@@ -186,9 +190,9 @@ func (c *Client) SubmitSipDecision(ctx context.Context, p *SubmitSipDecisionPayl
 // AddSip calls the "add_sip" endpoint of the "ingest" service.
 // AddSip may return the following errors:
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) AddSip(ctx context.Context, p *AddSipPayload) (res *AddSipResult, err error) {
 	var ires any
@@ -203,9 +207,9 @@ func (c *Client) AddSip(ctx context.Context, p *AddSipPayload) (res *AddSipResul
 // UploadSip may return the following errors:
 //   - "invalid_media_type" (type *goa.ServiceError): Error returned when the Content-Type header does not define a multipart request.
 //   - "invalid_multipart_request" (type *goa.ServiceError): Error returned when the request body is not a valid multipart content.
-//   - "internal_error" (type *goa.ServiceError): Fault while processing upload.
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) UploadSip(ctx context.Context, p *UploadSipPayload, req io.ReadCloser) (res *UploadSipResult, err error) {
 	var ires any
@@ -221,9 +225,9 @@ func (c *Client) UploadSip(ctx context.Context, p *UploadSipPayload, req io.Read
 // DownloadSipRequest may return the following errors:
 //   - "not_found" (type *SIPNotFound): SIP not found
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) DownloadSipRequest(ctx context.Context, p *DownloadSipRequestPayload) (res *DownloadSipRequestResult, err error) {
 	var ires any
@@ -238,9 +242,9 @@ func (c *Client) DownloadSipRequest(ctx context.Context, p *DownloadSipRequestPa
 // DownloadSip may return the following errors:
 //   - "not_found" (type *SIPNotFound): SIP not found
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) DownloadSip(ctx context.Context, p *DownloadSipPayload) (res *DownloadSipResult, resp io.ReadCloser, err error) {
 	var ires any
@@ -257,6 +261,7 @@ func (c *Client) DownloadSip(ctx context.Context, p *DownloadSipPayload) (res *D
 //   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ListUsers(ctx context.Context, p *ListUsersPayload) (res *Users, err error) {
 	var ires any
@@ -272,9 +277,9 @@ func (c *Client) ListUsers(ctx context.Context, p *ListUsersPayload) (res *Users
 // ListSipSourceObjects may return the following errors:
 //   - "not_found" (type *goa.ServiceError)
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ListSipSourceObjects(ctx context.Context, p *ListSipSourceObjectsPayload) (res *SIPSourceObjects, err error) {
 	var ires any
@@ -288,9 +293,9 @@ func (c *Client) ListSipSourceObjects(ctx context.Context, p *ListSipSourceObjec
 // AddBatch calls the "add_batch" endpoint of the "ingest" service.
 // AddBatch may return the following errors:
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) AddBatch(ctx context.Context, p *AddBatchPayload) (res *AddBatchResult, err error) {
 	var ires any
@@ -304,9 +309,9 @@ func (c *Client) AddBatch(ctx context.Context, p *AddBatchPayload) (res *AddBatc
 // ListBatches calls the "list_batches" endpoint of the "ingest" service.
 // ListBatches may return the following errors:
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ListBatches(ctx context.Context, p *ListBatchesPayload) (res *Batches, err error) {
 	var ires any
@@ -321,9 +326,9 @@ func (c *Client) ListBatches(ctx context.Context, p *ListBatchesPayload) (res *B
 // ShowBatch may return the following errors:
 //   - "not_found" (type *BatchNotFound): Batch not found
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ShowBatch(ctx context.Context, p *ShowBatchPayload) (res *Batch, err error) {
 	var ires any
@@ -338,9 +343,9 @@ func (c *Client) ShowBatch(ctx context.Context, p *ShowBatchPayload) (res *Batch
 // ReviewBatch may return the following errors:
 //   - "not_found" (type *BatchNotFound): Batch not found
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ReviewBatch(ctx context.Context, p *ReviewBatchPayload) (err error) {
 	_, err = c.ReviewBatchEndpoint(ctx, p)

--- a/internal/api/gen/ingest/interceptor_wrappers.go
+++ b/internal/api/gen/ingest/interceptor_wrappers.go
@@ -265,3 +265,255 @@ func wrapReviewBatchOperationTimeout(endpoint goa.Endpoint, i ServerInterceptors
 		return i.OperationTimeout(ctx, info, endpoint)
 	}
 }
+
+// wrapServerErrorHandlerMonitor applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapMonitorServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "Monitor",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerListSips applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapListSipsServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "ListSips",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerShowSip applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapShowSipServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "ShowSip",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerListSipWorkflows applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapListSipWorkflowsServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "ListSipWorkflows",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerConfirmSip applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapConfirmSipServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "ConfirmSip",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerRejectSip applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapRejectSipServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "RejectSip",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerShowSipDecision applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapShowSipDecisionServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "ShowSipDecision",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerSubmitSipDecision applies the ServerErrorHandler
+// server interceptor to endpoints.
+func wrapSubmitSipDecisionServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "SubmitSipDecision",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerAddSip applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapAddSipServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "AddSip",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerUploadSip applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapUploadSipServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "UploadSip",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerDownloadSipRequest applies the ServerErrorHandler
+// server interceptor to endpoints.
+func wrapDownloadSipRequestServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "DownloadSipRequest",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerDownloadSip applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapDownloadSipServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "DownloadSip",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerListUsers applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapListUsersServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "ListUsers",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerListSipSourceObjects applies the ServerErrorHandler
+// server interceptor to endpoints.
+func wrapListSipSourceObjectsServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "ListSipSourceObjects",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerAddBatch applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapAddBatchServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "AddBatch",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerListBatches applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapListBatchesServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "ListBatches",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerShowBatch applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapShowBatchServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "ShowBatch",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerReviewBatch applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapReviewBatchServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "ingest",
+			method:     "ReviewBatch",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}

--- a/internal/api/gen/ingest/service.go
+++ b/internal/api/gen/ingest/service.go
@@ -1137,7 +1137,7 @@ func (u *Value) UnmarshalJSON(data []byte) error {
 
 // MakeInternalError builds a goa.ServiceError from an error.
 func MakeInternalError(err error) *goa.ServiceError {
-	return goa.NewServiceError(err, "internal_error", false, false, false)
+	return goa.NewServiceError(err, "internal_error", false, false, true)
 }
 
 // MakeNotValid builds a goa.ServiceError from an error.

--- a/internal/api/gen/ingest/service_interceptors.go
+++ b/internal/api/gen/ingest/service_interceptors.go
@@ -20,6 +20,7 @@ import (
 // next to complete the request.
 type ServerInterceptors interface {
 	OperationTimeout(ctx context.Context, info *OperationTimeoutInfo, next goa.Endpoint) (any, error)
+	ServerErrorHandler(ctx context.Context, info *ServerErrorHandlerInfo, next goa.Endpoint) (any, error)
 }
 
 // Access interfaces for interceptor payloads and results
@@ -32,6 +33,14 @@ type (
 		callType   goa.InterceptorCallType
 		rawPayload any
 	}
+	// ServerErrorHandlerInfo provides metadata about the current interception.
+	// It includes service name, method name, and access to the endpoint.
+	ServerErrorHandlerInfo struct {
+		service    string
+		method     string
+		callType   goa.InterceptorCallType
+		rawPayload any
+	}
 )
 
 // WrapMonitorEndpoint wraps the monitor endpoint with the server-side
@@ -39,6 +48,7 @@ type (
 func WrapMonitorEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapMonitorOperationTimeout(endpoint, i)
+		endpoint = wrapMonitorServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -48,6 +58,7 @@ func WrapMonitorEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoi
 func WrapListSipsEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapListSipsOperationTimeout(endpoint, i)
+		endpoint = wrapListSipsServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -57,6 +68,7 @@ func WrapListSipsEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpo
 func WrapShowSipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapShowSipOperationTimeout(endpoint, i)
+		endpoint = wrapShowSipServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -66,6 +78,7 @@ func WrapShowSipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoi
 func WrapListSipWorkflowsEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapListSipWorkflowsOperationTimeout(endpoint, i)
+		endpoint = wrapListSipWorkflowsServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -75,6 +88,7 @@ func WrapListSipWorkflowsEndpoint(endpoint goa.Endpoint, i ServerInterceptors) g
 func WrapConfirmSipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapConfirmSipOperationTimeout(endpoint, i)
+		endpoint = wrapConfirmSipServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -84,6 +98,7 @@ func WrapConfirmSipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.End
 func WrapRejectSipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapRejectSipOperationTimeout(endpoint, i)
+		endpoint = wrapRejectSipServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -93,6 +108,7 @@ func WrapRejectSipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endp
 func WrapShowSipDecisionEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapShowSipDecisionOperationTimeout(endpoint, i)
+		endpoint = wrapShowSipDecisionServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -102,6 +118,7 @@ func WrapShowSipDecisionEndpoint(endpoint goa.Endpoint, i ServerInterceptors) go
 func WrapSubmitSipDecisionEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapSubmitSipDecisionOperationTimeout(endpoint, i)
+		endpoint = wrapSubmitSipDecisionServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -111,6 +128,7 @@ func WrapSubmitSipDecisionEndpoint(endpoint goa.Endpoint, i ServerInterceptors) 
 func WrapAddSipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapAddSipOperationTimeout(endpoint, i)
+		endpoint = wrapAddSipServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -120,6 +138,7 @@ func WrapAddSipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoin
 func WrapUploadSipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapUploadSipOperationTimeout(endpoint, i)
+		endpoint = wrapUploadSipServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -129,6 +148,7 @@ func WrapUploadSipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endp
 func WrapDownloadSipRequestEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapDownloadSipRequestOperationTimeout(endpoint, i)
+		endpoint = wrapDownloadSipRequestServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -138,6 +158,7 @@ func WrapDownloadSipRequestEndpoint(endpoint goa.Endpoint, i ServerInterceptors)
 func WrapDownloadSipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapDownloadSipOperationTimeout(endpoint, i)
+		endpoint = wrapDownloadSipServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -147,6 +168,7 @@ func WrapDownloadSipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.En
 func WrapListUsersEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapListUsersOperationTimeout(endpoint, i)
+		endpoint = wrapListUsersServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -156,6 +178,7 @@ func WrapListUsersEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endp
 func WrapListSipSourceObjectsEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapListSipSourceObjectsOperationTimeout(endpoint, i)
+		endpoint = wrapListSipSourceObjectsServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -165,6 +188,7 @@ func WrapListSipSourceObjectsEndpoint(endpoint goa.Endpoint, i ServerInterceptor
 func WrapAddBatchEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapAddBatchOperationTimeout(endpoint, i)
+		endpoint = wrapAddBatchServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -174,6 +198,7 @@ func WrapAddBatchEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpo
 func WrapListBatchesEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapListBatchesOperationTimeout(endpoint, i)
+		endpoint = wrapListBatchesServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -183,6 +208,7 @@ func WrapListBatchesEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.En
 func WrapShowBatchEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapShowBatchOperationTimeout(endpoint, i)
+		endpoint = wrapShowBatchServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -192,6 +218,7 @@ func WrapShowBatchEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endp
 func WrapReviewBatchEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapReviewBatchOperationTimeout(endpoint, i)
+		endpoint = wrapReviewBatchServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -215,5 +242,25 @@ func (info *OperationTimeoutInfo) CallType() goa.InterceptorCallType {
 
 // RawPayload returns the raw payload of the request.
 func (info *OperationTimeoutInfo) RawPayload() any {
+	return info.rawPayload
+}
+
+// Service returns the name of the service handling the request.
+func (info *ServerErrorHandlerInfo) Service() string {
+	return info.service
+}
+
+// Method returns the name of the method handling the request.
+func (info *ServerErrorHandlerInfo) Method() string {
+	return info.method
+}
+
+// CallType returns the type of call the interceptor is handling.
+func (info *ServerErrorHandlerInfo) CallType() goa.InterceptorCallType {
+	return info.callType
+}
+
+// RawPayload returns the raw payload of the request.
+func (info *ServerErrorHandlerInfo) RawPayload() any {
 	return info.rawPayload
 }

--- a/internal/api/gen/storage/client.go
+++ b/internal/api/gen/storage/client.go
@@ -67,9 +67,9 @@ func NewClient(monitor, listAips, createAip, downloadAipRequest, downloadAip, mo
 
 // Monitor calls the "monitor" endpoint of the "storage" service.
 // Monitor may return the following errors:
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) Monitor(ctx context.Context, p *MonitorPayload) (res MonitorClientStream, err error) {
 	var ires any
@@ -82,10 +82,10 @@ func (c *Client) Monitor(ctx context.Context, p *MonitorPayload) (res MonitorCli
 
 // ListAips calls the "list_aips" endpoint of the "storage" service.
 // ListAips may return the following errors:
-//   - "not_available" (type *goa.ServiceError)
 //   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ListAips(ctx context.Context, p *ListAipsPayload) (res *AIPs, err error) {
 	var ires any
@@ -101,6 +101,7 @@ func (c *Client) ListAips(ctx context.Context, p *ListAipsPayload) (res *AIPs, e
 //   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) CreateAip(ctx context.Context, p *CreateAipPayload) (res *AIP, err error) {
 	var ires any
@@ -116,9 +117,9 @@ func (c *Client) CreateAip(ctx context.Context, p *CreateAipPayload) (res *AIP, 
 // DownloadAipRequest may return the following errors:
 //   - "not_found" (type *AIPNotFound): AIP not found
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) DownloadAipRequest(ctx context.Context, p *DownloadAipRequestPayload) (res *DownloadAipRequestResult, err error) {
 	var ires any
@@ -133,9 +134,9 @@ func (c *Client) DownloadAipRequest(ctx context.Context, p *DownloadAipRequestPa
 // DownloadAip may return the following errors:
 //   - "not_found" (type *AIPNotFound): AIP not found
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) DownloadAip(ctx context.Context, p *DownloadAipPayload) (res *DownloadAipResult, resp io.ReadCloser, err error) {
 	var ires any
@@ -150,10 +151,10 @@ func (c *Client) DownloadAip(ctx context.Context, p *DownloadAipPayload) (res *D
 // MoveAip calls the "move_aip" endpoint of the "storage" service.
 // MoveAip may return the following errors:
 //   - "not_found" (type *AIPNotFound): AIP not found
-//   - "not_available" (type *goa.ServiceError)
 //   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) MoveAip(ctx context.Context, p *MoveAipPayload) (err error) {
 	_, err = c.MoveAipEndpoint(ctx, p)
@@ -166,6 +167,7 @@ func (c *Client) MoveAip(ctx context.Context, p *MoveAipPayload) (err error) {
 //   - "failed_dependency" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) MoveAipStatus(ctx context.Context, p *MoveAipStatusPayload) (res *MoveStatusResult, err error) {
 	var ires any
@@ -179,10 +181,10 @@ func (c *Client) MoveAipStatus(ctx context.Context, p *MoveAipStatusPayload) (re
 // RejectAip calls the "reject_aip" endpoint of the "storage" service.
 // RejectAip may return the following errors:
 //   - "not_found" (type *AIPNotFound): AIP not found
-//   - "not_available" (type *goa.ServiceError)
 //   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) RejectAip(ctx context.Context, p *RejectAipPayload) (err error) {
 	_, err = c.RejectAipEndpoint(ctx, p)
@@ -194,6 +196,7 @@ func (c *Client) RejectAip(ctx context.Context, p *RejectAipPayload) (err error)
 //   - "not_found" (type *AIPNotFound): AIP not found
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ShowAip(ctx context.Context, p *ShowAipPayload) (res *AIP, err error) {
 	var ires any
@@ -210,6 +213,7 @@ func (c *Client) ShowAip(ctx context.Context, p *ShowAipPayload) (res *AIP, err 
 //   - "not_found" (type *AIPNotFound): AIP not found
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ListAipWorkflows(ctx context.Context, p *ListAipWorkflowsPayload) (res *AIPWorkflows, err error) {
 	var ires any
@@ -225,9 +229,9 @@ func (c *Client) ListAipWorkflows(ctx context.Context, p *ListAipWorkflowsPayloa
 // AipDeletionAuto may return the following errors:
 //   - "not_found" (type *AIPNotFound): AIP not found
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) AipDeletionAuto(ctx context.Context, p *AipDeletionAutoPayload) (err error) {
 	_, err = c.AipDeletionAutoEndpoint(ctx, p)
@@ -239,9 +243,9 @@ func (c *Client) AipDeletionAuto(ctx context.Context, p *AipDeletionAutoPayload)
 // RequestAipDeletion may return the following errors:
 //   - "not_found" (type *AIPNotFound): AIP not found
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) RequestAipDeletion(ctx context.Context, p *RequestAipDeletionPayload) (err error) {
 	_, err = c.RequestAipDeletionEndpoint(ctx, p)
@@ -253,9 +257,9 @@ func (c *Client) RequestAipDeletion(ctx context.Context, p *RequestAipDeletionPa
 // ReviewAipDeletion may return the following errors:
 //   - "not_found" (type *AIPNotFound): AIP not found
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ReviewAipDeletion(ctx context.Context, p *ReviewAipDeletionPayload) (err error) {
 	_, err = c.ReviewAipDeletionEndpoint(ctx, p)
@@ -267,9 +271,9 @@ func (c *Client) ReviewAipDeletion(ctx context.Context, p *ReviewAipDeletionPayl
 // CancelAipDeletion may return the following errors:
 //   - "not_found" (type *AIPNotFound): AIP not found
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) CancelAipDeletion(ctx context.Context, p *CancelAipDeletionPayload) (err error) {
 	_, err = c.CancelAipDeletionEndpoint(ctx, p)
@@ -281,9 +285,9 @@ func (c *Client) CancelAipDeletion(ctx context.Context, p *CancelAipDeletionPayl
 // AipDeletionReportRequest may return the following errors:
 //   - "not_found" (type *goa.ServiceError)
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) AipDeletionReportRequest(ctx context.Context, p *AipDeletionReportRequestPayload) (res *AipDeletionReportRequestResult, err error) {
 	var ires any
@@ -299,9 +303,9 @@ func (c *Client) AipDeletionReportRequest(ctx context.Context, p *AipDeletionRep
 // AipDeletionReport may return the following errors:
 //   - "not_found" (type *goa.ServiceError)
 //   - "not_valid" (type *goa.ServiceError)
-//   - "internal_error" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) AipDeletionReport(ctx context.Context, p *AipDeletionReportPayload) (res *AipDeletionReportResult, resp io.ReadCloser, err error) {
 	var ires any
@@ -317,6 +321,7 @@ func (c *Client) AipDeletionReport(ctx context.Context, p *AipDeletionReportPayl
 // ListLocations may return the following errors:
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ListLocations(ctx context.Context, p *ListLocationsPayload) (res LocationCollection, err error) {
 	var ires any
@@ -332,6 +337,7 @@ func (c *Client) ListLocations(ctx context.Context, p *ListLocationsPayload) (re
 //   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) CreateLocation(ctx context.Context, p *CreateLocationPayload) (res *CreateLocationResult, err error) {
 	var ires any
@@ -347,6 +353,7 @@ func (c *Client) CreateLocation(ctx context.Context, p *CreateLocationPayload) (
 //   - "not_found" (type *LocationNotFound): Storage location not found
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ShowLocation(ctx context.Context, p *ShowLocationPayload) (res *Location, err error) {
 	var ires any
@@ -364,6 +371,7 @@ func (c *Client) ShowLocation(ctx context.Context, p *ShowLocationPayload) (res 
 //   - "not_valid" (type *goa.ServiceError)
 //   - "unauthorized" (type Unauthorized)
 //   - "forbidden" (type Forbidden)
+//   - "internal_error" (type *goa.ServiceError)
 //   - error: internal error
 func (c *Client) ListLocationAips(ctx context.Context, p *ListLocationAipsPayload) (res AIPCollection, err error) {
 	var ires any

--- a/internal/api/gen/storage/interceptor_wrappers.go
+++ b/internal/api/gen/storage/interceptor_wrappers.go
@@ -293,3 +293,283 @@ func wrapListLocationAipsOperationTimeout(endpoint goa.Endpoint, i ServerInterce
 		return i.OperationTimeout(ctx, info, endpoint)
 	}
 }
+
+// wrapServerErrorHandlerMonitor applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapMonitorServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "Monitor",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerListAips applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapListAipsServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "ListAips",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerCreateAip applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapCreateAipServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "CreateAip",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerDownloadAipRequest applies the ServerErrorHandler
+// server interceptor to endpoints.
+func wrapDownloadAipRequestServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "DownloadAipRequest",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerDownloadAip applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapDownloadAipServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "DownloadAip",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerMoveAip applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapMoveAipServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "MoveAip",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerMoveAipStatus applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapMoveAipStatusServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "MoveAipStatus",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerRejectAip applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapRejectAipServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "RejectAip",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerShowAip applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapShowAipServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "ShowAip",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerListAipWorkflows applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapListAipWorkflowsServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "ListAipWorkflows",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerAipDeletionAuto applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapAipDeletionAutoServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "AipDeletionAuto",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerRequestAipDeletion applies the ServerErrorHandler
+// server interceptor to endpoints.
+func wrapRequestAipDeletionServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "RequestAipDeletion",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerReviewAipDeletion applies the ServerErrorHandler
+// server interceptor to endpoints.
+func wrapReviewAipDeletionServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "ReviewAipDeletion",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerCancelAipDeletion applies the ServerErrorHandler
+// server interceptor to endpoints.
+func wrapCancelAipDeletionServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "CancelAipDeletion",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerAipDeletionReportRequest applies the
+// ServerErrorHandler server interceptor to endpoints.
+func wrapAipDeletionReportRequestServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "AipDeletionReportRequest",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerAipDeletionReport applies the ServerErrorHandler
+// server interceptor to endpoints.
+func wrapAipDeletionReportServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "AipDeletionReport",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerListLocations applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapListLocationsServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "ListLocations",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerCreateLocation applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapCreateLocationServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "CreateLocation",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerShowLocation applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapShowLocationServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "ShowLocation",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}
+
+// wrapServerErrorHandlerListLocationAips applies the ServerErrorHandler server
+// interceptor to endpoints.
+func wrapListLocationAipsServerErrorHandler(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		info := &ServerErrorHandlerInfo{
+			service:    "storage",
+			method:     "ListLocationAips",
+			callType:   goa.InterceptorUnary,
+			rawPayload: req,
+		}
+		return i.ServerErrorHandler(ctx, info, endpoint)
+	}
+}

--- a/internal/api/gen/storage/service.go
+++ b/internal/api/gen/storage/service.go
@@ -1349,12 +1349,7 @@ func (u *Value) UnmarshalJSON(data []byte) error {
 
 // MakeInternalError builds a goa.ServiceError from an error.
 func MakeInternalError(err error) *goa.ServiceError {
-	return goa.NewServiceError(err, "internal_error", false, false, false)
-}
-
-// MakeNotAvailable builds a goa.ServiceError from an error.
-func MakeNotAvailable(err error) *goa.ServiceError {
-	return goa.NewServiceError(err, "not_available", false, false, false)
+	return goa.NewServiceError(err, "internal_error", false, false, true)
 }
 
 // MakeNotValid builds a goa.ServiceError from an error.

--- a/internal/api/gen/storage/service_interceptors.go
+++ b/internal/api/gen/storage/service_interceptors.go
@@ -20,6 +20,7 @@ import (
 // next to complete the request.
 type ServerInterceptors interface {
 	OperationTimeout(ctx context.Context, info *OperationTimeoutInfo, next goa.Endpoint) (any, error)
+	ServerErrorHandler(ctx context.Context, info *ServerErrorHandlerInfo, next goa.Endpoint) (any, error)
 }
 
 // Access interfaces for interceptor payloads and results
@@ -32,6 +33,14 @@ type (
 		callType   goa.InterceptorCallType
 		rawPayload any
 	}
+	// ServerErrorHandlerInfo provides metadata about the current interception.
+	// It includes service name, method name, and access to the endpoint.
+	ServerErrorHandlerInfo struct {
+		service    string
+		method     string
+		callType   goa.InterceptorCallType
+		rawPayload any
+	}
 )
 
 // WrapMonitorEndpoint wraps the monitor endpoint with the server-side
@@ -39,6 +48,7 @@ type (
 func WrapMonitorEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapMonitorOperationTimeout(endpoint, i)
+		endpoint = wrapMonitorServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -48,6 +58,7 @@ func WrapMonitorEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoi
 func WrapListAipsEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapListAipsOperationTimeout(endpoint, i)
+		endpoint = wrapListAipsServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -57,6 +68,7 @@ func WrapListAipsEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpo
 func WrapCreateAipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapCreateAipOperationTimeout(endpoint, i)
+		endpoint = wrapCreateAipServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -66,6 +78,7 @@ func WrapCreateAipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endp
 func WrapDownloadAipRequestEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapDownloadAipRequestOperationTimeout(endpoint, i)
+		endpoint = wrapDownloadAipRequestServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -75,6 +88,7 @@ func WrapDownloadAipRequestEndpoint(endpoint goa.Endpoint, i ServerInterceptors)
 func WrapDownloadAipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapDownloadAipOperationTimeout(endpoint, i)
+		endpoint = wrapDownloadAipServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -84,6 +98,7 @@ func WrapDownloadAipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.En
 func WrapMoveAipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapMoveAipOperationTimeout(endpoint, i)
+		endpoint = wrapMoveAipServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -93,6 +108,7 @@ func WrapMoveAipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoi
 func WrapMoveAipStatusEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapMoveAipStatusOperationTimeout(endpoint, i)
+		endpoint = wrapMoveAipStatusServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -102,6 +118,7 @@ func WrapMoveAipStatusEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.
 func WrapRejectAipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapRejectAipOperationTimeout(endpoint, i)
+		endpoint = wrapRejectAipServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -111,6 +128,7 @@ func WrapRejectAipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endp
 func WrapShowAipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapShowAipOperationTimeout(endpoint, i)
+		endpoint = wrapShowAipServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -120,6 +138,7 @@ func WrapShowAipEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoi
 func WrapListAipWorkflowsEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapListAipWorkflowsOperationTimeout(endpoint, i)
+		endpoint = wrapListAipWorkflowsServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -129,6 +148,7 @@ func WrapListAipWorkflowsEndpoint(endpoint goa.Endpoint, i ServerInterceptors) g
 func WrapAipDeletionAutoEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapAipDeletionAutoOperationTimeout(endpoint, i)
+		endpoint = wrapAipDeletionAutoServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -138,6 +158,7 @@ func WrapAipDeletionAutoEndpoint(endpoint goa.Endpoint, i ServerInterceptors) go
 func WrapRequestAipDeletionEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapRequestAipDeletionOperationTimeout(endpoint, i)
+		endpoint = wrapRequestAipDeletionServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -147,6 +168,7 @@ func WrapRequestAipDeletionEndpoint(endpoint goa.Endpoint, i ServerInterceptors)
 func WrapReviewAipDeletionEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapReviewAipDeletionOperationTimeout(endpoint, i)
+		endpoint = wrapReviewAipDeletionServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -156,6 +178,7 @@ func WrapReviewAipDeletionEndpoint(endpoint goa.Endpoint, i ServerInterceptors) 
 func WrapCancelAipDeletionEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapCancelAipDeletionOperationTimeout(endpoint, i)
+		endpoint = wrapCancelAipDeletionServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -165,6 +188,7 @@ func WrapCancelAipDeletionEndpoint(endpoint goa.Endpoint, i ServerInterceptors) 
 func WrapAipDeletionReportRequestEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapAipDeletionReportRequestOperationTimeout(endpoint, i)
+		endpoint = wrapAipDeletionReportRequestServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -174,6 +198,7 @@ func WrapAipDeletionReportRequestEndpoint(endpoint goa.Endpoint, i ServerInterce
 func WrapAipDeletionReportEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapAipDeletionReportOperationTimeout(endpoint, i)
+		endpoint = wrapAipDeletionReportServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -183,6 +208,7 @@ func WrapAipDeletionReportEndpoint(endpoint goa.Endpoint, i ServerInterceptors) 
 func WrapListLocationsEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapListLocationsOperationTimeout(endpoint, i)
+		endpoint = wrapListLocationsServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -192,6 +218,7 @@ func WrapListLocationsEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.
 func WrapCreateLocationEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapCreateLocationOperationTimeout(endpoint, i)
+		endpoint = wrapCreateLocationServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -201,6 +228,7 @@ func WrapCreateLocationEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa
 func WrapShowLocationEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapShowLocationOperationTimeout(endpoint, i)
+		endpoint = wrapShowLocationServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -210,6 +238,7 @@ func WrapShowLocationEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.E
 func WrapListLocationAipsEndpoint(endpoint goa.Endpoint, i ServerInterceptors) goa.Endpoint {
 	if i != nil {
 		endpoint = wrapListLocationAipsOperationTimeout(endpoint, i)
+		endpoint = wrapListLocationAipsServerErrorHandler(endpoint, i)
 	}
 	return endpoint
 }
@@ -233,5 +262,25 @@ func (info *OperationTimeoutInfo) CallType() goa.InterceptorCallType {
 
 // RawPayload returns the raw payload of the request.
 func (info *OperationTimeoutInfo) RawPayload() any {
+	return info.rawPayload
+}
+
+// Service returns the name of the service handling the request.
+func (info *ServerErrorHandlerInfo) Service() string {
+	return info.service
+}
+
+// Method returns the name of the method handling the request.
+func (info *ServerErrorHandlerInfo) Method() string {
+	return info.method
+}
+
+// CallType returns the type of call the interceptor is handling.
+func (info *ServerErrorHandlerInfo) CallType() goa.InterceptorCallType {
+	return info.callType
+}
+
+// RawPayload returns the raw payload of the request.
+func (info *ServerErrorHandlerInfo) RawPayload() any {
 	return info.rawPayload
 }

--- a/internal/api/interceptors.go
+++ b/internal/api/interceptors.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -19,9 +20,10 @@ const (
 	defaultAPIOperationTimeout = 5 * time.Second
 	apiOperationSlowThreshold  = 2 * time.Second
 	apiOperationTimeoutMsg     = "API operation timed out"
+	apiInternalErrorMsg        = "internal error"
 )
 
-type operationInfo interface {
+type interceptorInfo interface {
 	Service() string
 	Method() string
 	CallType() goa.InterceptorCallType
@@ -40,19 +42,19 @@ type operationRule struct {
 	skipLogging   bool
 }
 
-// operationInterceptors is shared by all Goa services so service-level
+// serverInterceptors is shared by all Goa services so internal-error handling,
 // operation budgets, logging, and span annotations stay consistent. The rule
 // map keeps service/method exceptions explicit because Goa reports some
 // body-returning endpoints as unary.
-type operationInterceptors struct {
+type serverInterceptors struct {
 	logger           logr.Logger
 	operationTimeout time.Duration
 	slowThreshold    time.Duration
 	rules            map[operationKey]operationRule
 }
 
-func newOperationInterceptors(logger logr.Logger) *operationInterceptors {
-	return &operationInterceptors{
+func newServerInterceptors(logger logr.Logger) *serverInterceptors {
+	return &serverInterceptors{
 		logger:           logger,
 		operationTimeout: defaultAPIOperationTimeout,
 		slowThreshold:    apiOperationSlowThreshold,
@@ -82,11 +84,11 @@ func newOperationInterceptors(logger logr.Logger) *operationInterceptors {
 }
 
 type aboutServerInterceptors struct {
-	*operationInterceptors
+	*serverInterceptors
 }
 
 func newAboutServerInterceptors(logger logr.Logger) *aboutServerInterceptors {
-	return &aboutServerInterceptors{operationInterceptors: newOperationInterceptors(logger)}
+	return &aboutServerInterceptors{serverInterceptors: newServerInterceptors(logger)}
 }
 
 func (i *aboutServerInterceptors) OperationTimeout(
@@ -94,15 +96,23 @@ func (i *aboutServerInterceptors) OperationTimeout(
 	info *goaabout.OperationTimeoutInfo,
 	next goa.Endpoint,
 ) (any, error) {
-	return i.handle(ctx, info, next)
+	return i.handleOperationTimeout(ctx, info, next)
+}
+
+func (i *aboutServerInterceptors) ServerErrorHandler(
+	ctx context.Context,
+	info *goaabout.ServerErrorHandlerInfo,
+	next goa.Endpoint,
+) (any, error) {
+	return i.handleServerError(ctx, info, next)
 }
 
 type ingestServerInterceptors struct {
-	*operationInterceptors
+	*serverInterceptors
 }
 
 func newIngestServerInterceptors(logger logr.Logger) *ingestServerInterceptors {
-	return &ingestServerInterceptors{operationInterceptors: newOperationInterceptors(logger)}
+	return &ingestServerInterceptors{serverInterceptors: newServerInterceptors(logger)}
 }
 
 func (i *ingestServerInterceptors) OperationTimeout(
@@ -110,15 +120,23 @@ func (i *ingestServerInterceptors) OperationTimeout(
 	info *goaingest.OperationTimeoutInfo,
 	next goa.Endpoint,
 ) (any, error) {
-	return i.handle(ctx, info, next)
+	return i.handleOperationTimeout(ctx, info, next)
+}
+
+func (i *ingestServerInterceptors) ServerErrorHandler(
+	ctx context.Context,
+	info *goaingest.ServerErrorHandlerInfo,
+	next goa.Endpoint,
+) (any, error) {
+	return i.handleServerError(ctx, info, next)
 }
 
 type storageServerInterceptors struct {
-	*operationInterceptors
+	*serverInterceptors
 }
 
 func newStorageServerInterceptors(logger logr.Logger) *storageServerInterceptors {
-	return &storageServerInterceptors{operationInterceptors: newOperationInterceptors(logger)}
+	return &storageServerInterceptors{serverInterceptors: newServerInterceptors(logger)}
 }
 
 func (i *storageServerInterceptors) OperationTimeout(
@@ -126,12 +144,74 @@ func (i *storageServerInterceptors) OperationTimeout(
 	info *goastorage.OperationTimeoutInfo,
 	next goa.Endpoint,
 ) (any, error) {
-	return i.handle(ctx, info, next)
+	return i.handleOperationTimeout(ctx, info, next)
 }
 
-func (i *operationInterceptors) handle(
+func (i *storageServerInterceptors) ServerErrorHandler(
 	ctx context.Context,
-	info operationInfo,
+	info *goastorage.ServerErrorHandlerInfo,
+	next goa.Endpoint,
+) (any, error) {
+	return i.handleServerError(ctx, info, next)
+}
+
+func (i *serverInterceptors) handleServerError(
+	ctx context.Context,
+	info interceptorInfo,
+	next goa.Endpoint,
+) (any, error) {
+	res, err := next(ctx, info.RawPayload())
+	if err == nil {
+		return res, nil
+	}
+
+	// Check ServiceError first because it also implements GoaErrorNamer. Only
+	// the declared internal_error belongs to this handler; other service errors
+	// already have their own Goa classification and must pass through unchanged.
+	var serviceErr *goa.ServiceError
+	if errors.As(err, &serviceErr) {
+		if serviceErr.Name != "internal_error" {
+			return res, err
+		}
+	} else {
+		// Generated domain errors implement GoaErrorNamer without being
+		// ServiceErrors. Their generated transport mappings are authoritative,
+		// so preserve them instead of converting them to internal_error.
+		var namedErr goa.GoaErrorNamer
+		if errors.As(err, &namedErr) {
+			return res, err
+		}
+
+		// An unnamed error is an unexpected implementation failure. Classify it
+		// here so Goa consistently encodes it as the declared HTTP 500 response.
+		serviceErr = goa.NewServiceError(
+			err,
+			"internal_error",
+			false,
+			false,
+			true,
+		)
+	}
+
+	i.logger.Error(
+		err,
+		"API internal error.",
+		"service", info.Service(),
+		"method", info.Method(),
+		"error_id", serviceErr.ID,
+	)
+
+	// Preserve the Goa error ID and flags for correlation while ensuring that
+	// the transport exposes no implementation details.
+	sanitized := *serviceErr
+	sanitized.Message = apiInternalErrorMsg
+
+	return res, &sanitized
+}
+
+func (i *serverInterceptors) handleOperationTimeout(
+	ctx context.Context,
+	info interceptorInfo,
 	next goa.Endpoint,
 ) (any, error) {
 	rule := i.rule(info)
@@ -173,17 +253,8 @@ func (i *operationInterceptors) handle(
 			elapsed,
 			timeout,
 		)
-		i.logger.Error(
-			logErr,
-			"API operation timed out.",
-			"service", info.Service(),
-			"method", info.Method(),
-			"duration", elapsed,
-			"timeout", timeout,
-		)
-
 		return nil, goa.NewServiceError(
-			errors.New(apiOperationTimeoutMsg),
+			fmt.Errorf("%s: %v", apiOperationTimeoutMsg, logErr),
 			"internal_error",
 			true,
 			false,
@@ -205,7 +276,7 @@ func (i *operationInterceptors) handle(
 	return res, err
 }
 
-func (i *operationInterceptors) rule(info operationInfo) operationRule {
+func (i *serverInterceptors) rule(info interceptorInfo) operationRule {
 	rule := operationRule{
 		timeout:       i.operationTimeout,
 		slowThreshold: i.slowThreshold,

--- a/internal/api/interceptors_test.go
+++ b/internal/api/interceptors_test.go
@@ -3,10 +3,13 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -19,6 +22,145 @@ import (
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
 	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
 )
+
+func TestServerErrorHandlerLogsAndSanitizesInternalError(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("database unavailable")
+	returned := goastorage.MakeInternalError(fmt.Errorf("load AIP data: %v", cause))
+	var logged string
+	logger := funcr.New(
+		func(_, args string) { logged = args },
+		funcr.Options{},
+	)
+	endpoint := goastorage.WrapShowAipEndpoint(
+		func(context.Context, any) (any, error) { return nil, returned },
+		newStorageServerInterceptors(logger),
+	)
+
+	_, err := endpoint(context.Background(), "payload")
+
+	var serr *goa.ServiceError
+	assert.Assert(t, errors.As(err, &serr))
+	assert.DeepEqual(t, serr, &goa.ServiceError{
+		Name:    "internal_error",
+		ID:      returned.ID,
+		Message: apiInternalErrorMsg,
+		Fault:   true,
+	}, cmpopts.IgnoreUnexported(goa.ServiceError{}))
+	assert.Assert(t, strings.Contains(logged, "load AIP data: database unavailable"))
+	assert.Assert(t, strings.Contains(logged, `"service"="storage"`))
+	assert.Assert(t, strings.Contains(logged, `"method"="ShowAip"`))
+	assert.Assert(t, strings.Contains(logged, fmt.Sprintf(`"error_id"=%q`, serr.ID)))
+}
+
+func TestServerErrorHandlerClassifiesRawError(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("unexpected failure")
+	var logged string
+	logger := funcr.New(
+		func(_, args string) { logged = args },
+		funcr.Options{},
+	)
+	endpoint := goaabout.WrapAboutEndpoint(
+		func(context.Context, any) (any, error) { return nil, cause },
+		newAboutServerInterceptors(logger),
+	)
+
+	_, err := endpoint(context.Background(), "payload")
+
+	var serr *goa.ServiceError
+	assert.Assert(t, errors.As(err, &serr))
+	assert.DeepEqual(t, serr, &goa.ServiceError{
+		Name:    "internal_error",
+		Message: apiInternalErrorMsg,
+		Fault:   true,
+	},
+		cmpopts.IgnoreFields(goa.ServiceError{}, "ID"),
+		cmpopts.IgnoreUnexported(goa.ServiceError{}),
+	)
+	assert.Assert(t, strings.Contains(logged, cause.Error()))
+}
+
+func TestServerErrorHandlerPassesThroughOtherFault(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("unexpected dependency fault")
+	returned := goa.NewServiceError(cause, "dependency_fault", false, false, true)
+	var logged string
+	logger := funcr.New(
+		func(_, args string) { logged = args },
+		funcr.Options{},
+	)
+	endpoint := goaabout.WrapAboutEndpoint(
+		func(context.Context, any) (any, error) {
+			return nil, returned
+		},
+		newAboutServerInterceptors(logger),
+	)
+
+	_, err := endpoint(context.Background(), "payload")
+
+	assert.DeepEqual(t, err, returned, cmpopts.IgnoreUnexported(goa.ServiceError{}))
+	assert.Equal(t, logged, "")
+}
+
+func TestServerErrorHandlerPassesThroughDomainError(t *testing.T) {
+	t.Parallel()
+
+	domainErr := &goastorage.AIPNotFound{Message: "AIP not found"}
+	var logged string
+	logger := funcr.New(
+		func(_, args string) { logged = args },
+		funcr.Options{},
+	)
+	endpoint := goastorage.WrapShowAipEndpoint(
+		func(context.Context, any) (any, error) { return nil, domainErr },
+		newStorageServerInterceptors(logger),
+	)
+
+	_, err := endpoint(context.Background(), "payload")
+
+	assert.DeepEqual(t, err, domainErr)
+	assert.Equal(t, logged, "")
+}
+
+func TestServerErrorHandlerLogsTimeoutOnce(t *testing.T) {
+	t.Parallel()
+
+	var logs []string
+	logger := funcr.New(
+		func(_, args string) { logs = append(logs, args) },
+		funcr.Options{},
+	)
+	interceptors := newAboutServerInterceptors(logger)
+	interceptors.operationTimeout = time.Nanosecond
+	endpoint := goaabout.WrapAboutEndpoint(
+		func(ctx context.Context, _ any) (any, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		interceptors,
+	)
+
+	_, err := endpoint(context.Background(), "payload")
+
+	var serr *goa.ServiceError
+	assert.Assert(t, errors.As(err, &serr))
+	assert.DeepEqual(t, serr, &goa.ServiceError{
+		Name:    "internal_error",
+		Message: apiInternalErrorMsg,
+		Timeout: true,
+		Fault:   true,
+	},
+		cmpopts.IgnoreFields(goa.ServiceError{}, "ID"),
+		cmpopts.IgnoreUnexported(goa.ServiceError{}),
+	)
+	assert.Equal(t, len(logs), 1)
+	assert.Assert(t, strings.Contains(logs[0], apiOperationTimeoutMsg))
+	assert.Assert(t, strings.Contains(logs[0], fmt.Sprintf(`"error_id"=%q`, serr.ID)))
+}
 
 func TestOperationTimeoutMapsDeadlineExceeded(t *testing.T) {
 	t.Parallel()
@@ -36,7 +178,7 @@ func TestOperationTimeoutMapsDeadlineExceeded(t *testing.T) {
 	assert.Assert(t, errors.As(err, &serr))
 	assert.DeepEqual(t, serr, &goa.ServiceError{
 		Name:    "internal_error",
-		Message: apiOperationTimeoutMsg,
+		Message: apiInternalErrorMsg,
 		Timeout: true,
 		Fault:   true,
 	},
@@ -172,7 +314,7 @@ func TestOperationTimeoutRecordsSpanError(t *testing.T) {
 	assert.Assert(t, errors.As(err, &serr))
 	assert.DeepEqual(t, serr, &goa.ServiceError{
 		Name:    "internal_error",
-		Message: apiOperationTimeoutMsg,
+		Message: apiInternalErrorMsg,
 		Timeout: true,
 		Fault:   true,
 	},
@@ -213,10 +355,10 @@ func deadlineEndpoint(t *testing.T, wantDeadline bool) goa.Endpoint {
 }
 
 func newTestStorageServerInterceptors(timeout time.Duration) *storageServerInterceptors {
-	i := newOperationInterceptors(logr.Discard())
+	i := newServerInterceptors(logr.Discard())
 	i.operationTimeout = timeout
 
-	return &storageServerInterceptors{operationInterceptors: i}
+	return &storageServerInterceptors{serverInterceptors: i}
 }
 
 func spanAttribute(

--- a/internal/ingest/download_sip.go
+++ b/internal/ingest/download_sip.go
@@ -28,7 +28,7 @@ func (svc *ingestImpl) readSIP(ctx context.Context, id string) (*datatypes.SIP, 
 		if errors.Is(err, persistence.ErrNotFound) {
 			return nil, &goaingest.SIPNotFound{UUID: id, Message: "SIP not found"}
 		} else {
-			return nil, goaingest.MakeInternalError(errors.New("error reading SIP"))
+			return nil, goaingest.MakeInternalError(fmt.Errorf("read SIP: %v", err))
 		}
 	}
 
@@ -52,7 +52,7 @@ func (svc *ingestImpl) DownloadSipRequest(
 	// Check if the failed SIP/PIP exists in the internal bucket.
 	exists, err := svc.internalStorage.Exists(ctx, sip.FailedKey)
 	if err != nil {
-		return nil, goaingest.MakeInternalError(errors.New("error checking SIP/PIP file"))
+		return nil, goaingest.MakeInternalError(fmt.Errorf("check SIP/PIP file: %v", err))
 	}
 
 	if !exists {
@@ -68,7 +68,7 @@ func (svc *ingestImpl) DownloadSipRequest(
 		payload.UUID,
 	))
 	if err != nil {
-		return nil, goaingest.MakeInternalError(errors.New("ticket request failed"))
+		return nil, goaingest.MakeInternalError(fmt.Errorf("request SIP download ticket: %v", err))
 	}
 
 	// A ticket is not provided when authentication is disabled.
@@ -114,7 +114,7 @@ func (svc *ingestImpl) DownloadSip(
 				Message: "Failed SIP/PIP file not found in the internal storage",
 			}
 		} else {
-			return nil, nil, goaingest.MakeInternalError(errors.New("error reading SIP file"))
+			return nil, nil, goaingest.MakeInternalError(fmt.Errorf("read SIP file: %v", err))
 		}
 	}
 

--- a/internal/ingest/download_sip_test.go
+++ b/internal/ingest/download_sip_test.go
@@ -103,7 +103,7 @@ func TestDownloadSipRequest(t *testing.T) {
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockService) {
 				psvc.EXPECT().ReadSIP(ctx, sipUUID).Return(nil, persistence.ErrInternal)
 			},
-			wantErr: "error reading SIP",
+			wantErr: "read SIP: internal error",
 		},
 		{
 			name:    "Fails to request a SIP download (missing failed values)",
@@ -145,7 +145,7 @@ func TestDownloadSipRequest(t *testing.T) {
 					).
 					Return(errors.New("ticket error"))
 			},
-			wantErr: "ticket request failed",
+			wantErr: "request SIP download ticket: error storing ticket: ticket error",
 		},
 		{
 			name:    "Requests a SIP download",
@@ -289,7 +289,7 @@ func TestDownloadSip(t *testing.T) {
 				expectIngestTicketGrant(ctx, ts, sipDownloadGrant(sipUUID.String()))
 				psvc.EXPECT().ReadSIP(ctx, sipUUID).Return(nil, persistence.ErrInternal)
 			},
-			wantErr: "error reading SIP",
+			wantErr: "read SIP: internal error",
 		},
 		{
 			name: "Fails to download a SIP (missing failed values)",

--- a/internal/ingest/goa.go
+++ b/internal/ingest/goa.go
@@ -24,7 +24,6 @@ var (
 	ErrBulkStatusUnavailable error = errors.New("bulk status unavailable")
 	ErrForbidden             error = goaingest.Forbidden("Forbidden")
 	ErrUnauthorized          error = goaingest.Unauthorized("Unauthorized")
-	ErrInternalError         error = goaingest.MakeInternalError(errors.New("internal error"))
 )
 
 func (svc *ingestImpl) BearerAuth(
@@ -88,8 +87,7 @@ func (svc *ingestImpl) AddSip(ctx context.Context, payload *goaingest.AddSipPayl
 	}
 
 	if err := svc.perSvc.CreateSIP(ctx, s); err != nil {
-		svc.logger.Error(err, "add SIP")
-		return nil, ErrInternalError
+		return nil, goaingest.MakeInternalError(fmt.Errorf("create SIP: %v", err))
 	}
 
 	// Initialize the processing workflow.
@@ -110,8 +108,7 @@ func (svc *ingestImpl) AddSip(ctx context.Context, payload *goaingest.AddSipPayl
 				return svc.perSvc.DeleteSIP(cleanupCtx, s.UUID)
 			}),
 		)
-		svc.logger.Error(err, "add SIP")
-		return nil, ErrInternalError
+		return nil, goaingest.MakeInternalError(fmt.Errorf("start SIP processing workflow: %v", err))
 	}
 
 	PublishEvent(ctx, svc.evsvc, sipToCreatedEvent(s))
@@ -140,7 +137,7 @@ func (svc *ingestImpl) ListSips(ctx context.Context, payload *goaingest.ListSips
 
 	r, pg, err := svc.perSvc.ListSIPs(ctx, pf)
 	if err != nil {
-		return nil, goaingest.MakeInternalError(err)
+		return nil, goaingest.MakeInternalError(fmt.Errorf("list SIPs: %v", err))
 	}
 
 	items := make([]*goaingest.SIP, len(r))
@@ -170,7 +167,7 @@ func (svc *ingestImpl) ShowSip(
 	if err == persistence.ErrNotFound {
 		return nil, &goaingest.SIPNotFound{UUID: payload.UUID, Message: "SIP not found"}
 	} else if err != nil {
-		return nil, goaingest.MakeNotAvailable(errors.New("cannot perform operation"))
+		return nil, goaingest.MakeInternalError(fmt.Errorf("read SIP: %v", err))
 	}
 
 	return s.Goa(), nil
@@ -188,12 +185,12 @@ func (svc *ingestImpl) ListSipWorkflows(
 	if _, err := svc.perSvc.ReadSIP(ctx, sipUUID); err == persistence.ErrNotFound {
 		return nil, &goaingest.SIPNotFound{UUID: payload.UUID, Message: "SIP not found"}
 	} else if err != nil {
-		return nil, goaingest.MakeNotAvailable(errors.New("cannot perform operation"))
+		return nil, goaingest.MakeInternalError(fmt.Errorf("read SIP: %v", err))
 	}
 
 	workflows, err := svc.perSvc.ListWorkflowsBySIP(ctx, sipUUID)
 	if err != nil {
-		return nil, goaingest.MakeNotAvailable(errors.New("cannot perform operation"))
+		return nil, goaingest.MakeInternalError(fmt.Errorf("list SIP workflows: %v", err))
 	}
 
 	result := &goaingest.SIPWorkflows{
@@ -218,7 +215,7 @@ func (svc *ingestImpl) ConfirmSip(ctx context.Context, payload *goaingest.Confir
 	}
 	err = svc.tc.SignalWorkflow(ctx, temporalID, "", ReviewPerformedSignalName, signal)
 	if err != nil {
-		return goaingest.MakeNotAvailable(errors.New("cannot perform operation"))
+		return goaingest.MakeInternalError(fmt.Errorf("signal SIP confirmation: %v", err))
 	}
 
 	return nil
@@ -233,7 +230,7 @@ func (svc *ingestImpl) RejectSip(ctx context.Context, payload *goaingest.RejectS
 	signal := ReviewPerformedSignal{Accepted: false}
 	err = svc.tc.SignalWorkflow(ctx, temporalID, "", ReviewPerformedSignalName, signal)
 	if err != nil {
-		return goaingest.MakeNotAvailable(errors.New("cannot perform operation"))
+		return goaingest.MakeInternalError(fmt.Errorf("signal SIP rejection: %v", err))
 	}
 
 	return nil
@@ -286,12 +283,10 @@ func (svc *ingestImpl) SubmitSipDecision(
 		WaitForStage: temporalsdk_client.WorkflowUpdateStageCompleted,
 	})
 	if err != nil {
-		svc.logger.Error(err, "submit SIP decision: update workflow")
-		return ErrInternalError
+		return goaingest.MakeInternalError(fmt.Errorf("submit SIP decision update: %v", err))
 	}
 	if err := handle.Get(ctx, nil); err != nil {
-		svc.logger.Error(err, "submit SIP decision: update workflow result")
-		return ErrInternalError
+		return goaingest.MakeInternalError(fmt.Errorf("get SIP decision update result: %v", err))
 	}
 
 	return nil
@@ -315,14 +310,16 @@ func (svc *ingestImpl) pendingSIPWorkflowTemporalID(ctx context.Context, sipID s
 func (svc *ingestImpl) findChildDecision(ctx context.Context, temporalID string) (childwf.DecisionRequest, error) {
 	encoded, err := svc.tc.QueryWorkflow(ctx, temporalID, "", ChildDecisionQueryName)
 	if err != nil {
-		svc.logger.Error(err, "find child decision: query workflow", "workflow_id", temporalID)
-		return childwf.DecisionRequest{}, ErrInternalError
+		return childwf.DecisionRequest{}, goaingest.MakeInternalError(
+			fmt.Errorf("query child workflow decision %q: %v", temporalID, err),
+		)
 	}
 
 	var decision childwf.DecisionRequest
 	if err := encoded.Get(&decision); err != nil {
-		svc.logger.Error(err, "find child decision: decode query result", "workflow_id", temporalID)
-		return childwf.DecisionRequest{}, ErrInternalError
+		return childwf.DecisionRequest{}, goaingest.MakeInternalError(
+			fmt.Errorf("decode child workflow decision %q: %v", temporalID, err),
+		)
 	}
 	if decision.Message == "" {
 		return childwf.DecisionRequest{}, goaingest.MakeNotAvailable(
@@ -346,7 +343,7 @@ func (svc *ingestImpl) ListUsers(ctx context.Context, payload *goaingest.ListUse
 
 	r, pg, err := svc.perSvc.ListUsers(ctx, pf)
 	if err != nil {
-		return nil, goaingest.MakeInternalError(err)
+		return nil, goaingest.MakeInternalError(fmt.Errorf("list users: %v", err))
 	}
 
 	items := make([]*goaingest.User, len(r))
@@ -393,8 +390,7 @@ func (w *ingestImpl) ListSipSourceObjects(
 			return nil, goaingest.MakeNotValid(errors.New("invalid cursor"))
 		}
 
-		w.logger.Error(err, "Listing SIP source objects")
-		return nil, goaingest.MakeInternalError(errors.New("internal error"))
+		return nil, goaingest.MakeInternalError(fmt.Errorf("list SIP source objects: %v", err))
 	}
 
 	if page == nil {

--- a/internal/ingest/goa_batch.go
+++ b/internal/ingest/goa_batch.go
@@ -59,8 +59,7 @@ func (svc *ingestImpl) AddBatch(
 	}
 
 	if err := svc.perSvc.CreateBatch(ctx, b); err != nil {
-		svc.logger.Error(err, "AddBatch")
-		return nil, ErrInternalError
+		return nil, goaingest.MakeInternalError(fmt.Errorf("create batch: %v", err))
 	}
 
 	req := BatchWorkflowRequest{
@@ -78,8 +77,7 @@ func (svc *ingestImpl) AddBatch(
 				return svc.perSvc.DeleteBatch(cleanupCtx, b.UUID)
 			}),
 		)
-		svc.logger.Error(err, "AddBatch")
-		return nil, ErrInternalError
+		return nil, goaingest.MakeInternalError(fmt.Errorf("start batch workflow: %v", err))
 	}
 
 	PublishEvent(ctx, svc.evsvc, batchToCreatedEvent(b))
@@ -103,8 +101,7 @@ func (svc *ingestImpl) ListBatches(
 
 	r, pg, err := svc.perSvc.ListBatches(ctx, pf)
 	if err != nil {
-		svc.logger.Error(err, "ListBatches")
-		return nil, ErrInternalError
+		return nil, goaingest.MakeInternalError(fmt.Errorf("list batches: %v", err))
 	}
 
 	items := make([]*goaingest.Batch, len(r))
@@ -133,8 +130,7 @@ func (svc *ingestImpl) ShowBatch(
 	if err == persistence.ErrNotFound {
 		return nil, &goaingest.BatchNotFound{UUID: payload.UUID, Message: "Batch not found"}
 	} else if err != nil {
-		svc.logger.Error(err, "ShowBatch")
-		return nil, ErrInternalError
+		return nil, goaingest.MakeInternalError(fmt.Errorf("read batch: %v", err))
 	}
 
 	return b.Goa(), nil
@@ -150,8 +146,7 @@ func (svc *ingestImpl) ReviewBatch(ctx context.Context, payload *goaingest.Revie
 	if err == persistence.ErrNotFound {
 		return &goaingest.BatchNotFound{UUID: payload.UUID, Message: "Batch not found"}
 	} else if err != nil {
-		svc.logger.Error(err, "ReviewBatch")
-		return ErrInternalError
+		return goaingest.MakeInternalError(fmt.Errorf("read batch for review: %v", err))
 	}
 
 	if b.Status != enums.BatchStatusPending {
@@ -161,8 +156,7 @@ func (svc *ingestImpl) ReviewBatch(ctx context.Context, payload *goaingest.Revie
 	signal := BatchDecisionSignal{Continue: payload.Continue}
 	err = svc.tc.SignalWorkflow(ctx, BatchWorkflowID(batchUUID), "", BatchDecisionSignalName, signal)
 	if err != nil {
-		svc.logger.Error(err, "ReviewBatch")
-		return ErrInternalError
+		return goaingest.MakeInternalError(fmt.Errorf("signal batch review: %v", err))
 	}
 
 	return nil

--- a/internal/ingest/goa_batch_test.go
+++ b/internal/ingest/goa_batch_test.go
@@ -105,7 +105,7 @@ func TestAddBatch(t *testing.T) {
 					},
 				).Return(errors.New("persistence error"))
 			},
-			wantErr: "internal error",
+			wantErr: "create batch: persistence error",
 		},
 		{
 			name:    "Returns Temporal error",
@@ -139,7 +139,7 @@ func TestAddBatch(t *testing.T) {
 						return nil
 					})
 			},
-			wantErr: "internal error",
+			wantErr: "start batch workflow: temporal error",
 		},
 		{
 			name:    "Uploads a SIP",
@@ -269,7 +269,7 @@ func TestShowBatch(t *testing.T) {
 			mock: func(ctx context.Context, psvc *persistence_fake.MockService) {
 				psvc.EXPECT().ReadBatch(ctx, batchUUID).Return(nil, persistence.ErrInternal)
 			},
-			wantErr: "internal error",
+			wantErr: "read batch: internal error",
 		},
 		{
 			name:    "Returns batch",
@@ -355,7 +355,7 @@ func TestReviewBatch(t *testing.T) {
 			mock: func(ctx context.Context, psvc *persistence_fake.MockService, _ *temporalsdk_mocks.Client) {
 				psvc.EXPECT().ReadBatch(ctx, batchUUID).Return(nil, persistence.ErrInternal)
 			},
-			wantErr: "internal error",
+			wantErr: "read batch for review: internal error",
 		},
 		{
 			name:    "Returns not valid error (not pending)",
@@ -385,7 +385,7 @@ func TestReviewBatch(t *testing.T) {
 					ingest.BatchDecisionSignal{Continue: true},
 				).Return(errors.New("temporal error"))
 			},
-			wantErr: "internal error",
+			wantErr: "signal batch review: temporal error",
 		},
 		{
 			name:    "Signals batch decision",
@@ -595,7 +595,7 @@ func TestListBatches(t *testing.T) {
 					},
 				).Return(nil, nil, persistence.ErrInternal)
 			},
-			wantErr: "internal error",
+			wantErr: "list batches: internal error",
 		},
 		{
 			name: "Errors on a bad uploader_uuid",

--- a/internal/ingest/goa_test.go
+++ b/internal/ingest/goa_test.go
@@ -144,16 +144,16 @@ func TestListSipWorkflowsErrors(t *testing.T) {
 			wantErr: "not_valid",
 		},
 		{
-			name: "Returns not available when SIP cannot be read",
+			name: "Returns internal error when SIP cannot be read",
 			uuid: sipUUID.String(),
 			mock: func(psvc *persistence_fake.MockService) {
 				psvc.EXPECT().ReadSIP(mockutil.Context(), sipUUID).
 					Return(nil, errors.New("database failed"))
 			},
-			wantErr: "not_available",
+			wantErr: "internal_error",
 		},
 		{
-			name: "Returns not available when workflows cannot be listed",
+			name: "Returns internal error when workflows cannot be listed",
 			uuid: sipUUID.String(),
 			mock: func(psvc *persistence_fake.MockService) {
 				psvc.EXPECT().ReadSIP(mockutil.Context(), sipUUID).
@@ -161,7 +161,7 @@ func TestListSipWorkflowsErrors(t *testing.T) {
 				psvc.EXPECT().ListWorkflowsBySIP(mockutil.Context(), sipUUID).
 					Return(nil, errors.New("database failed"))
 			},
-			wantErr: "not_available",
+			wantErr: "internal_error",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -277,14 +277,14 @@ func TestShowSipDecision(t *testing.T) {
 			wantErrName: "not_available",
 		},
 		{
-			name: "Returns not available when workflows cannot be listed",
+			name: "Returns internal error when workflows cannot be listed",
 			mock: func(t *testing.T, psvc *persistence_fake.MockService, tc *temporalsdk_mocks.Client) {
 				psvc.EXPECT().ReadSIP(mockutil.Context(), sipUUID).
 					Return(&datatypes.SIP{UUID: sipUUID}, nil)
 				psvc.EXPECT().ListWorkflowsBySIP(mockutil.Context(), sipUUID).
 					Return(nil, errors.New("database failed"))
 			},
-			wantErrName: "not_available",
+			wantErrName: "internal_error",
 		},
 		{
 			name: "Returns internal error when child decision query fails",
@@ -676,7 +676,7 @@ func TestAddSIP(t *testing.T) {
 					},
 				).Return(errors.New("persistence error"))
 			},
-			wantErr: "internal error",
+			wantErr: "create SIP: persistence error",
 		},
 		{
 			name:    "Returns Temporal error",
@@ -720,7 +720,7 @@ func TestAddSIP(t *testing.T) {
 						return nil
 					})
 			},
-			wantErr: "internal error",
+			wantErr: "start SIP processing workflow: temporal error",
 		},
 		{
 			name:    "Uploads a SIP",
@@ -1032,10 +1032,10 @@ func TestListSIPs(t *testing.T) {
 				).Return(
 					[]*datatypes.SIP{},
 					&persistence.Page{},
-					persistence.ErrNotFound,
+					persistence.ErrInternal,
 				)
 			},
-			wantErr: "not found error",
+			wantErr: "list SIPs: internal error",
 		},
 		{
 			name: "Errors on a bad aip_uuid",
@@ -1256,7 +1256,7 @@ func TestListUsers(t *testing.T) {
 					Total: 1,
 				},
 			},
-			wantErr: "internal error",
+			wantErr: "list users: internal error",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1421,7 +1421,7 @@ func TestListSIPSourceObjects(t *testing.T) {
 					errors.New("internal error"),
 				)
 			},
-			wantErr: "internal error",
+			wantErr: "list SIP source objects: internal error",
 		},
 		{
 			name: "Returns an empty page when no objects found",

--- a/internal/ingest/monitor.go
+++ b/internal/ingest/monitor.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	goaingest "github.com/artefactual-sdps/enduro/internal/api/gen/ingest"
@@ -20,8 +21,7 @@ func (svc *ingestImpl) Monitor(
 	// Subscribe to the event service.
 	sub, err := svc.evsvc.Subscribe(ctx)
 	if err != nil {
-		svc.logger.Error(err, "failed to subscribe to event service")
-		return ErrInternalError
+		return goaingest.MakeInternalError(fmt.Errorf("subscribe to ingest events: %v", err))
 	}
 	defer sub.Close()
 

--- a/internal/ingest/upload.go
+++ b/internal/ingest/upload.go
@@ -70,17 +70,14 @@ func (svc *ingestImpl) UploadSip(
 	objectKey := fmt.Sprintf("%s%s-%s%s", SIPPrefix, name, sipUUID.String(), ext)
 	wr, err := svc.internalStorage.NewWriter(ctx, objectKey, &blob.WriterOptions{})
 	if err != nil {
-		return nil, err
+		return nil, goaingest.MakeInternalError(fmt.Errorf("create SIP upload writer: %v", err))
 	}
 
 	_, copyErr := io.Copy(wr, stream)
 	closeErr := wr.Close()
 
-	if copyErr != nil {
-		return nil, copyErr
-	}
-	if closeErr != nil {
-		return nil, closeErr
+	if err := errors.Join(copyErr, closeErr); err != nil {
+		return nil, goaingest.MakeInternalError(fmt.Errorf("write SIP upload: %v", err))
 	}
 
 	if err := svc.initSIP(
@@ -99,8 +96,7 @@ func (svc *ingestImpl) UploadSip(
 				return svc.internalStorage.Delete(cleanupCtx, objectKey)
 			}),
 		)
-		svc.logger.Error(err, "upload SIP")
-		return nil, ErrInternalError
+		return nil, goaingest.MakeInternalError(fmt.Errorf("initialize uploaded SIP: %v", err))
 	}
 
 	return &goaingest.UploadSipResult{UUID: sipUUID.String()}, nil

--- a/internal/ingest/upload_test.go
+++ b/internal/ingest/upload_test.go
@@ -106,7 +106,7 @@ func TestUpload(t *testing.T) {
 			multipartBody: zipMmultipartBody,
 			contentType:   "multipart/form-data; boundary=foobar",
 			maxUploadSize: 102400000,
-			wantErr:       "internal error",
+			wantErr:       "initialize uploaded SIP: persistence error",
 		},
 		{
 			name: "Returns Temporal error",
@@ -151,7 +151,7 @@ func TestUpload(t *testing.T) {
 			multipartBody: zipMmultipartBody,
 			contentType:   "multipart/form-data; boundary=foobar",
 			maxUploadSize: 102400000,
-			wantErr:       "internal error",
+			wantErr:       "initialize uploaded SIP: temporal error",
 		},
 		{
 			name:   "Uploads a SIP",

--- a/internal/storage/deletion_request.go
+++ b/internal/storage/deletion_request.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"go.artefactual.dev/tools/ref"
@@ -102,8 +103,7 @@ func (s *serviceImpl) requestAIPDeletion(
 		SkipReport:  skipReport,
 	})
 	if err != nil {
-		s.logger.Error(err, "error initializing delete workflow")
-		return ErrInternalError
+		return goastorage.MakeInternalError(fmt.Errorf("start AIP deletion workflow: %v", err))
 	}
 
 	return nil
@@ -134,9 +134,11 @@ func (s *serviceImpl) ReviewAipDeletion(ctx context.Context, payload *goastorage
 		AIPUUID: &aipID,
 		Status:  ref.New(enums.DeletionRequestStatusPending),
 	})
-	if err != nil || len(drs) == 0 {
-		s.logger.Error(err, "deletion request not found", "aip_id", aipID)
-		return ErrInternalError
+	if err != nil {
+		return goastorage.MakeInternalError(fmt.Errorf("list pending AIP deletion requests: %v", err))
+	}
+	if len(drs) == 0 {
+		return goastorage.MakeInternalError(errors.New("pending AIP deletion request not found"))
 	}
 
 	if drs[0].RequesterIss == claims.Iss && drs[0].RequesterSub == claims.Sub {
@@ -156,8 +158,7 @@ func (s *serviceImpl) ReviewAipDeletion(ctx context.Context, payload *goastorage
 	}
 	err = s.tc.SignalWorkflow(ctx, StorageDeleteWorkflowID(aipID), "", DeletionDecisionSignalName, signal)
 	if err != nil {
-		s.logger.Error(err, "error signaling delete workflow")
-		return ErrInternalError
+		return goastorage.MakeInternalError(fmt.Errorf("signal AIP deletion review: %v", err))
 	}
 
 	return nil
@@ -183,7 +184,7 @@ func (s *serviceImpl) CancelAipDeletion(
 		Status:  ref.New(enums.DeletionRequestStatusPending),
 	})
 	if err != nil {
-		return err
+		return goastorage.MakeInternalError(fmt.Errorf("list pending AIP deletion requests: %v", err))
 	}
 	if len(drs) == 0 {
 		return goastorage.MakeNotValid(errors.New("no valid deletion requests"))
@@ -212,8 +213,7 @@ func (s *serviceImpl) CancelAipDeletion(
 		},
 	)
 	if err != nil {
-		s.logger.Error(err, "error signaling delete workflow")
-		return ErrInternalError
+		return goastorage.MakeInternalError(fmt.Errorf("signal AIP deletion cancellation: %v", err))
 	}
 
 	return nil

--- a/internal/storage/deletion_request_test.go
+++ b/internal/storage/deletion_request_test.go
@@ -308,7 +308,7 @@ func TestRequestAipDeletion(t *testing.T) {
 					},
 				).Return(nil, errors.New("temporal error"))
 			},
-			wantErr: "internal error",
+			wantErr: "start AIP deletion workflow: temporal error",
 		},
 		{
 			name: "Requests AIP deletion",
@@ -463,7 +463,7 @@ func TestReviewAipDeletion(t *testing.T) {
 					Status:  ref.New(enums.DeletionRequestStatusPending),
 				}).Return(nil, errors.New("persistence error"))
 			},
-			wantErr: "internal error",
+			wantErr: "list pending AIP deletion requests: persistence error",
 		},
 		{
 			name: "Fails to review AIP deletion (reviewer matches requester)",
@@ -526,7 +526,7 @@ func TestReviewAipDeletion(t *testing.T) {
 					},
 				).Return(errors.New("temporal error"))
 			},
-			wantErr: "internal error",
+			wantErr: "signal AIP deletion review: temporal error",
 		},
 		{
 			name: "Reviews AIP deletion",
@@ -636,7 +636,7 @@ func TestCancelAipDeletion(t *testing.T) {
 					}).
 					Return(nil, errors.New("db: deletion_request not found"))
 			},
-			wantErr: "db: deletion_request not found",
+			wantErr: "list pending AIP deletion requests: db: deletion_request not found",
 		},
 		{
 			name: "Fails on deletion request read error",
@@ -656,7 +656,7 @@ func TestCancelAipDeletion(t *testing.T) {
 					}).
 					Return(nil, errors.New("db: persistence error"))
 			},
-			wantErr: "db: persistence error",
+			wantErr: "list pending AIP deletion requests: db: persistence error",
 		},
 		{
 			name: "Fails if no valid deletion request is found",
@@ -741,7 +741,7 @@ func TestCancelAipDeletion(t *testing.T) {
 					},
 				).Return(errors.New("temporal error"))
 			},
-			wantErr: "internal error",
+			wantErr: "signal AIP deletion cancellation: temporal error",
 		},
 		{
 			name: "Cancels AIP deletion request",

--- a/internal/storage/download_aip.go
+++ b/internal/storage/download_aip.go
@@ -30,8 +30,7 @@ func (s *serviceImpl) DownloadAipRequest(
 
 	bucket, err := s.openAIPBucket(ctx, aip)
 	if err != nil {
-		s.logger.Error(fmt.Errorf("open AIP bucket: %v", err), "AIP UUID", aip.UUID)
-		return nil, goastorage.MakeInternalError(errors.New("error opening AIP storage location"))
+		return nil, goastorage.MakeInternalError(fmt.Errorf("open AIP storage location: %v", err))
 	}
 	defer bucket.Close()
 
@@ -43,7 +42,7 @@ func (s *serviceImpl) DownloadAipRequest(
 				Message: "AIP not found",
 			}
 		} else {
-			return nil, goastorage.MakeInternalError(errors.New("error getting AIP attributes"))
+			return nil, goastorage.MakeInternalError(fmt.Errorf("get AIP attributes: %v", err))
 		}
 	}
 
@@ -53,7 +52,7 @@ func (s *serviceImpl) DownloadAipRequest(
 		payload.UUID,
 	))
 	if err != nil {
-		return nil, goastorage.MakeInternalError(errors.New("ticket request failed"))
+		return nil, goastorage.MakeInternalError(fmt.Errorf("request AIP download ticket: %v", err))
 	}
 
 	res := &goastorage.DownloadAipRequestResult{}
@@ -113,7 +112,7 @@ func (s *serviceImpl) DownloadAip(
 				Message: "AIP not found",
 			}
 		} else {
-			return nil, nil, goastorage.MakeInternalError(errors.New("error reading AIP file"))
+			return nil, nil, goastorage.MakeInternalError(fmt.Errorf("read AIP file: %v", err))
 		}
 	}
 

--- a/internal/storage/download_aip_test.go
+++ b/internal/storage/download_aip_test.go
@@ -76,7 +76,7 @@ func TestDownloadAipRequest(t *testing.T) {
 			mock: func(ctx context.Context, ts *auth_fake.MockTicketStore, psvc *persistence_fake.MockStorage) {
 				psvc.EXPECT().
 					ReadAIP(ctx, aipID).
-					Return(nil, goastorage.MakeNotAvailable(errors.New("persistence error")))
+					Return(nil, goastorage.MakeInternalError(errors.New("persistence error")))
 			},
 			wantErr: "persistence error",
 		},
@@ -156,7 +156,7 @@ func TestDownloadAipRequest(t *testing.T) {
 					).
 					Return(errors.New("ticket error"))
 			},
-			wantErr: "ticket request failed",
+			wantErr: "request AIP download ticket: error storing ticket: ticket error",
 		},
 		{
 			name:    "Requests a AIP download",
@@ -321,7 +321,7 @@ func TestDownloadAip(t *testing.T) {
 				expectStorageTicketGrant(ctx, ts, aipDownloadGrant(aipID.String()))
 				psvc.EXPECT().
 					ReadAIP(ctx, aipID).
-					Return(nil, goastorage.MakeNotAvailable(errors.New("persistence error")))
+					Return(nil, goastorage.MakeInternalError(errors.New("persistence error")))
 			},
 			wantErr: "persistence error",
 		},

--- a/internal/storage/download_deletion_report.go
+++ b/internal/storage/download_deletion_report.go
@@ -38,12 +38,12 @@ func deletionReportReader(
 
 	loc, err := s.Location(ctx, uuid.Nil)
 	if err != nil {
-		return nil, "", err
+		return nil, "", goastorage.MakeInternalError(fmt.Errorf("get deletion report location: %v", err))
 	}
 
 	b, err := loc.OpenBucket(ctx)
 	if err != nil {
-		return nil, "", err
+		return nil, "", goastorage.MakeInternalError(fmt.Errorf("open deletion report bucket: %v", err))
 	}
 
 	r, err = b.NewReader(ctx, *aip.DeletionReportKey, nil)
@@ -51,7 +51,7 @@ func deletionReportReader(
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			return nil, "", goastorage.MakeNotFound(errors.New("deletion report not found"))
 		} else {
-			return nil, "", goastorage.MakeInternalError(errors.New("error reading deletion report"))
+			return nil, "", goastorage.MakeInternalError(fmt.Errorf("read deletion report: %v", err))
 		}
 	}
 	return r, *aip.DeletionReportKey, nil
@@ -67,7 +67,9 @@ func (s *serviceImpl) AipDeletionReportRequest(
 	if err != nil {
 		return nil, err
 	}
-	r.Close()
+	if err := r.Close(); err != nil {
+		return nil, goastorage.MakeInternalError(fmt.Errorf("close deletion report reader: %v", err))
+	}
 
 	// Request a ticket.
 	ticket, err := s.ticketProvider.Request(ctx, auth.NewTicketGrant(
@@ -75,7 +77,7 @@ func (s *serviceImpl) AipDeletionReportRequest(
 		payload.UUID,
 	))
 	if err != nil {
-		return nil, goastorage.MakeInternalError(errors.New("ticket request failed"))
+		return nil, goastorage.MakeInternalError(fmt.Errorf("request deletion report ticket: %v", err))
 	}
 
 	res := &goastorage.AipDeletionReportRequestResult{}

--- a/internal/storage/download_deletion_report_test.go
+++ b/internal/storage/download_deletion_report_test.go
@@ -69,7 +69,7 @@ func TestAipDeletionReportRequest(t *testing.T) {
 			) {
 				psvc.EXPECT().
 					ReadAIP(ctx, aipID).
-					Return(nil, goastorage.MakeNotAvailable(errors.New("persistence error")))
+					Return(nil, goastorage.MakeInternalError(errors.New("persistence error")))
 			},
 			wantErr: "persistence error",
 		},
@@ -134,7 +134,7 @@ func TestAipDeletionReportRequest(t *testing.T) {
 					).
 					Return(errors.New("ticket error"))
 			},
-			wantErr: "ticket request failed",
+			wantErr: "request deletion report ticket: error storing ticket: ticket error",
 		},
 		{
 			name:    "Requests a deletion report download",

--- a/internal/storage/monitor.go
+++ b/internal/storage/monitor.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	goastorage "github.com/artefactual-sdps/enduro/internal/api/gen/storage"
@@ -20,8 +21,7 @@ func (s *serviceImpl) Monitor(
 	// Subscribe to the event service.
 	sub, err := s.evsvc.Subscribe(ctx)
 	if err != nil {
-		s.logger.Error(err, "failed to subscribe to event service")
-		return ErrInternalError
+		return goastorage.MakeInternalError(fmt.Errorf("subscribe to storage events: %v", err))
 	}
 	defer sub.Close()
 

--- a/internal/storage/persistence/ent/client/client.go
+++ b/internal/storage/persistence/ent/client/client.go
@@ -63,7 +63,7 @@ func (c *Client) CreateAIP(ctx context.Context, goaaip *goastorage.AIP) (*goasto
 					UUID: *goaaip.LocationUUID, Message: "location not found",
 				}
 			} else {
-				return nil, goastorage.MakeNotAvailable(errors.New("cannot perform operation"))
+				return nil, goastorage.MakeInternalError(fmt.Errorf("resolve AIP location: %v", err))
 			}
 		}
 		q.SetLocationID(id)
@@ -108,11 +108,11 @@ func (c *Client) ListAIPs(ctx context.Context, payload *goastorage.ListAipsPaylo
 
 	res, err := page.All(ctx)
 	if err != nil {
-		return nil, goastorage.MakeNotAvailable(errors.New("cannot perform operation"))
+		return nil, goastorage.MakeInternalError(fmt.Errorf("list AIPs: %v", err))
 	}
 	total, err := whole.Count(ctx)
 	if err != nil {
-		return nil, goastorage.MakeNotAvailable(errors.New("cannot perform operation"))
+		return nil, goastorage.MakeInternalError(fmt.Errorf("count AIPs: %v", err))
 	}
 
 	aips := []*goastorage.AIP{}
@@ -142,7 +142,7 @@ func (c *Client) ReadAIP(ctx context.Context, aipID uuid.UUID) (*goastorage.AIP,
 		if db.IsNotFound(err) {
 			return nil, &goastorage.AIPNotFound{UUID: aipID, Message: "AIP not found"}
 		} else {
-			return nil, goastorage.MakeNotAvailable(errors.New("cannot perform operation"))
+			return nil, goastorage.MakeInternalError(fmt.Errorf("read AIP: %v", err))
 		}
 	}
 
@@ -378,7 +378,7 @@ func (c *Client) ReadLocation(ctx context.Context, locationID uuid.UUID) (*goast
 		if db.IsNotFound(err) {
 			return nil, &goastorage.LocationNotFound{UUID: locationID, Message: "location not found"}
 		} else {
-			return nil, goastorage.MakeNotAvailable(errors.New("cannot perform operation"))
+			return nil, goastorage.MakeInternalError(fmt.Errorf("read location: %v", err))
 		}
 	}
 

--- a/internal/storage/service.go
+++ b/internal/storage/service.go
@@ -97,9 +97,8 @@ type serviceImpl struct {
 var _ Service = (*serviceImpl)(nil)
 
 var (
-	ErrUnauthorized  error = goastorage.Unauthorized("Unauthorized")
-	ErrForbidden     error = goastorage.Forbidden("Forbidden")
-	ErrInternalError error = goastorage.MakeInternalError(errors.New("internal error"))
+	ErrUnauthorized error = goastorage.Unauthorized("Unauthorized")
+	ErrForbidden    error = goastorage.Forbidden("Forbidden")
 )
 
 func NewService(
@@ -215,7 +214,12 @@ func (s *serviceImpl) ListLocations(
 	ctx context.Context,
 	payload *goastorage.ListLocationsPayload,
 ) (goastorage.LocationCollection, error) {
-	return s.storagePersistence.ListLocations(ctx)
+	locations, err := s.storagePersistence.ListLocations(ctx)
+	if err != nil {
+		return nil, goastorage.MakeInternalError(fmt.Errorf("list locations: %v", err))
+	}
+
+	return locations, nil
 }
 
 func (s *serviceImpl) ListAips(
@@ -242,8 +246,7 @@ func (s *serviceImpl) MoveAip(ctx context.Context, payload *goastorage.MoveAipPa
 		TaskQueue:  s.config.TaskQueue,
 	})
 	if err != nil {
-		s.logger.Error(err, "error initializing move workflow")
-		return goastorage.MakeNotAvailable(errors.New("cannot perform operation"))
+		return goastorage.MakeInternalError(fmt.Errorf("start AIP move workflow: %v", err))
 	}
 
 	return nil
@@ -265,7 +268,7 @@ func (s *serviceImpl) MoveAipStatus(
 
 	resp, err := s.tc.DescribeWorkflowExecution(ctx, fmt.Sprintf("%s-%s", StorageMoveWorkflowName, p.UUID), "")
 	if err != nil {
-		return nil, goastorage.MakeFailedDependency(errors.New("cannot perform operation"))
+		return nil, goastorage.MakeInternalError(fmt.Errorf("describe AIP move workflow: %v", err))
 	}
 
 	var done bool
@@ -291,7 +294,11 @@ func (s *serviceImpl) RejectAip(ctx context.Context, payload *goastorage.RejectA
 		return goastorage.MakeNotValid(errors.New("cannot perform operation"))
 	}
 
-	return s.UpdateAipStatus(ctx, aipID, enums.AIPStatusDeleted)
+	if err := s.UpdateAipStatus(ctx, aipID, enums.AIPStatusDeleted); err != nil {
+		return goastorage.MakeInternalError(fmt.Errorf("reject AIP: %v", err))
+	}
+
+	return nil
 }
 
 func (s *serviceImpl) ShowAip(ctx context.Context, payload *goastorage.ShowAipPayload) (*goastorage.AIP, error) {
@@ -476,7 +483,7 @@ func (s *serviceImpl) ListAipWorkflows(
 
 	workflows, err := s.storagePersistence.ListWorkflows(ctx, &f)
 	if err != nil {
-		return nil, goastorage.MakeNotAvailable(errors.New("cannot perform operation"))
+		return nil, goastorage.MakeInternalError(fmt.Errorf("list AIP workflows: %v", err))
 	}
 
 	return &goastorage.AIPWorkflows{Workflows: workflows}, nil
@@ -521,7 +528,7 @@ func (s *serviceImpl) CreateLocation(
 		UUID:        UUID,
 	}, &config)
 	if err != nil {
-		return nil, goastorage.MakeNotValid(errors.New("cannot persist location"))
+		return nil, goastorage.MakeInternalError(fmt.Errorf("create location: %v", err))
 	}
 
 	PublishEvent(ctx, s.evsvc, &goastorage.LocationCreatedEvent{
@@ -536,8 +543,7 @@ func (s *serviceImpl) CreateLocation(
 // layer.
 //
 // A `goastorage.LocationNotFound` error is returned if location UUID doesn't
-// exist. A `goa.ServiceError` "not_available" error is returned for all other
-// errors.
+// exist. Unexpected persistence errors are returned as internal errors.
 func (s *serviceImpl) ReadLocation(ctx context.Context, UUID uuid.UUID) (*goastorage.Location, error) {
 	return s.storagePersistence.ReadLocation(ctx, UUID)
 }
@@ -565,7 +571,7 @@ func (s *serviceImpl) ListLocationAips(
 
 	aips, err := s.storagePersistence.LocationAIPs(ctx, locationID)
 	if err != nil {
-		return nil, goastorage.MakeNotAvailable(errors.New("cannot perform operation"))
+		return nil, goastorage.MakeInternalError(fmt.Errorf("list location AIPs: %v", err))
 	}
 
 	return aips, nil

--- a/internal/storage/service_test.go
+++ b/internal/storage/service_test.go
@@ -947,7 +947,7 @@ func TestListAipWorkflows(t *testing.T) {
 					ListWorkflows(ctx, &persistence.WorkflowFilter{AIPUUID: &aipID}).
 					Return(nil, errors.New("persistence error"))
 			},
-			wantErr: "cannot perform operation",
+			wantErr: "list AIP workflows: persistence error",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1016,7 +1016,7 @@ func TestServiceMove(t *testing.T) {
 		assert.ErrorContains(t, err, "AIP not found")
 	})
 
-	t.Run("Returns not_available if workflow cannot be executed", func(t *testing.T) {
+	t.Run("Returns internal_error if workflow cannot be executed", func(t *testing.T) {
 		t.Parallel()
 
 		attrs := &setUpAttrs{}
@@ -1055,8 +1055,8 @@ func TestServiceMove(t *testing.T) {
 			UUID:         aipID.String(),
 			LocationUUID: locationID,
 		})
-		assert.Equal(t, err.(*goa.ServiceError).Name, "not_available")
-		assert.ErrorContains(t, err, "cannot perform operation")
+		assert.Equal(t, err.(*goa.ServiceError).Name, "internal_error")
+		assert.ErrorContains(t, err, "start AIP move workflow: something went wrong")
 	})
 
 	t.Run("Returns no error if AIP is moved", func(t *testing.T) {
@@ -1146,7 +1146,7 @@ func TestServiceMoveStatus(t *testing.T) {
 		assert.ErrorContains(t, err, "AIP not found")
 	})
 
-	t.Run("Returns failed_dependency error if workflow execution cannot be found", func(t *testing.T) {
+	t.Run("Returns internal_error if workflow execution cannot be described", func(t *testing.T) {
 		t.Parallel()
 
 		attrs := &setUpAttrs{}
@@ -1181,8 +1181,8 @@ func TestServiceMoveStatus(t *testing.T) {
 			UUID: aipID.String(),
 		})
 		assert.Assert(t, res == nil)
-		assert.Equal(t, err.(*goa.ServiceError).Name, "failed_dependency")
-		assert.ErrorContains(t, err, "cannot perform operation")
+		assert.Equal(t, err.(*goa.ServiceError).Name, "internal_error")
+		assert.ErrorContains(t, err, "describe AIP move workflow: something went wrong")
 	})
 
 	t.Run("Returns failed_dependency error if workflow execution failed", func(t *testing.T) {
@@ -1349,7 +1349,7 @@ func TestServiceAddLocation(t *testing.T) {
 		assert.ErrorContains(t, err, "invalid configuration")
 	})
 
-	t.Run("Returns not_valid if cannot persist location", func(t *testing.T) {
+	t.Run("Returns internal_error if location cannot be persisted", func(t *testing.T) {
 		attrs := &setUpAttrs{}
 		ctx := t.Context()
 		svc := setUpService(t, ctx, attrs)
@@ -1386,8 +1386,8 @@ func TestServiceAddLocation(t *testing.T) {
 			}),
 		})
 		assert.Assert(t, res == nil)
-		assert.Equal(t, err.(*goa.ServiceError).Name, "not_valid")
-		assert.ErrorContains(t, err, "cannot persist location")
+		assert.Equal(t, err.(*goa.ServiceError).Name, "internal_error")
+		assert.ErrorContains(t, err, "create location: unexpected error")
 	})
 
 	t.Run("Returns result with location UUID", func(t *testing.T) {
@@ -1533,7 +1533,7 @@ func TestServiceListLocationAips(t *testing.T) {
 		assert.ErrorContains(t, err, "cannot perform operation")
 	})
 
-	t.Run("Returns not_available if AIPs cannot be read", func(t *testing.T) {
+	t.Run("Returns internal_error if AIPs cannot be read", func(t *testing.T) {
 		t.Parallel()
 
 		attrs := &setUpAttrs{}
@@ -1555,8 +1555,8 @@ func TestServiceListLocationAips(t *testing.T) {
 			UUID: locationID.String(),
 		})
 		assert.Assert(t, res == nil)
-		assert.Equal(t, err.(*goa.ServiceError).Name, "not_available")
-		assert.ErrorContains(t, err, "cannot perform operation")
+		assert.Equal(t, err.(*goa.ServiceError).Name, "internal_error")
+		assert.ErrorContains(t, err, "list location AIPs: unexpected error")
 	})
 
 	t.Run("Returns stored AIPs", func(t *testing.T) {


### PR DESCRIPTION
Reserve HTTP 409 for genuine conflicts. Classify unexpected persistence, storage, ticket, event, and Temporal failures as internal errors.

Sanitize internal responses while logging diagnostic context once from a shared Goa server interceptor.

Refs #1663.