### PR TITLE
Preserve SIP modification times

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/XSAM/otelsql v0.43.0
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/artefactual-labs/bagit-gython v0.6.1
-	github.com/artefactual-sdps/temporal-activities v0.0.0-20260727224957-bc414cd11e01
+	github.com/artefactual-sdps/temporal-activities v0.0.0-20260824175558-e5c91dc26e57
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/cyphar/filepath-securejoin v0.7.0
 	github.com/dolmen-go/contextio v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/artefactual-labs/bagit-gython v0.6.1 h1:yCs4Zk+xDn4m2YvYZSGOapp7RQhrS
 github.com/artefactual-labs/bagit-gython v0.6.1/go.mod h1:4l3AoC/OlXJgfC2me9g9SC6QLV2n/wi8ZltiGB2NQvU=
 github.com/artefactual-labs/bine v0.28.3 h1:pDPcxuxjL102JPa3aG7oitYkuZxRJqVZEoW1IHBVtjE=
 github.com/artefactual-labs/bine v0.28.3/go.mod h1:E0JTUTzaakkToz6UlUOViEMkCCzHbGTKw5G5mgeYj0M=
-github.com/artefactual-sdps/temporal-activities v0.0.0-20260727224957-bc414cd11e01 h1:1epg+jHuUIE+auoiEu9YjHXVXM7f4hDgaSBQB/p7Y3A=
-github.com/artefactual-sdps/temporal-activities v0.0.0-20260727224957-bc414cd11e01/go.mod h1:apjykeFf9cvBJNzbHajrfpV8+0O1Zd20Lv8Nf47e9sw=
+github.com/artefactual-sdps/temporal-activities v0.0.0-20260824175558-e5c91dc26e57 h1:rysnWkiROMhUI616R5IonuaRR3r3pCfLy55bV6ptQfg=
+github.com/artefactual-sdps/temporal-activities v0.0.0-20260824175558-e5c91dc26e57/go.mod h1:apjykeFf9cvBJNzbHajrfpV8+0O1Zd20Lv8Nf47e9sw=
 github.com/aws/aws-sdk-go-v2 v1.41.9 h1:/rYeyO2+HrMztAmxAq9++XJtFMqSIpSsNA0yDGALYq4=
 github.com/aws/aws-sdk-go-v2 v1.41.9/go.mod h1:+HsoOEX80qAVUitj1A2DhCNTjmb3edVyuDypb6LNEeo=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.11 h1:h5+3VT69KUBK24grGuuA5saDJTj2IIjLb9au668Fo5I=

--- a/internal/sftp/goclient.go
+++ b/internal/sftp/goclient.go
@@ -114,7 +114,31 @@ func (c *GoClient) UploadDirectory(ctx context.Context, srcPath string) (string,
 func uploadFile(ctx context.Context, src io.Reader, remotePath string, upload *AsyncUploadImpl) {
 	defer upload.Close()
 
-	remoteCopy(ctx, upload, src, remotePath)
+	var info fs.FileInfo
+	if file, ok := src.(fs.File); ok {
+		var err error
+		info, err = file.Stat()
+		if err != nil {
+			upload.Err() <- fmt.Errorf("goclient: stat source file: %v", err)
+			return
+		}
+	}
+
+	if err := remoteCopy(ctx, upload, src, remotePath); err != nil {
+		upload.Err() <- err
+		return
+	}
+	if info != nil {
+		modTime := info.ModTime()
+		if err := upload.conn.Chtimes(remotePath, modTime, modTime); err != nil {
+			upload.Err() <- fmt.Errorf(
+				"preserve remote file %q modification time: %v",
+				remotePath,
+				err,
+			)
+			return
+		}
+	}
 
 	upload.Done() <- true
 }
@@ -132,6 +156,12 @@ func uploadDirectory(ctx context.Context, srcPath, remoteDir string, upload *Asy
 	}
 	defer scopedRoot.Close()
 
+	type directoryModTime struct {
+		path string
+		info fs.FileInfo
+	}
+	var directories []directoryModTime
+
 	err = fs.WalkDir(scopedRoot.FS(), ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -148,9 +178,25 @@ func uploadDirectory(ctx context.Context, srcPath, remoteDir string, upload *Asy
 				return err
 			}
 			defer f.Close()
+			info, err := f.Stat()
+			if err != nil {
+				return err
+			}
 
-			remoteCopy(ctx, upload, f, remotePath)
+			if err := remoteCopy(ctx, upload, f, remotePath); err != nil {
+				return err
+			}
+			modTime := info.ModTime()
+			if err := upload.conn.Chtimes(remotePath, modTime, modTime); err != nil {
+				return fmt.Errorf("preserve remote file %q modification time: %v", remotePath, err)
+			}
 		} else {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			directories = append(directories, directoryModTime{path: remotePath, info: info})
+
 			err = upload.conn.MkdirAll(remotePath)
 			if err != nil {
 				return err
@@ -161,6 +207,30 @@ func uploadDirectory(ctx context.Context, srcPath, remoteDir string, upload *Asy
 	})
 	if err != nil {
 		upload.Err() <- fmt.Errorf("goclient: %v", err)
+		return
+	}
+
+	// Avoid remote calls if the upload was canceled during the directory walk.
+	if err := ctx.Err(); err != nil {
+		upload.Err() <- fmt.Errorf(
+			"goclient: restore directory modification times: %v",
+			err,
+		)
+		return
+	}
+
+	// Creating files and subdirectories updates their parent directories' mtimes,
+	// so restore directory mtimes only after the walk is complete.
+	for _, directory := range directories {
+		modTime := directory.info.ModTime()
+		if err := upload.conn.Chtimes(directory.path, modTime, modTime); err != nil {
+			upload.Err() <- fmt.Errorf(
+				"goclient: preserve remote directory %q modification time: %v",
+				directory.path,
+				err,
+			)
+			return
+		}
 	}
 
 	upload.Done() <- true
@@ -189,17 +259,15 @@ func (c *GoClient) dial(ctx context.Context) (*connection, error) {
 	return &conn, nil
 }
 
-// remoteCopy copies data from the src reader to a remote file at dest, and
-// updates upload progress asynchronously. Upload status and progress will be
-// sent to the upload struct via the `upload.Done()` and `upload.Error()` channels.
-func remoteCopy(ctx context.Context, upload *AsyncUploadImpl, src io.Reader, dest string) {
+// remoteCopy copies data from the src reader to a remote file at dest and
+// updates upload progress asynchronously. It closes the remote file before
+// returning so callers can safely update its metadata.
+func remoteCopy(ctx context.Context, upload *AsyncUploadImpl, src io.Reader, dest string) error {
 	// Note: Some SFTP servers don't support O_RDWR mode.
 	w, err := upload.conn.OpenFile(dest, (os.O_WRONLY | os.O_CREATE | os.O_TRUNC))
 	if err != nil {
-		upload.Err() <- fmt.Errorf("sftp: open remote file %q: %v", dest, err)
-		return
+		return fmt.Errorf("sftp: open remote file %q: %v", dest, err)
 	}
-	defer w.Close()
 
 	// Write the number of bytes copied to upload.
 	src = contextio.NewReader(ctx, src)
@@ -207,10 +275,16 @@ func remoteCopy(ctx context.Context, upload *AsyncUploadImpl, src io.Reader, des
 
 	// Use contextio to stop the upload if a context cancellation signal is
 	// received.
-	_, err = io.Copy(contextio.NewWriter(ctx, w), src)
-	if err != nil {
-		upload.Err() <- fmt.Errorf("remote copy: %v", err)
+	_, copyErr := io.Copy(contextio.NewWriter(ctx, w), src)
+	closeErr := w.Close()
+	if copyErr != nil {
+		copyErr = fmt.Errorf("remote copy: %v", copyErr)
 	}
+	if closeErr != nil {
+		closeErr = fmt.Errorf("close remote file %q: %v", dest, closeErr)
+	}
+
+	return errors.Join(copyErr, closeErr)
 }
 
 var statusCodeRegex = regexp.MustCompile(`\(SSH_[A-Z_]+\)$`)

--- a/internal/sftp/goclient_test.go
+++ b/internal/sftp/goclient_test.go
@@ -151,6 +151,13 @@ func startSFTPServer(t *testing.T) (string, string) {
 func TestUploadFile(t *testing.T) {
 	t.Parallel()
 
+	source := tfs.NewFile(t, "", tfs.WithContent("Testing 1-2-3"))
+	wantModTime := time.Date(2000, time.January, 2, 3, 4, 5, 0, time.UTC)
+	assert.NilError(t, os.Chtimes(source.Path(), wantModTime, wantModTime))
+	sourceFile, err := os.Open(source.Path())
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = sourceFile.Close() })
+
 	host, port := startSFTPServer(t)
 
 	// Start a listener on an open port and use the address to test a bad SFTP
@@ -167,8 +174,9 @@ func TestUploadFile(t *testing.T) {
 		dest string
 	}
 	type results struct {
-		Bytes int64
-		Paths []tfs.PathOp
+		Bytes   int64
+		Paths   []tfs.PathOp
+		ModTime time.Time
 	}
 
 	type test struct {
@@ -190,12 +198,13 @@ func TestUploadFile(t *testing.T) {
 				},
 			},
 			params: params{
-				src:  strings.NewReader("Testing 1-2-3"),
+				src:  sourceFile,
 				dest: "test.txt",
 			},
 			want: results{
-				Bytes: 13,
-				Paths: []tfs.PathOp{tfs.WithFile("test.txt", "Testing 1-2-3")},
+				Bytes:   13,
+				Paths:   []tfs.PathOp{tfs.WithFile("test.txt", "Testing 1-2-3")},
+				ModTime: wantModTime,
 			},
 		},
 		{
@@ -321,6 +330,11 @@ func TestUploadFile(t *testing.T) {
 			case <-upload.Done():
 				assert.Equal(t, upload.Bytes(), tc.want.Bytes)
 				assert.Assert(t, tfs.Equal(remoteDir.Path(), tfs.Expected(t, tc.want.Paths...)))
+				if !tc.want.ModTime.IsZero() {
+					info, err := os.Stat(remotePath)
+					assert.NilError(t, err)
+					assert.Equal(t, info.ModTime().Unix(), tc.want.ModTime.Unix())
+				}
 			case err = <-upload.Err():
 				t.Fatal(err)
 			}
@@ -333,8 +347,16 @@ func TestUploadDirectory(t *testing.T) {
 
 	testTransferDir := tfs.NewDir(t, "test_transfer",
 		tfs.WithFile("test.txt", "Testing 1-2-3"),
-		tfs.WithFile("test2.txt", "Testing 4-5-6-7"),
+		tfs.WithDir("nested",
+			tfs.WithFile("test2.txt", "Testing 4-5-6-7"),
+		),
 	)
+	fileModTime := time.Date(2001, time.February, 3, 4, 5, 6, 0, time.UTC)
+	nestedDirModTime := time.Date(2002, time.March, 4, 5, 6, 7, 0, time.UTC)
+	rootDirModTime := time.Date(2003, time.April, 5, 6, 7, 8, 0, time.UTC)
+	assert.NilError(t, os.Chtimes(testTransferDir.Join("test.txt"), fileModTime, fileModTime))
+	assert.NilError(t, os.Chtimes(testTransferDir.Join("nested"), nestedDirModTime, nestedDirModTime))
+	assert.NilError(t, os.Chtimes(testTransferDir.Path(), rootDirModTime, rootDirModTime))
 
 	host, port := startSFTPServer(t)
 
@@ -421,6 +443,18 @@ func TestUploadDirectory(t *testing.T) {
 			select {
 			case <-upload.Done():
 				assert.Equal(t, upload.Bytes(), tc.wantBytes)
+				info, err := os.Stat(filepath.Join(remotePath, "test.txt"))
+				assert.NilError(t, err)
+				assert.Equal(t, info.ModTime().Unix(), fileModTime.Unix())
+
+				for path, want := range map[string]time.Time{
+					remotePath:                          rootDirModTime,
+					filepath.Join(remotePath, "nested"): nestedDirModTime,
+				} {
+					info, err := os.Stat(path)
+					assert.NilError(t, err)
+					assert.Equal(t, info.ModTime().Unix(), want.Unix())
+				}
 			case err = <-upload.Err():
 				t.Fatal(err)
 			}

--- a/internal/watcher/filesystem.go
+++ b/internal/watcher/filesystem.go
@@ -8,11 +8,11 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"syscall"
 
 	"github.com/fsnotify/fsnotify"
 	cp "github.com/otiai10/copy"
 	"go.artefactual.dev/tools/bucket"
-	"go.artefactual.dev/tools/fsutil"
 	"gocloud.dev/blob"
 
 	"github.com/artefactual-sdps/enduro/internal/filenotify"
@@ -174,13 +174,37 @@ func (w *filesystemWatcher) Dispose(key string) error {
 	src := filepath.Join(w.path, key)
 	dst := filepath.Join(w.completedDir, key)
 
-	return fsutil.Move(src, dst)
+	return movePreservingTimes(src, dst)
+}
+
+func movePreservingTimes(src, dst string) error {
+	if _, err := os.Stat(dst); err == nil {
+		return errors.New("destination already exists")
+	}
+
+	if err := os.Rename(src, dst); err != nil {
+		if !errors.Is(err, syscall.EXDEV) {
+			return err
+		}
+
+		if err := cp.Copy(src, dst, cp.Options{
+			Sync:          true,
+			PreserveTimes: true,
+			OnDirExists:   func(src, dst string) cp.DirExistsAction { return cp.Untouchable },
+		}); err != nil {
+			return err
+		}
+
+		return os.RemoveAll(src)
+	}
+
+	return nil
 }
 
 // Download copies key to dest. Key may be the name of a directory or file.
 func (w *filesystemWatcher) Download(ctx context.Context, dest, key string) error {
 	src := filepath.Clean(filepath.Join(w.path, key))
-	if err := cp.Copy(src, filepath.Clean(dest)); err != nil {
+	if err := cp.Copy(src, filepath.Clean(dest), cp.Options{PreserveTimes: true}); err != nil {
 		return fmt.Errorf("filesystem watcher: download: %v", err)
 	}
 

--- a/internal/watcher/filesystem_test.go
+++ b/internal/watcher/filesystem_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -163,6 +164,46 @@ func TestFileSystemWatcher(t *testing.T) {
 		)))
 	})
 
+	t.Run("Dispose preserves mtimes across filesystems", func(t *testing.T) {
+		watchedDir := t.TempDir()
+		completedDir, err := os.MkdirTemp("/dev/shm", "enduro-completed-")
+		if err != nil {
+			t.Skipf("cross-filesystem test requires writable /dev/shm: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(completedDir) })
+
+		deviceID := func(path string) uint64 {
+			info, err := os.Stat(path)
+			assert.NilError(t, err)
+			stat, ok := info.Sys().(*syscall.Stat_t)
+			assert.Assert(t, ok)
+			return uint64(stat.Dev)
+		}
+		if deviceID(watchedDir) == deviceID(completedDir) {
+			t.Skip("temporary and completed directories are on the same filesystem")
+		}
+
+		sourceDir := filepath.Join(watchedDir, "example-sip")
+		sourceFile := filepath.Join(sourceDir, "objects", "test.txt")
+		assert.NilError(t, os.MkdirAll(filepath.Dir(sourceFile), 0o755))
+		assert.NilError(t, os.WriteFile(sourceFile, []byte("A test file."), 0o600))
+		wantModTime := time.Date(2001, time.February, 3, 4, 5, 6, 0, time.UTC)
+		assert.NilError(t, os.Chtimes(sourceFile, wantModTime, wantModTime))
+
+		w, err := watcher.NewFilesystemWatcher(t.Context(), &watcher.FilesystemConfig{
+			Name:            "filesystem",
+			Path:            watchedDir,
+			CompletedDir:    completedDir,
+			RetentionPeriod: -1 * time.Second,
+		})
+		assert.NilError(t, err)
+		assert.NilError(t, w.Dispose("example-sip"))
+
+		info, err := os.Stat(filepath.Join(completedDir, "example-sip", "objects", "test.txt"))
+		assert.NilError(t, err)
+		assert.Equal(t, info.ModTime().Unix(), wantModTime.Unix())
+	})
+
 	t.Run("Download copies a file to the destination path", func(t *testing.T) {
 		t.Parallel()
 
@@ -171,6 +212,8 @@ func TestFileSystemWatcher(t *testing.T) {
 		src := fs.NewDir(t, "enduro-test-fswatcher",
 			fs.WithFile("sip.zip", "A test file."),
 		)
+		wantModTime := time.Date(2001, time.February, 3, 4, 5, 6, 0, time.UTC)
+		assert.NilError(t, os.Chtimes(src.Join("sip.zip"), wantModTime, wantModTime))
 		dest := fs.NewDir(t, "enduro-test-fswatcher")
 
 		w, err := watcher.NewFilesystemWatcher(ctx, &watcher.FilesystemConfig{
@@ -186,6 +229,7 @@ func TestFileSystemWatcher(t *testing.T) {
 		info, err := os.Stat(destPath)
 		assert.NilError(t, err)
 		assert.Assert(t, !info.IsDir())
+		assert.Equal(t, info.ModTime().Unix(), wantModTime.Unix())
 
 		got, err := os.ReadFile(destPath)
 		assert.NilError(t, err)
@@ -203,6 +247,8 @@ func TestFileSystemWatcher(t *testing.T) {
 				fs.WithFile("test2", "Another test file."),
 			),
 		)
+		wantModTime := time.Date(2001, time.February, 3, 4, 5, 6, 0, time.UTC)
+		assert.NilError(t, os.Chtimes(src.Join("example-sip", "test.txt"), wantModTime, wantModTime))
 		dest := fs.NewDir(t, "enduro-test-fswatcher")
 
 		w, err := watcher.NewFilesystemWatcher(ctx, &watcher.FilesystemConfig{
@@ -220,5 +266,8 @@ func TestFileSystemWatcher(t *testing.T) {
 				fs.WithFile("test2", "Another test file.", fs.WithMode(0o644)),
 			),
 		)))
+		info, err := os.Stat(filepath.Join(dest.Path(), "example-sip", "test.txt"))
+		assert.NilError(t, err)
+		assert.Equal(t, info.ModTime().Unix(), wantModTime.Unix())
 	})
 }

--- a/internal/workflow/activities/bundle.go
+++ b/internal/workflow/activities/bundle.go
@@ -114,10 +114,18 @@ func (a *BundleActivity) SingleFile(
 		return "", fmt.Errorf("open source file: %v", err)
 	}
 	defer src.Close()
+	info, err := src.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat source file: %v", err)
+	}
 
-	err = b.Write(filepath.Join("objects", filepath.Base(sourcePath)), src)
+	objectPath := filepath.Join("objects", filepath.Base(sourcePath))
+	err = b.Write(objectPath, src)
 	if err != nil {
 		return "", fmt.Errorf("write file: %v", err)
+	}
+	if err := os.Chtimes(filepath.Join(b.FullBaseFsPath(), objectPath), info.ModTime(), info.ModTime()); err != nil {
+		return "", fmt.Errorf("preserve file modification time: %v", err)
 	}
 
 	if err := b.Bundle(); err != nil {
@@ -152,7 +160,7 @@ func (a *BundleActivity) Copy(ctx context.Context, src, dst string) (string, err
 		return "", fmt.Errorf("error creating temporary directory: %s", err)
 	}
 
-	if err := copy.Copy(src, tempDir); err != nil {
+	if err := copy.Copy(src, tempDir, copy.Options{PreserveTimes: true}); err != nil {
 		return "", fmt.Errorf("error copying transfer: %v", err)
 	}
 

--- a/internal/workflow/activities/bundle_test.go
+++ b/internal/workflow/activities/bundle_test.go
@@ -1,8 +1,10 @@
 package activities_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"go.artefactual.dev/tools/temporal"
 	temporalsdk_activity "go.temporal.io/sdk/activity"
@@ -16,16 +18,19 @@ import (
 func TestBundleActivity(t *testing.T) {
 	t.Parallel()
 
+	wantModTime := time.Date(2001, time.February, 3, 4, 5, 6, 0, time.UTC)
 	sourceDir := fs.NewDir(t, "enduro-bundle-test",
 		fs.FromDir("../../testdata"),
 	)
 	destDir := fs.NewDir(t, "enduro-bundle-test")
 
 	type test struct {
-		name    string
-		params  *activities.BundleActivityParams
-		wantFs  fs.Manifest
-		wantErr string
+		name     string
+		params   *activities.BundleActivityParams
+		wantFs   fs.Manifest
+		wantErr  string
+		mtimeSrc string
+		mtimeDst string
 	}
 	for _, tt := range []test{
 		{
@@ -42,6 +47,8 @@ func TestBundleActivity(t *testing.T) {
 				),
 				fs.WithDir("metadata", fs.WithMode(activities.ModeDir)),
 			),
+			mtimeSrc: sourceDir.Join("single_file_transfer", "small.txt"),
+			mtimeDst: filepath.Join("objects", "small.txt"),
 		},
 		{
 			name: "Bundles a local standard transfer directory",
@@ -60,6 +67,8 @@ func TestBundleActivity(t *testing.T) {
 				),
 				fs.WithFile("small.txt", "I am a small file.\n", fs.WithMode(activities.ModeFile)),
 			),
+			mtimeSrc: sourceDir.Join("standard_transfer", "small", "small.txt"),
+			mtimeDst: "small.txt",
 		},
 		{
 			name: "Bundles a BagIt transfer",
@@ -116,10 +125,13 @@ e91f941be5973ff71f1dccbdd1a32d598881893a7f21be516aca743da38b1689 bagit.txt
 					),
 				),
 			),
+			mtimeSrc: sourceDir.Join("bag", "small_bag", "data", "small.txt"),
+			mtimeDst: "small.txt",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			assert.NilError(t, os.Chtimes(tt.mtimeSrc, wantModTime, wantModTime))
 
 			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
 			env := ts.NewTestActivityEnvironment()
@@ -145,7 +157,10 @@ e91f941be5973ff71f1dccbdd1a32d598881893a7f21be516aca743da38b1689 bagit.txt
 			if tt.wantFs != (fs.Manifest{}) {
 				assert.Assert(t, fs.Equal(res.FullPath, tt.wantFs))
 			}
+
+			info, err := os.Stat(filepath.Join(res.FullPath, tt.mtimeDst))
 			assert.NilError(t, err)
+			assert.Equal(t, info.ModTime().Unix(), wantModTime.Unix())
 
 			rp, err := filepath.Rel(tt.params.TransferDir, res.FullPath)
 			assert.NilError(t, err)


### PR DESCRIPTION
Preserve source mtimes while bundling, moving, downloading, and uploading SIP/PIP content.

Update temporal-activities so archiving, extraction and BagIt creation retain source modification times.

Refs artefactual-sdps/enduro#1757.